### PR TITLE
issue #172 fix - memory crash on mod - update flatten_model.py

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -319,6 +319,7 @@ def get_or_make_var(expr):
             elif flatexpr.name == 'mod': # binary
 
                 if (ubs[0]+1) - lbs[0] > 1000000 or (ubs[1]+1) - lbs[1] > 1000000:
+                    # special check: if the bounds are too loose we can not check all possibilities below
                     ivar = _IntVarImpl(-2147483648, 2147483647)
                 else:
                     l = np.arange(lbs[0], ubs[0]+1)
@@ -351,7 +352,7 @@ def get_or_make_var(expr):
             - Global constraint (non-Boolean) (examples: Max,Min,Element)
             """
             # we don't currently have a generic way to get bounds from non-Boolean globals...
-            # XXX Add to GlobalCons as function? e.g. (lb,ub) = expr.get_bounds()? would also work for Operator...
+            # TODO issue #96 Add to GlobalCons as function? e.g. (lb,ub) = expr.get_bounds()? would also work for Operator...
             ivar = _IntVarImpl(-2147483648, 2147483647) # TODO, this can breaks solvers
 
             return (ivar, [flatexpr == ivar]+flatcons)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -317,12 +317,17 @@ def get_or_make_var(expr):
                 # the above can give fractional values, tighten bounds to integer
                 ivar = _IntVarImpl(math.ceil(min(bnds)), math.floor(max(bnds)))
             elif flatexpr.name == 'mod': # binary
-                l = np.arange(lbs[0], ubs[0]+1)
-                r = np.arange(lbs[1], ubs[1]+1)
-                # check all possibilities
-                remainders = np.mod(l[:,None],r)
-                lb, ub = np.min(remainders), np.max(remainders)
-                ivar = _IntVarImpl(lb,ub)
+
+                if (ubs[0]+1) - lbs[0] > 1000000 or (ubs[1]+1) - lbs[1] > 1000000:
+                    ivar = _IntVarImpl(-2147483648, 2147483647)
+                else:
+                    l = np.arange(lbs[0], ubs[0]+1)
+                    r = np.arange(lbs[1], ubs[1]+1)
+                    # check all possibilities
+                    remainders = np.mod(l[:,None],r)
+                    lb, ub = np.min(remainders), np.max(remainders)
+                    ivar = _IntVarImpl(lb,ub)
+
             elif flatexpr.name == 'pow': # binary
                 base = [lbs[0], ubs[0]]
                 exp = [lbs[1], ubs[1]]


### PR DESCRIPTION
This concerns issue #172.

The bug appeared when trying to flatten the mod expression, when either the left or the right side (or both of course) includes a reference to a cpm_array, with a variable being the index. When a cpm_array is used with a variable as the index, the bounds are assumed to be [-2147483648, 2147483647] , as actual bounds are not calculated (so, it is a more generic bug that could happen in other cases too).

The memory crash was the result of the following:

```
 elif flatexpr.name == 'mod': # binary
                l = np.arange(lbs[0], ubs[0]+1)
                r = np.arange(lbs[1], ubs[1]+1)
                # check all possibilities
                remainders = np.mod(l[:,None],r)
                lb, ub = np.min(remainders), np.max(remainders)
                ivar = _IntVarImpl(lb,ub)
```

When trying to check all possibilities for the results of the mod, it was needed to create arrays that were too large (best case in the above example: 32GB).


This pull request just avoids to really calculate the bounds of 'mod' when we do not have real bounds in the left or right side of the mod. In that case, we can just return the intvar bounds:

``ivar = _IntVarImpl(-2147483648, 2147483647) ``

So, the bounds calculation for the 'mod' expression is just changed to the following:

```
elif flatexpr.name == 'mod': # binary
                if (ubs[0]+1) - lbs[0] > 1000000 or (ubs[1]+1) - lbs[1] > 1000000:
                    ivar = _IntVarImpl(-2147483648, 2147483647)
                else:
                    l = np.arange(lbs[0], ubs[0]+1)
                    r = np.arange(lbs[1], ubs[1]+1)
                    # check all possibilities
                    remainders = np.mod(l[:,None],r)
                    lb, ub = np.min(remainders), np.max(remainders)
                    ivar = _IntVarImpl(lb,ub)
```


