### PR TITLE
Decompose globals

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -446,7 +446,7 @@ class Element(GlobalConstraint):
         from .python_builtins import any
 
         arr, idx = self.args
-        return [(idx == i).implies(Comparison(cpm_op, arr[i], cpm_rhs)) for i in range(len(arr))] + \
+        return [(idx == i).implies(eval_comparison(cpm_op, arr[i], cpm_rhs)) for i in range(len(arr))] + \
                [idx >= 0, idx < len(arr)]
 
     def __repr__(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -434,7 +434,7 @@ class Element(GlobalConstraint):
             return argval(arr[idxval])
         return None # default
 
-    def decompose_comparison(self, cmp_op, cmp_rhs):
+    def decompose_comparison(self, cpm_op, cpm_rhs):
         """
             `Element(arr,ix)` represents the array lookup itself (a numeric variable)
             It is not a constraint itself, so it can not have a decompose().
@@ -445,8 +445,9 @@ class Element(GlobalConstraint):
         """
         from .python_builtins import any
 
-        arr,idx = self.args
-        return [any(eval_comparison(cmp_op, arr[j], cmp_rhs) & (idx == j) for j in range(len(arr)))]
+        arr, idx = self.args
+        return [(idx == i).implies(Comparison(cpm_op, arr[i], cpm_rhs)) for i in range(len(arr))] + \
+               [idx >= 0, idx < len(arr)]
 
     def __repr__(self):
         return "{}[{}]".format(self.args[0], self.args[1])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -369,7 +369,7 @@ class Minimum(GlobalConstraint):
 
         arr = argval(self.args)
         _min = intvar(-2147483648, 2147483647)
-        return all([any(x <= _min for x in arr), all(x >= _min for x in arr), eval_comparison(cpm_op, _min, cpm_rhs)])
+        return [any(x <= _min for x in arr), all(x >= _min for x in arr), eval_comparison(cpm_op, _min, cpm_rhs)]
 
 class Maximum(GlobalConstraint):
     """
@@ -403,7 +403,7 @@ class Maximum(GlobalConstraint):
 
         arr = argval(self.args)
         _max = intvar(-2147483648, 2147483647)
-        return all([any(x >= _max for x in arr), all(x <= _max for x in arr), eval_comparison(cpm_op, _max, cpm_rhs)])
+        return [any(x >= _max for x in arr), all(x <= _max for x in arr), eval_comparison(cpm_op, _max, cpm_rhs)]
 
 
 def element(arg_list):

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -30,6 +30,7 @@ from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..expressions.core import *
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
 from ..transformations.comparison import only_numexpr_equality
+from ..transformations.decompose_global import decompose_global
 from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, only_positive_bv
@@ -264,6 +265,7 @@ class CPM_gurobi(SolverInterface):
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
         cpm_cons = flatten_constraint(cpm_expr)  # flat normal form
+        cpm_cons = decompose_global(cpm_cons, supported={"min","max", "element", "alldifferent"}) #element and alldiff have specialized MIP decomp in linearize
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_bv_implies(cpm_cons)  # anything that can create full reif should go above...
         cpm_cons = linearize_constraint(cpm_cons)  # the core of the MIP-linearization

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -360,14 +360,6 @@ class CPM_gurobi(SolverInterface):
             if sub_expr.name == "==":
                 return self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.EQUAL, self.solver_var(rhs))
 
-        # Global constraints
-        elif hasattr(cpm_expr, 'decompose'):
-            # global constraint not known, try posting generic decomposition
-            # side-step `__add__()` as the decomposition can contain non-user (auxiliary) variables
-            for con in self.transform(cpm_expr.decompose()):
-                self._post_constraint(con)
-            return
-
         raise NotImplementedError(cpm_expr)  # if you reach this... please report on github
 
     def solveAll(self, display=None, time_limit=None, solution_limit=None, call_from_model=False, **kwargs):

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -32,6 +32,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, boolvar
 from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.utils import is_num, is_any_list, eval_comparison
+from ..transformations.decompose_global import decompose_global
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective
 from ..transformations.reification import only_bv_implies, reify_rewrite
@@ -322,6 +323,7 @@ class CPM_ortools(SolverInterface):
         :return: list of Expression
         """
         cpm_cons = flatten_constraint(cpm_expr)  # flat normal form
+        cpm_cons = decompose_global(cpm_cons, supported={"min","max","element","alldifferent","xor","table", "cumulative","circuit"})
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=
         cpm_cons = only_bv_implies(cpm_cons) # everything that can create
@@ -444,14 +446,7 @@ class CPM_ortools(SolverInterface):
             elif cpm_expr.name == 'xor':
                 return self.ort_model.AddBoolXOr(self.solver_vars(cpm_expr.args))
             else:
-                # NOT (YET?) MAPPED: Automaton, ForbiddenAssignments, Inverse?,
-                #    ReservoirConstraint, ReservoirConstraintWithActive
-            
-                # global constraint not known, try posting generic decomposition
-                # side-step `__add__()` as the decomposition can contain non-user (auxiliary) variables
-                for con in self.transform(cpm_expr.decompose()):
-                    self._post_constraint(con)
-                return None  # will throw error if used in reification
+                raise NotImplementedError(f"Unknown global constraint {cpm_expr}, should be decomposed! If you reach this, please report on github.")
 
         # unlikely base case: Boolean variable
         elif isinstance(cpm_expr, _BoolVarImpl):

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -41,7 +41,7 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
 
         return True
 
-    assert supported_reif <= supported, "`supported` set is assumed to be a subset of the `supported_reified` set"
+    assert supported_reif <= supported, "`supported_reif` set is assumed to be a subset of the `supported` set"
     if not is_any_list(lst_of_expr):
         lst_of_expr= [lst_of_expr]
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -16,7 +16,7 @@ def decompose_global(lst_of_expr, supported={}):
     def _is_supported(cpm_expr):
         if isinstance(cpm_expr, GlobalConstraint) and cpm_expr.name not in supported:
             return False
-        if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalConstraint) and cpm_expr.name not in supported:
+        if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalConstraint) and cpm_expr.args[0].name not in supported:
             return False
         return True
 
@@ -35,7 +35,7 @@ def decompose_global(lst_of_expr, supported={}):
             if cpm_expr.name == "==" and not _is_supported(lhs): # can be both boolean or numerical globals
                 decomp_idx = 0
 
-            if isinstance(lhs, GlobalConstraint) and lhs.name not in supported:
+            if not _is_supported(cpm_expr):
                 cpm_expr = do_decompose(cpm_expr) # base global constraint in comparison
                 decomp_idx = None
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -1,0 +1,71 @@
+
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.core import Expression, Comparison, Operator
+from ..expressions.utils import is_any_list, eval_comparison
+from ..expressions.python_builtins import all
+from .flatten_model import flatten_constraint
+
+def decompose_global(lst_of_expr, supported={}):
+
+    """
+        Decomposes any global constraint not supported by the solver
+        Accepts a list of flat constraints as input
+        Returns a list of flat constraints
+    """
+
+    if not is_any_list(lst_of_expr):
+        lst_of_expr= [lst_of_expr]
+
+    newlist = []
+    for cpm_expr in lst_of_expr:
+        assert isinstance(cpm_expr, Expression), f"Expected CPMpy expression but got {cpm_expr}, run 'cpmpy.transformations.normalize.toplevel_list' first"
+
+        # 1: Base case boolean global constraint
+        if hasattr(cpm_expr, "decompose") and cpm_expr.name not in supported:
+            cpm_expr = cpm_expr.decompose()
+        # 2: global constraint on lhs of a comparison
+        elif isinstance(cpm_expr, Comparison):
+            lhs, rhs = cpm_expr.args
+            if isinstance(lhs, GlobalConstraint) and lhs.name not in supported:
+                cpm_expr = _decompose_global_comp(cpm_expr)
+        elif isinstance(cpm_expr, Operator) and cpm_expr.name == "->":
+            cond, subexpr = cpm_expr.args
+            if hasattr(subexpr, "decompose") and subexpr.name not in supported: # probably most frequent case
+                # 3: Boolean global constraint on rhs of implies
+                cpm_expr = [cond.implies(all(subexpr.decompose()))]
+            elif hasattr(cond, "decompose") and cond.name not in supported:
+                # 4: Boolean global constraint on lhs of implies
+                cpm_expr = [all(cond.decompose()).implies(subexpr)]
+            elif isinstance(cond, Comparison) and \
+                    isinstance(cond.args[0], GlobalConstraint) and cond.args[0].name not in supported:
+                # 5: global constraint on lhs of comparison on lhs of implies
+                cpm_expr = [all(_decompose_global_comp(cond)).implies(subexpr)]
+            elif isinstance(subexpr, Comparison) and \
+                    isinstance(subexpr.args[0], GlobalConstraint) and subexpr.args[0].name not in supported:
+                # 6: Numerical global constraint on lhs of comparison on rhs of implies
+                cpm_expr = [cond.implies(all(_decompose_global_comp(subexpr)))]
+
+        if isinstance(cpm_expr, list): # some decomposition happened, have to run again as decomp can contain new global
+            newlist.extend(decompose_global(flatten_constraint(cpm_expr), supported=supported))
+        else:
+            # default
+            newlist.append(cpm_expr)
+
+    return newlist
+
+
+def _decompose_global_comp(cpm_expr):
+    """
+        Helper function for decomposing global constraints in comparisons
+    """
+    assert isinstance(cpm_expr, Comparison), f"expected CPMpy Comparison, got {cpm_expr}"
+
+    lhs, rhs = cpm_expr.args
+    if hasattr(lhs, "decompose_comparison"):
+        # numerical global
+        return lhs.decompose_comparison(cpm_expr.name, rhs)
+    if hasattr(lhs, "decompose"):
+        # boolean global
+        return [Comparison(cpm_expr.name, all(lhs.decompose()), rhs)]
+
+    raise ValueError(f"Expected global constraint on lhs of comparison {cpm_expr}, got {lhs}")

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -20,6 +20,13 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
         Numerical global constraints are left reified even if not part of the `supported_reified` set
             as they can be rewritten using `cpmpy.transformations.reification.reify_rewrite`...
                 ... reified partial functions are decomposed when unsupported by `supported_reified`
+                The following `bv -> NumExpr <comp> Var/Const` can always be rewritten as ...
+                                [bv -> IV0 <comp> Var/Const, NumExpr == IV0].
+                So even if numerical constraints are not supported in reified context, we can rewrite them to non-reified versions.
+                TODO: decide if we want to do the rewrite of unsupported globals here or leave it to `reify_rewrite`.
+                    Currently, we left it for `reify_rewrite`
+
+
 
     """
     def _is_supported(cpm_expr, reified):

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -26,7 +26,7 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
         if isinstance(cpm_expr, GlobalConstraint) and cpm_expr.is_bool():
             if reified and cpm_expr.name not in supported_reif:
                 return False
-            if reified and cpm_expr.name not in supported:
+            if not reified and cpm_expr.name not in supported:
                 return False
         if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalConstraint):
             if not cpm_expr.args[0].name in supported:
@@ -50,7 +50,7 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
         assert isinstance(cpm_expr, Expression), f"Expected CPMpy expression but got {cpm_expr}, run 'cpmpy.transformations.normalize.toplevel_list' first"
         decomp_idx = None
 
-        if hasattr(cpm_expr, "decompose") and cpm_expr.is_bool() and cpm_expr.name not in supported:
+        if hasattr(cpm_expr, "decompose") and not _is_supported(cpm_expr, reified=False):
             cpm_expr = cpm_expr.decompose() # base boolean global constraints
         elif isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -137,20 +137,6 @@ def reify_rewrite(constraints, supported=frozenset()):
                 #   at the very least, (iv1 == iv2) == bv has to be supported
                 if isinstance(lhs, _NumVarImpl) or lhs.name in supported:
                     newcons.append(cpm_expr)
-                elif isinstance(lhs, Element) and (lhs.args[1].lb < 0 or lhs.args[1].ub >= len(lhs.args[0])):
-                    # special case: (Element(arr,idx) <OP> RHS) == BV (or -> in some way)
-                    # if the domain of 'idx' is larger than the range of 'arr', then 
-                    # this is allowed and BV should be false if it takes a value there
-                    # so we can not use Element (which would restruct the domain of idx)
-                    # and have to work with an element-wise decomposition instead
-                    reifexpr = copy.copy(cpm_expr)
-                    decomp = all(lhs.decompose_comparison(op,rhs))  # decomp() returns list
-                    if decomp is False:
-                        # TODO uh... special case, can't insert a constant here with the current transformations...
-                        # use IV < IV.lb which will be false...
-                        decomp = (lhs.args[1] < lhs.args[1].lb)
-                    reifexpr.args[boolexpr_index] = decomp
-                    newcons += flatten_constraint(reifexpr)
                 else:  #   other cases (assuming LHS is a total function):
                     #     (AUX,c) = get_or_make_var(LHS)
                     #     return c+[Comp(OP,AUX,RHS) == BV] or +[Comp(OP,AUX,RHS) -> BV] or +[Comp(OP,AUX,RHS) <- BV]

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -127,17 +127,30 @@ def reify_rewrite(constraints, supported=frozenset()):
                 if boolexpr.name in supported:
                     newcons.append(cpm_expr)
                 else:
-                    reifexpr = copy.copy(cpm_expr)
-                    reifexpr.args[boolexpr_index] = all(boolexpr.decompose())  # decomp() returns list
-                    newcons += flatten_constraint(reifexpr)
+                    raise ValueError(f"Unsupported boolexpr {boolexpr} in reification, run `cpmpy.transformations.decompose_global.decompose_global` to decompose unsupported global constraints")
             elif isinstance(boolexpr, Comparison):
                 # Case 3, BE is Comparison(OP, LHS, RHS)
-                op,(lhs,rhs) = boolexpr.name, boolexpr.args
+                op, (lhs, rhs) = boolexpr.name, boolexpr.args
                 #   have list of supported lhs's such as sum and wsum...
                 #   at the very least, (iv1 == iv2) == bv has to be supported
                 if isinstance(lhs, _NumVarImpl) or lhs.name in supported:
                     newcons.append(cpm_expr)
-                else:  #   other cases (assuming LHS is a total function):
+                elif isinstance(lhs, Element) and (lhs.args[1].lb < 0 or lhs.args[1].ub >= len(lhs.args[0])):
+                    # special case: (Element(arr,idx) <OP> RHS) == BV (or -> in some way)
+                    # if the domain of 'idx' is larger than the range of 'arr', then
+                    # this is allowed and BV should be false if it takes a value there
+                    # so we can not use Element (which would restruct the domain of idx)
+                    # and have to work with an element-wise decomposition instead
+                    reifexpr = copy.copy(cpm_expr)
+                    decomp = all(lhs.decompose_comparison(op, rhs))  # decomp() returns list
+                    print(decomp)
+                    if decomp is False:
+                        # TODO uh... special case, can't insert a constant here with the current transformations...
+                        # use IV < IV.lb which will be false...
+                        decomp = (lhs.args[1] < lhs.args[1].lb)
+                    reifexpr.args[boolexpr_index] = decomp
+                    newcons += flatten_constraint(reifexpr)
+                else:  # other cases (assuming LHS is a total function):
                     #     (AUX,c) = get_or_make_var(LHS)
                     #     return c+[Comp(OP,AUX,RHS) == BV] or +[Comp(OP,AUX,RHS) -> BV] or +[Comp(OP,AUX,RHS) <- BV]
                     (auxvar, cons) = get_or_make_var(lhs)

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -1,0 +1,53 @@
+import unittest
+import numpy as np
+from cpmpy import *
+from cpmpy.transformations.flatten_model import flatten_constraint
+from cpmpy.transformations.decompose_global import decompose_global
+from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl  # to reset counters
+
+
+class TestTransfDecomp(unittest.TestCase):
+
+    def setUp(self):
+        _IntVarImpl.counter = 0
+        _BoolVarImpl.counter = 0
+
+    def test_decompose_bool(self):
+        ivs = [intvar(1, 9, name=n) for n in "xyz"]
+        bv = boolvar(name="bv")
+
+        cons = AllDifferent(ivs)
+        self.assertEqual(str(decompose_global(cons)), "[(x) != (y), (x) != (z), (y) != (z)]")
+        # reified
+        cons = bv.implies(AllDifferent(ivs))
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(bv) -> ((x) != (y)), (bv) -> ((x) != (z)), (bv) -> ((y) != (z))]")
+        cons = AllDifferent(ivs).implies(bv)
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(and([BV0, BV1, BV2])) -> (bv), ((x) != (y)) == (BV0), ((x) != (z)) == (BV1), ((y) != (z)) == (BV2)]")
+        cons = AllDifferent(ivs) == (bv)
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(and([BV3, BV4, BV5])) == (bv), ((x) != (y)) == (BV3), ((x) != (z)) == (BV4), ((y) != (z)) == (BV5)]")
+        # tricky one
+        cons = AllDifferent(ivs) < (bv)
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(BV9) < (bv), (and([BV6, BV7, BV8])) == (BV9), ((x) != (y)) == (BV6), ((x) != (z)) == (BV7), ((y) != (z)) == (BV8)]")
+
+    def test_decompose_num(self):
+
+        ivs = [intvar(1, 9, name=n) for n in "xy"]
+        bv = boolvar(name="bv")
+
+        cons = min(ivs) <= 1
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(BV0) or (BV1), ((x) <= (IV0)) == (BV0), ((y) <= (IV0)) == (BV1), (x) >= (IV0), (y) >= (IV0), IV0 <= 1]")
+        # reified
+        cons = bv.implies(min(ivs) <= 1)
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(bv) -> ((BV2) or (BV3)), ((x) <= (IV1)) == (BV2), ((y) <= (IV1)) == (BV3), (bv) -> ((x) >= (IV1)), (bv) -> ((y) >= (IV1)), (bv) -> (IV1 <= 1)]")
+        cons = (min(ivs) <= 1).implies(bv)
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(and([BV6, BV7, BV8, BV9])) -> (bv), ((BV4) or (BV5)) == (BV6), ((x) <= (IV2)) == (BV4), ((y) <= (IV2)) == (BV5), ((x) >= (IV2)) == (BV7), ((y) >= (IV2)) == (BV8), (IV2 <= 1) == (BV9)]")
+        cons = (min(ivs) <= 1) == (bv)
+        self.assertEqual(str(decompose_global(cons)),
+                         "[(and([BV12, BV13, BV14, BV15])) == (bv), ((BV10) or (BV11)) == (BV12), ((x) <= (IV3)) == (BV10), ((y) <= (IV3)) == (BV11), ((x) >= (IV3)) == (BV13), ((y) >= (IV3)) == (BV14), (IV3 <= 1) == (BV15)]")

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -18,20 +18,36 @@ class TestTransfDecomp(unittest.TestCase):
 
         cons = AllDifferent(ivs)
         self.assertEqual(str(decompose_global(cons)), "[(x) != (y), (x) != (z), (y) != (z)]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"})), str([cons]))
+
         # reified
         cons = bv.implies(AllDifferent(ivs))
         self.assertEqual(str(decompose_global(cons)),
                          "[(bv) -> ((x) != (y)), (bv) -> ((x) != (z)), (bv) -> ((y) != (z))]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"})),
+                         "[(bv) -> ((x) != (y)), (bv) -> ((x) != (z)), (bv) -> ((y) != (z))]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"}, supported_reif={"alldifferent"})),str([cons]))
+
         cons = AllDifferent(ivs).implies(bv)
         self.assertEqual(str(decompose_global(cons)),
                          "[(and([BV0, BV1, BV2])) -> (bv), ((x) != (y)) == (BV0), ((x) != (z)) == (BV1), ((y) != (z)) == (BV2)]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"})),
+                         "[(and([BV3, BV4, BV5])) -> (bv), ((x) != (y)) == (BV3), ((x) != (z)) == (BV4), ((y) != (z)) == (BV5)]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"}, supported_reif={"alldifferent"})),
+                         str([cons]))
+
         cons = AllDifferent(ivs) == (bv)
         self.assertEqual(str(decompose_global(cons)),
-                         "[(and([BV3, BV4, BV5])) == (bv), ((x) != (y)) == (BV3), ((x) != (z)) == (BV4), ((y) != (z)) == (BV5)]")
+                         "[(and([BV6, BV7, BV8])) == (bv), ((x) != (y)) == (BV6), ((x) != (z)) == (BV7), ((y) != (z)) == (BV8)]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"})),
+                         "[(and([BV9, BV10, BV11])) == (bv), ((x) != (y)) == (BV9), ((x) != (z)) == (BV10), ((y) != (z)) == (BV11)]")
+        self.assertEqual(str(decompose_global(cons, supported={"alldifferent"}, supported_reif={"alldifferent"})),
+                         str([cons]))
+
         # tricky one
         cons = AllDifferent(ivs) < (bv)
         self.assertEqual(str(decompose_global(cons)),
-                         "[(BV9) < (bv), (and([BV6, BV7, BV8])) == (BV9), ((x) != (y)) == (BV6), ((x) != (z)) == (BV7), ((y) != (z)) == (BV8)]")
+                         "[(BV15) < (bv), (and([BV12, BV13, BV14])) == (BV15), ((x) != (y)) == (BV12), ((x) != (z)) == (BV13), ((y) != (z)) == (BV14)]")
 
     def test_decompose_num(self):
 

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -80,22 +80,20 @@ class TestTransfReif(unittest.TestCase):
         ivs = intvar(1,9, shape=3, name="ivs")
         rv = boolvar(name="rv")
         arr = cpm_array([0,1,2])
-        
-        # various reify_rewrite cases:
-        cases = [(rv == bvs[0], "[(rv) == (bvs[0])]"),
-                 (rv == all(bvs), "[(and([bvs[0], bvs[1], bvs[2], bvs[3]])) == (rv)]"),
-                 (rv.implies(any(bvs)), "[(rv) -> (or([bvs[0], bvs[1], bvs[2], bvs[3]]))]"),
-                 ((bvs[0].implies(bvs[1])).implies(rv), "[(~rv) -> (bvs[0]), (~rv) -> (~bvs[1])]"),
-                 (rv == AllDifferent(ivs), "[(and([BV0, BV1, BV2])) == (rv), ((ivs[0]) != (ivs[1])) == (BV0), ((ivs[0]) != (ivs[2])) == (BV1), ((ivs[1]) != (ivs[2])) == (BV2)]"),
-                 (rv.implies(AllDifferent(ivs)), "[(rv) -> ((ivs[0]) != (ivs[1])), (rv) -> ((ivs[0]) != (ivs[2])), (rv) -> ((ivs[1]) != (ivs[2]))]"),
-                 (rv == (arr[intvar(-1,3)] != 1), "[((BV6) or (BV7)) == (rv), (IV0 == 0) == (BV6), (IV0 == 2) == (BV7)]"),
-                 (rv == (arr[intvar(0,2)] != 1), "[([0 1 2][IV1]) == (IV2), (IV2 != 1) == (rv)]"),
-                 (rv == (max(ivs) > 5), "[(max(ivs[0],ivs[1],ivs[2])) == (IV4), (IV4 > 5) == (rv)]"),
-                 (rv.implies(min(ivs) != 0), "[(min(ivs[0],ivs[1],ivs[2])) == (IV6), (rv) -> (IV6 != 0)]"),
-                 ((min(ivs) != 0).implies(rv), "[(min(ivs[0],ivs[1],ivs[2])) == (IV8), (IV8 != 0) -> (rv)]"),
-                ]
 
-        # test transformation
-        for (expr, strexpr) in cases:
-            self.assertEqual( str(reify_rewrite(flatten_constraint(expr))), strexpr )
-            self.assertTrue(Model(expr).solve())
+        f = lambda expr : str(reify_rewrite(flatten_constraint(expr)))
+        fd = lambda expr : str(reify_rewrite(decompose_global(flatten_constraint(expr))))
+
+
+        # various reify_rewrite cases:
+        self.assertEqual(f(rv == bvs[0]), "[(rv) == (bvs[0])]")
+        self.assertEqual(f(rv == all(bvs)), "[(and([bvs[0], bvs[1], bvs[2], bvs[3]])) == (rv)]")
+        self.assertEqual(f(rv.implies(any(bvs))), "[(rv) -> (or([bvs[0], bvs[1], bvs[2], bvs[3]]))]")
+        self.assertEqual(f((bvs[0].implies(bvs[1])).implies(rv)), "[(~rv) -> (bvs[0]), (~rv) -> (~bvs[1])]")
+        self.assertRaises(ValueError, lambda : f(rv == AllDifferent(ivs)))
+        self.assertEqual(fd(rv.implies(AllDifferent(ivs))), "[(rv) -> ((ivs[0]) != (ivs[1])), (rv) -> ((ivs[0]) != (ivs[2])), (rv) -> ((ivs[1]) != (ivs[2]))]")
+        self.assertEqual(f(rv == (arr[intvar(-1, 3)] != 1)), "[(and([BV0, BV1, BV2])) == (rv), (IV0 != 1) == (BV0), (IV0 >= 0) == (BV1), (IV0 < 3) == (BV2)]")
+        self.assertEqual(f(rv == (arr[intvar(0, 2)] != 1)), "[([0 1 2][IV1]) == (IV2), (IV2 != 1) == (rv)]")
+        self.assertEqual(f(rv == (max(ivs) > 5)), "[(max(ivs[0],ivs[1],ivs[2])) == (IV3), (IV3 > 5) == (rv)]")
+        self.assertEqual(f(rv.implies(min(ivs) != 0)), "[(min(ivs[0],ivs[1],ivs[2])) == (IV4), (rv) -> (IV4 != 0)]")
+        self.assertEqual(f((min(ivs) != 0).implies(rv)), "[(min(ivs[0],ivs[1],ivs[2])) == (IV5), (IV5 != 0) -> (rv)]")

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 from cpmpy import *
+from cpmpy.transformations.decompose_global import decompose_global
 from cpmpy.transformations.get_variables import get_variables
 from cpmpy.transformations.flatten_model import flatten_constraint
 from cpmpy.transformations.reification import only_bv_implies, reify_rewrite


### PR DESCRIPTION
New transformation to decompose any unsupported global constraints in flat expressions.
Code is functional but can be somewhat compacted I think...

Transformation should be run after flatten() for every solver so we do not have to decompose globals at a later stage.

Work in progress still