### PR TITLE
Manage incomplete functions when calculating value

### DIFF
--- a/cpmpy/exceptions.py
+++ b/cpmpy/exceptions.py
@@ -17,3 +17,6 @@ class MinizincNameException(CPMpyException):
 
 class NotSupportedError(CPMpyException):
     pass
+
+class IncompleteFunctionError(CPMpyException):
+    pass

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -543,11 +543,16 @@ class Operator(Expression):
         elif self.name == "wsum": return sum(arg_vals[0]*np.array(arg_vals[1]))
         elif self.name == "mul": return arg_vals[0] * arg_vals[1]
         elif self.name == "sub": return arg_vals[0] - arg_vals[1]
-        elif self.name == "div": return arg_vals[0] // arg_vals[1]
         elif self.name == "mod": return arg_vals[0] % arg_vals[1]
         elif self.name == "pow": return arg_vals[0] ** arg_vals[1]
         elif self.name == "-":   return -arg_vals[0]
         elif self.name == "abs": return -arg_vals[0] if arg_vals[0] < 0 else arg_vals[0]
+        elif self.name == "div":
+            try:
+                return arg_vals[0] // arg_vals[1]
+            except ZeroDivisionError:
+                raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}")
+
         # boolean
         elif self.name == "and": return all(arg_vals)
         elif self.name == "or" : return any(arg_vals)

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -78,7 +78,9 @@ from types import GeneratorType
 from collections.abc import Iterable
 import numpy as np
 
-from .utils import is_num, is_any_list, flatlist
+from .utils import is_num, is_any_list, flatlist, argval
+from ..exceptions import IncompleteFunctionError
+
 
 class Expression(object):
     """
@@ -530,9 +532,9 @@ class Operator(Expression):
     def value(self):
         if self.name == "wsum":
             # wsum: arg0 is list of constants, no .value() use as is
-            arg_vals = [self.args[0], [arg.value() if isinstance(arg, Expression) else arg for arg in self.args[1]]]
+            arg_vals = [self.args[0], [argval(arg) for arg in self.args[1]]]
         else:
-            arg_vals = [arg.value() if isinstance(arg, Expression) else arg for arg in self.args]
+            arg_vals = [argval(arg) for arg in self.args]
 
 
         if any(a is None for a in arg_vals): return None

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -106,7 +106,7 @@
 """
 import warnings # for deprecation warning
 import numpy as np
-from ..exceptions import CPMpyException
+from ..exceptions import CPMpyException, IncompleteFunctionError
 from .core import Expression, Operator, Comparison
 from .variables import boolvar, intvar, cpm_array
 from .utils import flatlist, all_pairs, argval, is_num, eval_comparison, is_any_list
@@ -408,7 +408,9 @@ class Element(GlobalConstraint):
         arr, idx = self.args
         idxval = argval(idx)
         if idxval is not None:
-            return argval(arr[idxval])
+            if idxval >= 0 and idxval < len(arr):
+                return argval(arr[idxval])
+            raise IncompleteFunctionError(f"Index {idxval} out of range for array of length {len(arr)} while calculating value for expression {self}")
         return None # default
 
     def decompose_comparison(self, cmp_op, cmp_rhs):

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -26,6 +26,9 @@ import numpy as np
 from collections.abc import Iterable # for _flatten
 from itertools import chain, combinations
 
+from cpmpy.exceptions import IncompleteFunctionError
+
+
 def is_int(arg):
     """ can it be interpreted as an integer? (incl bool and numpy variants)
     """
@@ -76,7 +79,11 @@ def argval(a):
         
         We check with hasattr instead of isinstance to avoid circular dependency
     """
-    return a.value() if hasattr(a, "value") else a
+    try:
+        return a.value() if hasattr(a, "value") else a
+    except IncompleteFunctionError as e:
+        if a.is_bool(): return False
+        raise e
 
 def eval_comparison(str_op, lhs, rhs):
     """

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,6 +1,8 @@
 import unittest
 import cpmpy as cp
 import numpy as np
+
+from cpmpy.exceptions import IncompleteFunctionError
 from cpmpy.expressions import *
 from cpmpy.expressions.variables import NDVarArray
 from cpmpy.expressions.core import Operator, Expression
@@ -193,6 +195,31 @@ class TestMul(unittest.TestCase):
             self.assertTrue(isinstance(expr, Expression) or expr == 0)
 
 
+    def test_incomplete_func(self):
+        # element constraint
+        arr = cpm_array([1,2,3])
+        i = intvar(0,5,name="i")
+        p = boolvar()
+
+        cons = (arr[i] == 1).implies(p)
+        m = cp.Model([cons, i == 5])
+        self.assertTrue(m.solve())
+        self.assertTrue(cons.value())
+
+        # div constraint
+        a,b = intvar(1,2,shape=2)
+        cons = (42 // (a - b)) >= 3
+        m = cp.Model([p.implies(cons), a == b])
+        if cp.SolverLookup.lookup("z3").supported():
+            self.assertTrue(m.solve(solver="z3")) # ortools does not support divisor spanning 0 work here
+            self.assertRaises(IncompleteFunctionError, cons.value)
+
+        # mayhem
+        cons = (arr[10 // (a - b)] == 1).implies(p)
+        m = cp.Model([cons, a == b])
+        if cp.SolverLookup.lookup("z3").supported():
+            self.assertTrue(m.solve(solver="z3"))
+            self.assertTrue(cons.value())
 
 
 


### PR DESCRIPTION
Implemented a new type of exception to work with incomplete functions.
Changed `.value()` computation of `->` and `or` accordingly