### PR TITLE
reified element: support index values larger than array, fixes #100

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -105,7 +105,6 @@ import warnings # for deprecation warning
 from .core import Expression, Operator, Comparison
 from .variables import boolvar, intvar, cpm_array
 from .utils import flatlist, all_pairs, argval, is_num, eval_comparison
-from .python_builtins import any
 from ..transformations.flatten_model import get_or_make_var
 
 # Base class GlobalConstraint
@@ -349,6 +348,8 @@ class Element(GlobalConstraint):
             That is what this function does
             (for now only used in transformations/reification.py)
         """
+        from .python_builtins import any
+
         arr,idx = self.args
         return [any(eval_comparison(cmp_op, cmp_rhs, j) & (idx == j) for j in range(len(arr)))]
 

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -19,6 +19,7 @@ Internal utilities for expression handling.
         flatlist
         all_pairs
         argval
+        eval_comparison
 """
 
 import numpy as np
@@ -66,3 +67,34 @@ def argval(a):
         We check with hasattr instead of isinstance to avoid circular dependency
     """
     return a.value() if hasattr(a, "value") else a
+
+def eval_comparison(str_op, lhs, rhs):
+    """
+        Internal function: evaluates the textual `str_op` comparison operator
+        lhs <str_op> rhs
+
+        Valid str_op's:
+        * '=='
+        * '!='
+        * '>'
+        * '>='
+        * '<'
+        * '<='
+
+        Especially useful in decomposition and transformation functions that already involve a comparison.
+    """
+    if str_op == '==':
+        return lhs == rhs
+    elif str_op == '!=':
+        return lhs != rhs
+    elif str_op == '>':
+        return lhs > rhs
+    elif str_op == '>=':
+        return lhs >= rhs
+    elif str_op == '<':
+        return lhs < rhs
+    elif str_op == '<=':
+        return lhs <= rhs
+    else:
+        raise Exception("Not a known comparison:", str_op)
+

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -133,7 +133,7 @@ def reify_rewrite(constraints, supported=frozenset(['sum', 'wsum'])):
                     reifexpr = copy.copy(cpm_expr)
                     reifexpr.args[boolexpr_index] = all(lhs.decompose_comparison(op,rhs))  # decomp() returns list
                     newcons += flatten_constraint(reifexpr)
-                else:  #   other cases:
+                else:  #   other cases (assuming LHS is a total function):
                     #     (AUX,c) = get_or_make_var(LHS)
                     #     return c+[Comp(OP,AUX,RHS) == BV] or +[Comp(OP,AUX,RHS) -> BV] or +[Comp(OP,AUX,RHS) <- BV]
                     (auxvar, cons) = get_or_make_var(lhs)

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -124,7 +124,7 @@ def reify_rewrite(constraints, supported=frozenset(['sum', 'wsum'])):
                 #   at the very least, (iv1 == iv2) == bv has to be supported (or equivalently, sum: (iv1 - iv2 == 0) == bv)
                 if isinstance(lhs, _NumVarImpl) or lhs.name in supported:
                     newcons.append(cpm_expr)
-                elif isinstance(lhs, Element) and (lhs.args[1].lb < 0 or lhs.args[1].ub >= arr.size()):
+                elif isinstance(lhs, Element) and (lhs.args[1].lb < 0 or lhs.args[1].ub >= len(lhs.args[0])):
                     # special case: (Element(arr,idx) <OP> RHS) == BV (or -> in some way)
                     # if the domain of 'idx' is larger than the range of 'arr', then 
                     # this is allowed and BV should be false if it takes a value there

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -41,6 +41,10 @@ class TestTransfReif(unittest.TestCase):
         for e in [e1,e2]:
             self.assertTrue(Model(e).solve())
 
+
+        # Another case to be careful with:
+        # in reified context, the index variable can have a larger domain
+        # than the array range, needs a reified equality decomposition.
         idx = intvar(-1,3, name="idx")
         arr = cpm_array([0,1,2])
 
@@ -48,6 +52,7 @@ class TestTransfReif(unittest.TestCase):
         self.assertEqual(Model(e).solveAll(), 5)
 
         
+        # various reify_rewrite cases:
         cases = [(rv == (arr[idx] != 1), "[((BV2) or (BV3)) == (rv), (idx == 0) == (BV2), (idx == 2) == (BV3)]"),
                 ]
 

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -1,8 +1,9 @@
 import unittest
 import numpy as np
 from cpmpy import *
-from cpmpy.transformations.reification import only_bv_implies
 from cpmpy.transformations.get_variables import get_variables
+from cpmpy.transformations.flatten_model import flatten_constraint
+from cpmpy.transformations.reification import only_bv_implies, reify_rewrite
 
 class TestTransfReif(unittest.TestCase):
     def test_only_bv_implies(self):
@@ -26,9 +27,9 @@ class TestTransfReif(unittest.TestCase):
             self.assertTrue(Model(expr).solve())
 
     def test_reif_rewrite(self):
-        bvs = boolvar(shape=5)
-        iv = intvar(1,10)
-        rv = boolvar()
+        bvs = boolvar(shape=5, name="bvs")
+        iv = intvar(1,10, name="iv")
+        rv = boolvar(name="rv")
 
         # have to be careful with Element, if an Element over
         # Bools is treated as a BoolExpr then it would be treated as a
@@ -40,3 +41,17 @@ class TestTransfReif(unittest.TestCase):
         for e in [e1,e2]:
             self.assertTrue(Model(e).solve())
 
+        idx = intvar(-1,3, name="idx")
+        arr = cpm_array([0,1,2])
+
+        e = (rv == (arr[idx] != 1))
+        self.assertEqual(Model(e).solveAll(), 5)
+
+        
+        cases = [(rv == (arr[idx] != 1), "[((BV2) or (BV3)) == (rv), (idx == 0) == (BV2), (idx == 2) == (BV3)]"),
+                ]
+
+        # test transformation
+        for (expr, strexpr) in cases:
+            self.assertEqual( str(reify_rewrite(flatten_constraint(expr))), strexpr )
+            self.assertTrue(Model(expr).solve())

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -4,8 +4,13 @@ from cpmpy import *
 from cpmpy.transformations.get_variables import get_variables
 from cpmpy.transformations.flatten_model import flatten_constraint
 from cpmpy.transformations.reification import only_bv_implies, reify_rewrite
+from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl # to reset counters
 
 class TestTransfReif(unittest.TestCase):
+    def setUp(self):
+        _IntVarImpl.counter = 0
+        _BoolVarImpl.counter = 0
+
     def test_only_bv_implies(self):
         a,b,c = [boolvar(name=n) for n in "abc"]
         
@@ -26,7 +31,7 @@ class TestTransfReif(unittest.TestCase):
             self.assertEqual( str(only_bv_implies(expr)), strexpr )
             self.assertTrue(Model(expr).solve())
 
-    def test_reif_rewrite(self):
+    def test_reif_element(self):
         bvs = boolvar(shape=5, name="bvs")
         iv = intvar(1,10, name="iv")
         rv = boolvar(name="rv")
@@ -45,15 +50,44 @@ class TestTransfReif(unittest.TestCase):
         # Another case to be careful with:
         # in reified context, the index variable can have a larger domain
         # than the array range, needs a reified equality decomposition.
-        idx = intvar(-1,3, name="idx")
         arr = cpm_array([0,1,2])
 
-        e = (rv == (arr[idx] != 1))
-        self.assertEqual(Model(e).solveAll(), 5)
+        cases = [(-1,3,5), # idx.lb, idx.ub, cnt
+                 (-1,2,4),
+                 (-1,1,3),
+                 (-1,0,2),
+                 (0,3,4),
+                 (0,2,3),
+                 (0,1,2),
+                 (1,2,2),
+                 (1,3,3),
+                 (2,3,2),
+                ]
 
+        for (lb,ub,cnt) in cases:
+            idx = intvar(lb,ub, name="idx")
+            e = (rv == (arr[idx] != 1))
+            self.assertEqual(Model(e).solveAll(), cnt)
+
+
+    def test_reif_rewrite(self):
+        bvs = boolvar(shape=4, name="bvs")
+        ivs = intvar(1,9, shape=3, name="ivs")
+        rv = boolvar(name="rv")
+        arr = cpm_array([0,1,2])
         
         # various reify_rewrite cases:
-        cases = [(rv == (arr[idx] != 1), "[((BV2) or (BV3)) == (rv), (idx == 0) == (BV2), (idx == 2) == (BV3)]"),
+        cases = [(rv == bvs[0], "[(rv) == (bvs[0])]"),
+                 (rv == all(bvs), "[(and([bvs[0], bvs[1], bvs[2], bvs[3]])) == (rv)]"),
+                 (rv.implies(any(bvs)), "[(rv) -> (or([bvs[0], bvs[1], bvs[2], bvs[3]]))]"),
+                 ((bvs[0].implies(bvs[1])).implies(rv), "[((~bvs[0]) or (bvs[1])) -> (rv)]"),
+                 (rv == AllDifferent(ivs), "[(and([BV0, BV1, BV2])) == (rv), ((ivs[0]) != (ivs[1])) == (BV0), ((ivs[0]) != (ivs[2])) == (BV1), ((ivs[1]) != (ivs[2])) == (BV2)]"),
+                 (rv.implies(AllDifferent(ivs)), "[(rv) -> (and([BV6, BV7, BV8])), ((ivs[0]) != (ivs[1])) == (BV6), ((ivs[0]) != (ivs[2])) == (BV7), ((ivs[1]) != (ivs[2])) == (BV8)]"),
+                 (rv == (arr[intvar(-1,3)] != 1), "[((BV12) or (BV13)) == (rv), (IV0 == 0) == (BV12), (IV0 == 2) == (BV13)]"),
+                 (rv == (arr[intvar(0,2)] != 1), "[([0 1 2][IV1]) == (IV2), (IV2 != 1) == (rv)]"),
+                 (rv == (max(ivs) > 5), "[(max(ivs[0],ivs[1],ivs[2])) == (IV4), (IV4 > 5) == (rv)]"),
+                 (rv.implies(min(ivs) != 0), "[(min(ivs[0],ivs[1],ivs[2])) == (IV6), (rv) -> (IV6 != 0)]"),
+                 ((min(ivs) != 0).implies(rv), "[(min(ivs[0],ivs[1],ivs[2])) == (IV8), (IV8 != 0) -> (rv)]"),
                 ]
 
         # test transformation


### PR DESCRIPTION
Surprisingly elegant to handle in the new `reify_rewrite()`

The concept of `decompose_comparison()` could also be helpful for solvers that do not have some numeric expressions (like min, max) to have decompositions for those...

Note this branch MAY NOT be merged unless tests for all reify_rewrite cases are added to the test_transf_reify.py suite