### PR TITLE
Make line-expr more linear

### DIFF
--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -381,7 +381,7 @@ def only_const_rhs(cpm_expr):
 
 def only_var_lhs(cpm_expr):
     """
-        Transforms linear expression such that left hand size only contains sums/wsums of variables
+        Transforms linear expression such that left hand side of comparisons only contains sums/wsums of variables
 
         Assumes constraint is in linear form (so only apply after `linearize_constraint`
     """

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -343,7 +343,76 @@ def only_positive_bv(cpm_expr):
 
     raise Exception(f"{cpm_expr} is not linear or is not supported. Please report on github")
 
+def only_const_rhs(cpm_expr):
+    """
+        Transforms linear expressions so that no constants appear on lhs of comparisons
 
+        Assumes constraint is in linear form (so only apply after `linearize_constraint`
+    """
+
+    if is_any_list(cpm_expr):
+        crhs_cons = [only_const_rhs(expr) for expr in cpm_expr]
+        return [c for l in crhs_cons for c in l]
+
+    if isinstance(cpm_expr, Operator) and cpm_expr.name == "->":
+        cond, expr = cpm_expr.args
+        new_expr = only_const_rhs(expr)[0]
+        return [Operator("->", [cond, new_expr])]
+
+    elif isinstance(cpm_expr, Comparison):
+        lhs, rhs = cpm_expr.args
+        if is_num(rhs):
+            return [cpm_expr] # fine
+
+        if isinstance(lhs, Operator) and lhs.name == "sum":
+            lhs = Operator("wsum", [[1]*len(lhs.args)+[-1], lhs.args+[rhs]])
+            rhs = 0
+        elif isinstance(lhs, Operator) and lhs.name == "wsum":
+            lhs = Operator("wsum", [lhs.args[0]+[-1], lhs.args[1]+[rhs]])
+            rhs = 0
+        else:
+            # GenExpr such as min, max
+            pass
+        return [Comparison(cpm_expr.name, lhs, rhs)]
+    else:
+        # global constraints
+        return [cpm_expr]
+
+
+def only_var_lhs(cpm_expr):
+    """
+        Transforms linear expression such that left hand size only contains sums/wsums of variables
+
+        Assumes constraint is in linear form (so only apply after `linearize_constraint`
+    """
+    if is_any_list(cpm_expr):
+        vlhs_cons = [only_var_lhs(expr) for expr in cpm_expr]
+        return [c for l in vlhs_cons for c in l]
+
+    if isinstance(cpm_expr, Operator) and cpm_expr.name == "->":
+        cond, expr = cpm_expr.args
+        new_expr = only_var_lhs(expr)[0]
+        return [Operator("->", [cond, new_expr])]
+
+    elif isinstance(cpm_expr, Comparison):
+        lhs, rhs = cpm_expr.args
+
+        if isinstance(lhs, Operator) and lhs.name == "sum":
+            sum_args = lhs.args
+            lhs = Operator("sum", [arg for arg in sum_args if not is_num(arg)]) # filter lhs to only vars
+            rhs -= sum(arg for arg in sum_args if is_num(arg)) # bring consts to rhs
+
+        elif isinstance(lhs, Operator) and lhs.name == "wsum":
+            weights, args = lhs.args
+            lhs = Operator("wsum", list(map(list,zip(*[[w,a] for w,a in zip(weights, args) if not is_num(a)])))) # filter lhs to only vars
+            rhs -= sum(w * a for w,a in zip(weights, args) if is_num(a)) # bring consts with weights to rhs
+        else:
+            # GenExpr such as min, max
+            pass
+        return [Comparison(cpm_expr.name, lhs, rhs)]
+    else:
+        # global constraints
+        return [cpm_expr]
 
 
 

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -80,6 +80,10 @@ class TestTransConstRhs(unittest.TestCase):
         cons = only_const_rhs(cons)[0]
         self.assertEqual("(max(a,b,c)) <= (r)", str(cons))
 
+        cons = cp.AllDifferent([a,b,c])
+        cons = only_const_rhs(cons)[0]
+        self.assertEqual("alldifferent(a,b,c)", str(cons))
+
 
 class TestTransVarsLhs(unittest.TestCase):
 
@@ -119,4 +123,9 @@ class TestTransVarsLhs(unittest.TestCase):
         cons = cp.max([a,b,c,5]) <= rhs
         cons = only_var_lhs(cons)[0]
         self.assertEqual("(max(a,b,c,5)) <= (r)", str(cons))
+
+        cons = cp.AllDifferent([a, b, c])
+        cons = only_var_lhs(cons)[0]
+        self.assertEqual("alldifferent(a,b,c)", str(cons))
+
 

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -2,7 +2,8 @@ import unittest
 
 import cpmpy as cp
 from cpmpy.expressions import boolvar, intvar
-from cpmpy.transformations.linearize import linearize_constraint
+from cpmpy.expressions.core import Operator
+from cpmpy.transformations.linearize import linearize_constraint, only_const_rhs, only_var_lhs
 
 class TestTransLineariez(unittest.TestCase):
 
@@ -37,3 +38,85 @@ class TestTransLineariez(unittest.TestCase):
             s1 = cp.Model(e1).solve("ortools")
             self.assertTrue(s1)
             self.assertEqual([bv[0].value(), bv[1].value(), iv.value()],[True, True, 1])
+
+
+
+class TestTransConstRhs(unittest.TestCase):
+
+    def test_sum(self):
+        a,b,c = [cp.intvar(0,10,name=n) for n in "abc"]
+        rhs = intvar(0,10,name="r")
+
+        cons = only_const_rhs(cp.sum([a,b,c]) <= rhs)[0]
+        self.assertEqual("sum([1, 1, 1, -1] * [a, b, c, r]) <= 0", str(cons))
+
+    def test_wsum(self):
+        a, b, c = [cp.intvar(0, 10,name=n) for n in "abc"]
+        rhs = intvar(0, 10, name="r")
+
+        cons = 1*a + 2*b + 3*c <= rhs
+        cons = only_const_rhs(cons)[0]
+        self.assertEqual("sum([1, 2, 3, -1] * [a, b, c, r]) <= 0", str(cons))
+
+    def test_impl(self):
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = intvar(0, 10, name="r")
+        cond = cp.boolvar(name="bv")
+
+        cons = cond.implies(1 * a + 2 * b + 3 * c <= rhs)
+        cons = only_const_rhs(cons)[0]
+        self.assertEqual("(bv) -> (sum([1, 2, 3, -1] * [a, b, c, r]) <= 0)", str(cons))
+
+        cons = (~cond).implies(1 * a + 2 * b + 3 * c <= rhs)
+        cons = only_const_rhs(cons)[0]
+        self.assertEqual("(~bv) -> (sum([1, 2, 3, -1] * [a, b, c, r]) <= 0)", str(cons))
+
+    def test_others(self):
+
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = intvar(0, 10, name="r")
+
+        cons = cp.max([a,b,c]) <= rhs
+        cons = only_const_rhs(cons)[0]
+        self.assertEqual("(max(a,b,c)) <= (r)", str(cons))
+
+
+class TestTransVarsLhs(unittest.TestCase):
+
+    def test_sum(self):
+        a,b,c = [cp.intvar(0,10,name=n) for n in "abc"]
+        rhs = 5
+
+        cons = only_var_lhs(cp.sum([a,b,c,10]) <= rhs)[0]
+        self.assertEqual("sum([a, b, c]) <= -5", str(cons))
+
+    def test_wsum(self):
+        a, b, c = [cp.intvar(0, 10,name=n) for n in "abc"]
+        rhs = 5
+
+        cons = Operator("wsum",[[1,2,3,-1],[a,b,c,10]]) <= rhs
+        cons = only_var_lhs(cons)[0]
+        self.assertEqual("sum([1, 2, 3] * [a, b, c]) <= 15", str(cons))
+
+    def test_impl(self):
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = 5
+        cond = cp.boolvar(name="bv")
+
+        cons = cond.implies(Operator("wsum",[[1,2,3,-1],[a,b,c,10]]) <= rhs)
+        cons = only_var_lhs(cons)[0]
+        self.assertEqual("(bv) -> (sum([1, 2, 3] * [a, b, c]) <= 15)", str(cons))
+
+        cons = (~cond).implies(Operator("wsum",[[1,2,3,-1],[a,b,c,10]]) <= rhs)
+        cons = only_var_lhs(cons)[0]
+        self.assertEqual("(~bv) -> (sum([1, 2, 3] * [a, b, c]) <= 15)", str(cons))
+
+    def test_others(self):
+
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = intvar(0, 10, name="r")
+
+        cons = cp.max([a,b,c,5]) <= rhs
+        cons = only_var_lhs(cons)[0]
+        self.assertEqual("(max(a,b,c,5)) <= (r)", str(cons))
+


### PR DESCRIPTION
Implemented two new transformations for linear expressions:
1) only allow variables on lhs of comparisons
2) only allow constants on rhs of comparisons

Some solvers (such as Exact) require these types of linear constraints a input.