### PR TITLE
166 assertionerror when using a value of 00 with type numpyfloat32 as weight in a weighted sum objective

### DIFF
--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -29,7 +29,8 @@ from itertools import chain, combinations
 def is_int(arg):
     """ can it be interpreted as an integer? (incl bool and numpy variants)
     """
-    return isinstance(arg, (bool, np.bool_, int, np.integer))
+    return isinstance(arg, (bool, np.bool_, int, np.integer)) or \
+            int(arg) == arg # allows for floats with zero fractional part
 def is_num(arg):
     """ is it an int or float? (incl numpy variants)
     """

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,4 +1,7 @@
 import unittest
+
+import pytest
+
 import cpmpy as cp
 from cpmpy.expressions.variables import NullShapeError, _IntVarImpl, _BoolVarImpl, NegBoolView, NDVarArray
 
@@ -33,6 +36,15 @@ class TestSolvers(unittest.TestCase):
             iv = cp.intvar(0, i, i)
             self.assertEqual(iv.shape, (i,), f"Shape should be equal size: expected {(i, )} got {iv.shape}")
             self.assertIsInstance(iv, NDVarArray, f"Instance not {NDVarArray} got {type(iv)}")
+
+    def test_intvar_float_bounds(self):
+        with pytest.raises(AssertionError):
+            cp.intvar(0.5, 5)
+        # zero fractional part is fine
+        self.assertIsNotNone(cp.intvar(0.0,10))
+        self.assertIsNotNone(cp.intvar(0.0,10.0))
+
+
 
     def test_array_intvar(self):
         for i in range(2, 10):


### PR DESCRIPTION
Fixed by testing if `int(arg) == arg` and allowing for empty decimal parts of the float.