### PR TITLE
Added floordivision '//' on integer variables

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -73,6 +73,7 @@
         Comparison
         Operator
 """
+import warnings
 from types import GeneratorType
 from collections.abc import Iterable
 import numpy as np
@@ -298,10 +299,18 @@ class Expression(object):
 
     # other mathematical ones
     def __truediv__(self, other):
+        warnings.warn("We only support floordivision, use // in stead of /", SyntaxWarning)
         if is_num(other) and other == 1:
             return self
         return Operator("div", [self, other])
     def __rtruediv__(self, other):
+        warnings.warn("We only support floordivision, use // in stead of /", DeprecationWarning)
+        return Operator("div", [other, self])
+    def __floordiv__(self, other):
+        if is_num(other) and other == 1:
+            return self
+        return Operator("div", [self, other])
+    def __rfloordiv__(self, other):
         return Operator("div", [other, self])
 
     def __mod__(self, other):
@@ -400,7 +409,7 @@ class Operator(Expression):
         '-':   (1, False), # -x
         'abs': (1, False),
     }
-    printmap = {'sum': '+', 'sub': '-', 'mul': '*', 'div': '/'}
+    printmap = {'sum': '+', 'sub': '-', 'mul': '*', 'div': '//'}
 
     def __init__(self, name, arg_list):
         # sanity checks
@@ -503,7 +512,7 @@ class Operator(Expression):
         elif self.name == "wsum": return sum(arg_vals[0]*np.array(arg_vals[1]))
         elif self.name == "mul": return arg_vals[0] * arg_vals[1]
         elif self.name == "sub": return arg_vals[0] - arg_vals[1]
-        elif self.name == "div": return arg_vals[0] / arg_vals[1]
+        elif self.name == "div": return arg_vals[0] // arg_vals[1]
         elif self.name == "mod": return arg_vals[0] % arg_vals[1]
         elif self.name == "pow": return arg_vals[0] ** arg_vals[1]
         elif self.name == "-":   return -arg_vals[0]

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -304,7 +304,7 @@ class Expression(object):
             return self
         return Operator("div", [self, other])
     def __rtruediv__(self, other):
-        warnings.warn("We only support floordivision, use // in stead of /", DeprecationWarning)
+        warnings.warn("We only support floordivision, use // in stead of /", SyntaxWarning)
         return Operator("div", [other, self])
     def __floordiv__(self, other):
         if is_num(other) and other == 1:

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -497,9 +497,13 @@ class NDVarArray(Expression, np.ndarray):
     def __rmul__(self, other):
         return self._vectorized(other, '__rmul__') 
     def __truediv__(self, other):
-        return self._vectorized(other, '__truediv__') 
+        return self._vectorized(other, '__truediv__')
     def __rtruediv__(self, other):
-        return self._vectorized(other, '__rtruediv__') 
+        return self._vectorized(other, '__rtruediv__')
+    def __floordiv__(self, other):
+        return self._vectorized(other, '__floordiv__')
+    def __rfloordiv__(self, other):
+        return self._vectorized(other, '__rfloordiv__')
     def __mod__(self, other):
         return self._vectorized(other, '__mod__') 
     def __rmod__(self, other):

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -123,8 +123,8 @@ class TestFlattenExpr(unittest.TestCase):
         self.assertEqual( str(get_or_make_var( a+b+c )), "(IV6, [(sum([IV0, IV1, IV2])) == (IV6)])" )
         self.assertEqual( str(get_or_make_var( 2*a )), "(IV7, [(2 * (IV0)) == (IV7)])" )
         self.assertEqual( str(get_or_make_var( a*b )), "(IV8, [((IV0) * (IV1)) == (IV8)])" )
-        self.assertEqual( str(get_or_make_var( a/b )), "(IV9, [((IV0) / (IV1)) == (IV9)])" )
-        self.assertEqual( str(get_or_make_var( 1/b )), "(IV10, [(1 / (IV1)) == (IV10)])" )
+        self.assertEqual( str(get_or_make_var( a/b )), "(IV9, [((IV0) // (IV1)) == (IV9)])" )
+        self.assertEqual( str(get_or_make_var( 1/b )), "(IV10, [(1 // (IV1)) == (IV10)])" )
         self.assertEqual( str(get_or_make_var( a/1 )), "(IV0, [])" )
         self.assertEqual( str(get_or_make_var( abs(cp.intvar(-5,5, name="x")) )), "(IV11, [(abs([x])) == (IV11)])" )
         self.assertEqual( str(get_or_make_var( 1*a + 2*b + 3*c )), "(IV12, [(sum([1, 2, 3] * [IV0, IV1, IV2])) == (IV12)])")
@@ -139,7 +139,7 @@ class TestFlattenExpr(unittest.TestCase):
         self.assertEqual( str(flatten_objective( a+b )), f"(({str(a)}) + ({str(b)}), [])" )
         self.assertEqual( str(flatten_objective( 2*a+3*b )), "(sum([2, 3] * [IV0, IV1]), [])" )
         self.assertEqual( str(flatten_objective( 2*a+3*(b + c) )), "(sum([2, 3] * [IV0, IV5]), [((IV1) + (IV2)) == (IV5)])" )
-        self.assertEqual( str(flatten_objective( a/b+c )), f"((IV6) + ({str(c)}), [(({str(a)}) / ({str(b)})) == (IV6)])" )
+        self.assertEqual( str(flatten_objective( a/b+c )), f"((IV6) + ({str(c)}), [(({str(a)}) // ({str(b)})) == (IV6)])" )
         self.assertEqual( str(flatten_objective( cp.cpm_array([1,2,3])[a] )), "(IV7, [([1 2 3][IV0]) == (IV7)])" )
         self.assertEqual( str(flatten_objective( cp.cpm_array([1,2,3])[a]+b )), "((IV8) + (IV1), [([1 2 3][IV0]) == (IV8)])" )
         self.assertEqual( str(flatten_objective( a+b-c )), "(sum([IV0, IV1, IV9]), [(-1 * (IV2)) == (IV9)])" )
@@ -184,8 +184,8 @@ class TestFlattenExpr(unittest.TestCase):
         self.assertEqual( str(flatten_constraint( (a == 10).implies(b == c+d) )), "[(IV0 == 10) -> (BV9), (((IV2) + (IV3)) == (IV1)) == (BV9)]" )
         # different order should not create more tempvars
         self.assertEqual( str(flatten_constraint( (a == 10).implies(c+d == b) )), "[(IV0 == 10) -> (BV10), (((IV2) + (IV3)) == (IV1)) == (BV10)]" )
-        self.assertEqual( str(flatten_constraint( a / b == c )), "[((IV0) / (IV1)) == (IV2)]" )
-        self.assertEqual( str(flatten_constraint( c == a / b )), "[((IV0) / (IV1)) == (IV2)]" )
+        self.assertEqual( str(flatten_constraint( a / b == c )), "[((IV0) // (IV1)) == (IV2)]" )
+        self.assertEqual( str(flatten_constraint( c == a / b )), "[((IV0) // (IV1)) == (IV2)]" )
 
         # double negation #146
         self.assertEqual( str(flatten_constraint( ~(~(a == 7)) )), "[IV0 == 7]" )


### PR DESCRIPTION
I put a syntax warning on using / in stead of a deprecation warning, because this prints the warning message.

