### PR TITLE
Added new file for custom cpmpy exceptions

### DIFF
--- a/cpmpy/exceptions.py
+++ b/cpmpy/exceptions.py
@@ -10,3 +10,4 @@ class CPMpyException(Exception):
 
 class MinizincPathException(CPMpyException):
     pass
+

--- a/cpmpy/expressions/cpmpy_exceptions.py
+++ b/cpmpy/expressions/cpmpy_exceptions.py
@@ -1,0 +1,12 @@
+'''
+Custom exception classes, for finer grained error handling
+'''
+
+
+class CPMpyException(Exception):
+    '''Parent class for all our exceptions'''
+    pass
+
+
+class MinizincPathException(CPMpyException):
+    pass


### PR DESCRIPTION
Added the cpmpy_expressions.py file where we can add our own exception classes.
They would all have to inherit from the CPMpyException
Added one exception class already as an example.

Does it make sense to have this file in the expressions folder? Or is it better to have a new folder

I will be using cpmpy exceptions in other bug fixes, that's why I am posting this pull request first.