### PR TITLE
191 mus tool crashes with only 1 soft constraint

### DIFF
--- a/cpmpy/tools/mus.py
+++ b/cpmpy/tools/mus.py
@@ -5,6 +5,7 @@ Loosely based on PySat's MUSX:
 https://github.com/pysathq/pysat/blob/master/examples/musx.py
 
 """
+import numpy as np
 from cpmpy import *
 from cpmpy.expressions.variables import NDVarArray
 from cpmpy.transformations.get_variables import get_variables
@@ -33,7 +34,7 @@ def mus(soft, hard=[], solver="ortools"):
 
     assump = boolvar(shape=len(soft), name="assump")
     if len(soft) == 1:
-        assump = NDVarArray([assump])
+        assump = NDVarArray(shape=1, dtype=object, buffer=np.array([assump]))
 
     m = Model(hard+[assump.implies(candidates)]) # each assumption variable implies a candidate
     s = SolverLookup.get(solver, m)

--- a/cpmpy/tools/mus.py
+++ b/cpmpy/tools/mus.py
@@ -6,6 +6,7 @@ https://github.com/pysathq/pysat/blob/master/examples/musx.py
 
 """
 from cpmpy import *
+from cpmpy.expressions.variables import NDVarArray
 from cpmpy.transformations.get_variables import get_variables
 
 def mus(soft, hard=[], solver="ortools"):
@@ -29,8 +30,11 @@ def mus(soft, hard=[], solver="ortools"):
     """
     # order so that constraints with many variables are tried and removed first
     candidates = sorted(soft, key=lambda c: -len(get_variables(c)))
-    
+
     assump = boolvar(shape=len(soft), name="assump")
+    if len(soft) == 1:
+        assump = NDVarArray([assump])
+
     m = Model(hard+[assump.implies(candidates)]) # each assumption variable implies a candidate
     s = SolverLookup.get(solver, m)
     assert not s.solve(assumptions=assump), "MUS: model must be UNSAT"

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -21,6 +21,20 @@ class MusTests(TestCase):
         self.assertEqual(mus(cons), cons[:3])
         self.assertEqual(mus_naive(cons), cons[:3])
 
+    def test_bug_191(self):
+        """Source of the error is assum.implies(candidates). 
+        When assum is a single boolvar and candidates is a list (of length 1), it fails.
+
+        We should check when invoking bv.implies(rhs) rhs is either a single expression
+        or a list of length 1, and extract this value I think. Or change to all(candidates)
+        in the mus tool, but this might have some side effect by itself... to check.
+        """
+        bv = boolvar()
+        hard = [~bv]
+        soft = [bv, bv]
+        mus_cons = mus(soft=soft, hard=hard) # crashes
+        # self.assertEqual(set(mus(cons)), set(cons[1:3]))
+
     def test_wglobal(self):
         x = intvar(-9, 9, name="x")
         y = intvar(-9, 9, name="y")
@@ -40,3 +54,4 @@ class MusTests(TestCase):
 
         self.assertEqual(set(mus(cons)), set(cons[1:3]))
         self.assertEqual(set(mus_naive(cons)), set(cons[1:3]))
+

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -23,6 +23,7 @@ class MusTests(TestCase):
 
     def test_bug_191(self):
         """
+        Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
         """
         bv = boolvar(name="x")

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -48,18 +48,12 @@ class MusTests(TestCase):
         y = intvar(-9, 9, name="y")
         hard = [x > 2]
         soft = [
-            x < 0,
-            x == 4,
-            y == 4,
-            (x + y > 0) | (y < 0),
-            (y >= 0) | (x >= 0),
-            (y < 0) | (x < 0),
-            (y > 0) | (x < 0),
-            AllDifferent(x,y) # invalid for musx_assum
+            x + y < 6,
+            y == 4
         ]
 
         mus_cons = mus(soft=soft, hard=hard) # crashes
-        self.assertEqual(set(mus_cons), set(soft[:1]))
+        self.assertEqual(set(mus_cons), set(soft))
 
     def test_wglobal(self):
         x = intvar(-9, 9, name="x")

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -22,12 +22,8 @@ class MusTests(TestCase):
         self.assertEqual(mus_naive(cons), cons[:3])
 
     def test_bug_191(self):
-        """Source of the error is assum.implies(candidates). 
+        """
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
-
-        We should check when invoking bv.implies(rhs) rhs is either a single expression
-        or a list of length 1, and extract this value I think. Or change to all(candidates)
-        in the mus tool, but this might have some side effect by itself... to check.
         """
         bv = boolvar(name="x")
         hard = [~bv]
@@ -37,12 +33,9 @@ class MusTests(TestCase):
         self.assertEqual(set(mus_cons), set(soft))
 
     def test_bug_191_many_soft(self):
-        """Source of the error is assum.implies(candidates). 
-        When assum is a single boolvar and candidates is a list (of length 1), it fails.
-
-        We should check when invoking bv.implies(rhs) rhs is either a single expression
-        or a list of length 1, and extract this value I think. Or change to all(candidates)
-        in the mus tool, but this might have some side effect by itself... to check.
+        """
+        Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
+        when the number of soft constraints > 1.
         """
         x = intvar(-9, 9, name="x")
         y = intvar(-9, 9, name="y")

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -29,12 +29,37 @@ class MusTests(TestCase):
         or a list of length 1, and extract this value I think. Or change to all(candidates)
         in the mus tool, but this might have some side effect by itself... to check.
         """
-        bv = boolvar()
+        bv = boolvar(name="x")
         hard = [~bv]
         soft = [bv]
 
         mus_cons = mus(soft=soft, hard=hard) # crashes
         self.assertEqual(set(mus_cons), set(soft))
+
+    def test_bug_191_many_soft(self):
+        """Source of the error is assum.implies(candidates). 
+        When assum is a single boolvar and candidates is a list (of length 1), it fails.
+
+        We should check when invoking bv.implies(rhs) rhs is either a single expression
+        or a list of length 1, and extract this value I think. Or change to all(candidates)
+        in the mus tool, but this might have some side effect by itself... to check.
+        """
+        x = intvar(-9, 9, name="x")
+        y = intvar(-9, 9, name="y")
+        hard = [x > 2]
+        soft = [
+            x < 0,
+            x == 4,
+            y == 4,
+            (x + y > 0) | (y < 0),
+            (y >= 0) | (x >= 0),
+            (y < 0) | (x < 0),
+            (y > 0) | (x < 0),
+            AllDifferent(x,y) # invalid for musx_assum
+        ]
+
+        mus_cons = mus(soft=soft, hard=hard) # crashes
+        self.assertEqual(set(mus_cons), set(soft[:1]))
 
     def test_wglobal(self):
         x = intvar(-9, 9, name="x")

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -31,6 +31,8 @@ class MusTests(TestCase):
 
         mus_cons = mus(soft=soft, hard=hard) # crashes
         self.assertEqual(set(mus_cons), set(soft))
+        mus_naive_cons = mus_naive(soft=soft, hard=hard) # crashes
+        self.assertEqual(set(mus_naive_cons), set(soft))
 
     def test_bug_191_many_soft(self):
         """
@@ -47,6 +49,8 @@ class MusTests(TestCase):
 
         mus_cons = mus(soft=soft, hard=hard) # crashes
         self.assertEqual(set(mus_cons), set(soft))
+        mus_naive_cons = mus_naive(soft=soft, hard=hard) # crashes
+        self.assertEqual(set(mus_naive_cons), set(soft))
 
     def test_wglobal(self):
         x = intvar(-9, 9, name="x")

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -1,4 +1,4 @@
-import time
+import unittest
 from unittest import TestCase
 
 from cpmpy import *
@@ -31,9 +31,10 @@ class MusTests(TestCase):
         """
         bv = boolvar()
         hard = [~bv]
-        soft = [bv, bv]
+        soft = [bv]
+
         mus_cons = mus(soft=soft, hard=hard) # crashes
-        # self.assertEqual(set(mus(cons)), set(cons[1:3]))
+        self.assertEqual(set(mus_cons), set(soft))
 
     def test_wglobal(self):
         x = intvar(-9, 9, name="x")
@@ -55,3 +56,5 @@ class MusTests(TestCase):
         self.assertEqual(set(mus(cons)), set(cons[1:3]))
         self.assertEqual(set(mus_naive(cons)), set(cons[1:3]))
 
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```
from cpmpy import *
from cpmpy.tools.mus import mus


bv = boolvar()
mus(soft=[bv], hard=[~bv]) # crashes
```

> Source of the error is assum.implies(candidates). When assum is a single boolvar and candidates is a list (of length 1), it fails.
> 
> We should check when invoking bv.implies(rhs) rhs is either a single expression or a list of length 1, and extract this value I think. Or change to all(candidates) in the mus tool, but this might have some side effect by itself... to check.

When `assum` is a single boolvar, it now converts the assumption variable to a `NDVarArray` of length 1.