### PR TITLE
table decomposition bug

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -108,7 +108,7 @@ import warnings # for deprecation warning
 import numpy as np
 from ..exceptions import CPMpyException
 from .core import Expression, Operator, Comparison
-from .variables import boolvar, intvar, cpm_array
+from .variables import boolvar, intvar, cpm_array, NDVarArray
 from .utils import flatlist, all_pairs, argval, is_num, eval_comparison, is_any_list
 from ..transformations.flatten_model import get_or_make_var
 
@@ -294,8 +294,14 @@ class Table(GlobalConstraint):
     def decompose(self):
         from .python_builtins import any, all
         arr, tab = self.args
-        #make it a list because other code assumes decompositions return a list of constraints
-        return [any(all(arr == row) for row in tab)]
+        #Comparing multiple values at once only works with an NDVarArray. We cannot assume that arr has that type here
+        options = []
+        for row in tab:
+            assignment = []
+            for i in range(len(row)):
+                assignment += [arr[i] == row[i]]
+            options += [all(assignment)]
+        return [any(options)]
 
 
     def deepcopy(self, memodict={}):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -294,14 +294,7 @@ class Table(GlobalConstraint):
     def decompose(self):
         from .python_builtins import any, all
         arr, tab = self.args
-        #Comparing multiple values at once only works with an NDVarArray. We cannot assume that arr has that type here
-        options = []
-        for row in tab:
-            assignment = []
-            for i in range(len(row)):
-                assignment += [arr[i] == row[i]]
-            options += [all(assignment)]
-        return [any(options)]
+        return [any(all(ai == ri for ai, ri in zip(arr, row)) for row in tab)]
 
 
     def deepcopy(self, memodict={}):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -108,7 +108,7 @@ import warnings # for deprecation warning
 import numpy as np
 from ..exceptions import CPMpyException
 from .core import Expression, Operator, Comparison
-from .variables import boolvar, intvar, cpm_array, NDVarArray
+from .variables import boolvar, intvar, cpm_array
 from .utils import flatlist, all_pairs, argval, is_num, eval_comparison, is_any_list
 from ..transformations.flatten_model import get_or_make_var
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -104,6 +104,14 @@ class TestGlobal(unittest.TestCase):
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)
+
+        constraints = [cp.Table([iv[0], iv[1], iv[2]], [ (5, 2, 2)])]
+        model = cp.Model(constraints)
+        self.assertTrue(model.solve())
+
+        model = cp.Model(constraints[0].decompose())
+        self.assertTrue(model.solve())
+
         constraints = [cp.Table(iv, [[10, 8, 2], [5, 2, 2]])]
         model = cp.Model(constraints)
         self.assertTrue(model.solve())


### PR DESCRIPTION
more robust decompose(), does not look pretty but I don't know how to implement it otherwise without assuming arr is a NDVarArray