### PR TITLE
transf: add reify_rewrite, generic way of handling reification if onl…

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -373,7 +373,7 @@ class Xor(GlobalConstraint):
 
     def decompose(self):
         if len(self.args) == 2:
-            return (self.args[0] + self.args[1]) == 1
+            return [(self.args[0] + self.args[1]) == 1]
         prev_var, cons = get_or_make_var(self.args[0] ^ self.args[1])
         for arg in self.args[2:]:
             prev_var, new_cons = get_or_make_var(prev_var ^ arg)

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -32,7 +32,7 @@ from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _Num
 from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, only_positive_bv
-from ..transformations.reification import only_bv_implies
+from ..transformations.reification import only_bv_implies, reify_rewrite
 
 try:
     import gurobipy as gp
@@ -255,6 +255,7 @@ class CPM_gurobi(SolverInterface):
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
 
         cpm_cons = flatten_constraint(cpm_con)
+        cpm_cons = reify_rewrite(cpm_cons)
         cpm_cons = only_bv_implies(cpm_cons)
         cpm_cons = linearize_constraint(cpm_cons)
         cpm_cons = only_positive_bv(cpm_cons)

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -31,7 +31,7 @@ from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegB
 from ..expressions.utils import is_num, is_any_list
 from ..transformations.get_variables import get_variables_model, get_variables
 from ..transformations.flatten_model import flatten_model, flatten_constraint, flatten_objective, get_or_make_var, negated_normal
-from ..transformations.reification import only_bv_implies
+from ..transformations.reification import only_bv_implies, reify_rewrite
 
 class CPM_ortools(SolverInterface):
     """
@@ -307,7 +307,7 @@ class CPM_ortools(SolverInterface):
         self.user_vars.update(get_variables(cpm_con))
 
         # apply transformations, then post internally
-        cpm_cons = only_bv_implies(flatten_constraint(cpm_con))
+        cpm_cons = only_bv_implies(reify_rewrite(flatten_constraint(cpm_con)))
         for con in cpm_cons:
             self._post_constraint(con)
 

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -1,7 +1,10 @@
+import copy
 from ..expressions.core import Operator, Comparison
-from ..expressions.variables import _BoolVarImpl
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.variables import _BoolVarImpl, _NumVarImpl
 from ..expressions.utils import is_any_list
-from .flatten_model import negated_normal
+from .flatten_model import flatten_constraint, negated_normal, get_or_make_var
+
 """
   Transformations regarding reification constraints.
 
@@ -64,4 +67,71 @@ def only_bv_implies(constraints):
             # all other flat normal form expressions are fine
             newcons.append(cpm_expr)
     
+    return newcons
+
+
+def reify_rewrite(constraints, supported=frozenset(['sum', 'wsum'])):
+    """
+        Rewrites reified constraints not natively supported by a solver,
+        to a version that uses standard constraints and reification over equalities between variables.
+
+        Input is expected to be in Flat Normal Form (so after `flatten_constraint()`)
+        Output will also be in Flat Normal Form
+
+        argument 'supported' is a list (or set) of expression names that support reification in the solver
+    """
+    if not is_any_list(constraints):
+        # assume list, so make list
+        constraints = [constraints]
+
+    newcons = []
+    for cpm_expr in constraints:
+        # check if reif, get (the index of) the Boolean subexpression BE
+        boolexpr_index = None
+        if cpm_expr.name == '->':
+            if not isinstance(cpm_expr.args[0], _BoolVarImpl):  # BE -> BV
+                boolexpr_index = 0
+            elif not isinstance(cpm_expr.args[1], _BoolVarImpl):  # BV -> BE
+                boolexpr_index = 1
+            else:
+                pass  # both BV
+        elif cpm_expr.name == '==' and \
+                not isinstance(cpm_expr.args[0], _BoolVarImpl) and \
+                isinstance(cpm_expr.args[1], _BoolVarImpl):  # BE == BV
+            boolexpr_index = 0
+
+        if boolexpr_index is None:  # non-reified or variable-only reification
+            newcons.append(cpm_expr)
+        else:  # reification, check for rewrite
+            boolexpr = cpm_expr.args[boolexpr_index]
+            if isinstance(boolexpr, Operator):
+                # Case 1, BE is Operator (and, or, ->)
+                #   assume supported, return as is
+                newcons.append(cpm_expr)
+                #   could actually rewrite into list of clauses like to_cnf() does... not for here
+            elif isinstance(boolexpr, GlobalConstraint):
+                # Case 2, BE is a GlobalConstraint
+                # replace BE by its decomposition, then flatten
+                reifexpr = copy.copy(cpm_expr)
+                reifexpr.args[boolexpr_index] = Operator("and", boolexpr.decompose())  # decomp() returns list
+                newcons += flatten_constraint(reifexpr)
+            elif isinstance(boolexpr, Comparison):
+                # Case 3, BE is Comparison(OP, LHS, RHS)
+                op,(lhs,rhs) = boolexpr.name, boolexpr.args
+                #   have list of supported lhs's such as sum and wsum...
+                #   at the very least, (iv1 == iv2) == bv has to be supported (or equivalently, sum: (iv1 - iv2 == 0) == bv)
+                if isinstance(lhs, _NumVarImpl) or lhs.name in supported:
+                    newcons.append(cpm_expr)
+                else:  #   other cases:
+                    #     (AUX,c) = get_or_make_var(LHS)
+                    #     return c+[Comp(OP,AUX,RHS) == BV] or +[Comp(OP,AUX,RHS) -> BV] or +[Comp(OP,AUX,RHS) <- BV]
+                    (auxvar, cons) = get_or_make_var(lhs)
+                    newcons += cons
+                    reifexpr = copy.copy(cpm_expr)
+                    reifexpr.args[boolexpr_index] = Comparison(op, auxvar, rhs)  # Comp(OP,AUX,RHS)
+                    newcons.append(reifexpr)
+            else:
+                # don't think this will be reached
+                newcons.append(cpm_expr)
+
     return newcons


### PR DESCRIPTION
…y few constraints support it by the solver

Implementation of the discussion in #105 
used in ortools and gurobi

only limitly tested, e.g. 
```
ivs = intvar(1,3, shape=5, name="ivs")
rv = boolvar(name="rv")

e = []
e += [(rv == AllDifferent(ivs))]
e += [(Element(ivs, intvar(1,9)) <= 2).implies(rv)]
e += [rv.implies(max(ivs) < 5)]
sat = Model(e).solve("ortools")
print(sat, ":", rv.value(), ivs.value())
```

@IgnaceBleukx can you test it more extensively with your test suite? Quite possible there are edge cases we are not covering here...