### PR TITLE
NativeConstraint prototype

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -387,3 +387,31 @@ class Xor(GlobalConstraint):
        """
         copied_args = self._deepcopy_args(memodict)
         return Xor(copied_args)
+
+class NativeConstraint(Expression):
+    """
+        A constraint whose name corresponds to a native solver API function,
+        and whose arguments match those of the solver function.
+
+        A solver interface will map the arguments to native solver variables
+        where possible, and will call the native API function.
+    """
+    # is_bool: whether this is normal constraint (True or False)
+    def __init__(self, name, arg_list, arg_novar=None):
+        """
+            arg_list: list of arguments to give to the function with name 'name'
+            arg_novar: list of arguments that contain no variables,
+                       that can be passed 'as is' without scanning for variables
+        """
+        super().__init__(name, arg_list)
+        self.arg_novar = arg_novar
+
+    def is_bool(self):
+        """ is it a Boolean (return type) Operator?
+        """
+        return True
+
+    def deepcopy(self, memodict={}):
+        copied_args = self._deepcopy_args(memodict)
+        return type(self)(self.name, copied_args)
+

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -454,9 +454,9 @@ class CPM_ortools(SolverInterface):
         elif cpm_expr.name == 'alldifferent':
             return self.ort_model.AddAllDifferent(self.solver_vars(cpm_expr.args))
         elif cpm_expr.name == 'table':
-            assert (len(cpm_expr.args) == 2)  # args = [array, table]
-            array, table = self.solver_vars(cpm_expr.args)
-            return self.ort_model.AddAllowedAssignments(array, table)
+            assert (len(cpm_expr.args) == 2)
+            array, table = cpm_expr.args
+            return self.ort_model.AddAllowedAssignments(self.solver_vars(array), table)
         else:
             # TODO: NOT YET MAPPED: Automaton, Circuit, Cumulative,
             #    ForbiddenAssignments, Inverse?, NoOverlap, NoOverlap2D,


### PR DESCRIPTION
See #74 

A proposal to make native constraints (API calls) more accessible, like we use global constraints.

```python
from cpmpy import *
from cpmpy.expressions.globalconstraints import NativeConstraint
x = intvar(0,10, shape=3)

# CPMpy standard
s = SolverLookup.get("ortools")
s += Table(x, [[0,1,2],[2,1,0]])
print(s.solveAll())

# CPMpy with currently recommended 'direct solver access' use
s = SolverLookup.get("ortools")
s.ort_model.AddAllowedAssignments(s.solver_vars(x), [[0,1,2],[2,1,0]])
print(s.solveAll())

# Proposal in branch
s = SolverLookup.get("ortools")
s += NativeConstraint("AddAllowedAssignments", (x, [[0,1,2],[2,1,0]]))
print(s.solveAll())

# Proposal also allows to indicate some args are const/novar/should be passed as is
# the top two variants (now) also do not scan the data part
s = SolverLookup.get("ortools")
s += NativeConstraint("AddAllowedAssignments", (x, [[0,1,2],[2,1,0]]), arg_novar=[1])
print(s.solveAll())
```