### PR TITLE
Adding an empty constraint should not impact the model 

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -75,6 +75,10 @@ class Model(object):
             m = Model()
             m += [x > 0]
         """
+        # ignore empty clause
+        if is_any_list(con) and len(con)==0:
+            return self
+
         if is_any_list(con) and len(con) == 1 and is_any_list(con[0]):
             # top level list of constraints
             con = con[0]


### PR DESCRIPTION
When creating a model and adding the empty constraint, it should be ignored. Example:

```python3
x1 = intvar(lb=2, ub=4)
model = cp.Model()
model += (x1 > 3)
model += []
print(model)
```