### PR TITLE
Circuit with 1 variable fix - issue #157 fix

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -215,6 +215,10 @@ class Circuit(GlobalConstraint):
         """
         succ = cpm_array(self.args)
         n = len(succ)
+
+        if n <= 1:
+            return None
+
         order = intvar(0,n-1, shape=n)
         return [
             # different successors

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -433,7 +433,9 @@ class CPM_ortools(SolverInterface):
             #    ReservoirConstraint, ReservoirConstraintWithActive
             
             # global constraint not known, try posting generic decomposition
-            self += cpm_expr.decompose()  # assumes a decomposition exists...
+            c = cpm_expr.decompose()
+            if c is not None:
+                self += c  # if a decomposition exists...
             # TODO: DirectConstraint/NativeConstraint from cpm_expr.name to API call? see #74
             return None # will throw error if used in reification
         


### PR DESCRIPTION
This pull request is fixing issue #157 

This issue appears when a circuit of 1 element is created and it crashes both "ortools" and "gurobi".

The bug appears when the "decompose" method of the expression is called, in _post_constraint(). The decompose method is called only in ortools and gurobi and that is why this happens there.

In the decompose method of Circuit, it is assumed that it contains more than one variables.
So, "order" is assumed to be an array of variables
order = intvar(0,n-1, shape=n)
and then an index is used to define that the last one has no succesor
order[n-1] == 0

However, when only 1 variable is given, then n = 1, resulting in "order" not being subscriptable.

It was an easy fix, just returning nothing when it Circuit constraint contains less than 2 variables, skipping the decomposition.

It also needed a check in ortools.py, to check if None is returned before adding the decomposed expression to the model of the solver.

