### PR TITLE
Bug correction and additional test cases on to_cnf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.DS_Store

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -106,16 +106,19 @@ def flat2cnf(constraints):
         # BE != BE (same as xor)
         elif isinstance(expr, Comparison) and expr.name == "!=":
             a0,a1 = expr.args
-            # using 'implies' means it will recursively work for BE's too
-            cnf += flat2cnf([a0.implies(~a1), (~a0).implies(a1)]) # one true and one false
-            continue
+            if a0.is_bool() and a1.is_bool():
+                # using 'implies' means it will recursively work for BE's too
+                cnf += flat2cnf([a0.implies(~a1), (~a0).implies(a1)]) # one true and one false
+                continue
 
         # BE == BE
         elif isinstance(expr, Comparison) and expr.name == "==":
             a0,a1 = expr.args
-            # using 'implies' means it will recursively work for BE's too
-            cnf += flat2cnf([a0.implies(a1), a1.implies(a0)]) # a0->a1 and a1->a0
-            continue
+
+            if a0.is_bool() and a1.is_bool():
+                # using 'implies' means it will recursively work for BE's too
+                cnf += flat2cnf([a0.implies(a1), a1.implies(a0)]) # a0->a1 and a1->a0
+                continue
 
         # BE -> BE
         elif is_operator and expr.name == '->':

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -104,21 +104,18 @@ def flat2cnf(constraints):
                 raise NotImplementedError("TODO: nary xor")
 
         # BE != BE (same as xor)
-        elif isinstance(expr, Comparison) and expr.name == "!=":
+        elif isinstance(expr, Comparison) and expr.name == "!=" and expr.args[0].is_bool():
             a0,a1 = expr.args
-            if a0.is_bool() and a1.is_bool():
-                # using 'implies' means it will recursively work for BE's too
-                cnf += flat2cnf([a0.implies(~a1), (~a0).implies(a1)]) # one true and one false
-                continue
+            # using 'implies' means it will recursively work for BE's too
+            cnf += flat2cnf([a0.implies(~a1), (~a0).implies(a1)]) # one true and one false
+            continue
 
         # BE == BE
-        elif isinstance(expr, Comparison) and expr.name == "==":
+        elif isinstance(expr, Comparison) and expr.name == "==" and expr.args[0].is_bool():
             a0,a1 = expr.args
-
-            if a0.is_bool() and a1.is_bool():
-                # using 'implies' means it will recursively work for BE's too
-                cnf += flat2cnf([a0.implies(a1), a1.implies(a0)]) # a0->a1 and a1->a0
-                continue
+            # using 'implies' means it will recursively work for BE's too
+            cnf += flat2cnf([a0.implies(a1), a1.implies(a0)]) # a0->a1 and a1->a0
+            continue
 
         # BE -> BE
         elif is_operator and expr.name == '->':

--- a/tests/test_tocnf.py
+++ b/tests/test_tocnf.py
@@ -45,6 +45,8 @@ class TestToCnf(unittest.TestCase):
         edge_cases = [
             # do not consider object as a double implcation, but as a sum
             (a + b + c) == 1,
+            a * b == 1,
+            a * b != 1,
             (a + b + c) != 1,
             sum(bvs) > 2,
             sum(bvs) <= 2,

--- a/tests/test_tocnf.py
+++ b/tests/test_tocnf.py
@@ -39,6 +39,24 @@ class TestToCnf(unittest.TestCase):
             for ss1,ss2 in zip(s1,s2):
                 self.assertTrue(np.all(ss1 == ss2), (case, s1, s2))
 
+        # test for errors in edge cases of to_cnf
+        bvs = boolvar(shape=3)
+        ivs = intvar(lb=2, ub=3, shape=3)
+        edge_cases = [
+            # do not consider object as a double implcation, but as a sum
+            (a + b + c) == 1,
+            (a + b + c) != 1,
+            sum(bvs) > 2,
+            sum(bvs) <= 2,
+            sum(ivs) <= 3
+        ]
+
+        # check for error in edge cases
+        for case in edge_cases:
+            cnf = to_cnf(case)
+            # Expressions should not be decomposed at the to_cnf level!
+            self.assertEqual(len(cnf), 1)
+
     def allsols(self, cons, vs):
         sols = []
 
@@ -49,3 +67,6 @@ class TestToCnf(unittest.TestCase):
 
         return np.array(sols)
 
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`to_cnf()` of comparison equals/not equals a value is considered a double implication. For example:

```Python
to_cnf(sum([BV1, BV2, BV3]) == 1)
a  * b == 1
```

- Constraints should not be transformed to_cnf and left identical to be handled at the solver level.
- Added test cases