### PR TITLE
Add Inverse() global constraint

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -264,6 +264,11 @@ class Inverse(GlobalConstraint):
         fwd, rev = self.args
         return [all(rev[x] == i for i, x in enumerate(fwd))]
 
+    def value(self):
+        fwd = argval(self.args[0])
+        rev = argval(self.args[1])
+        return len(fwd) == len(rev) and all(rev[x] == i for i, x in enumerate(fwd))
+
 class Table(GlobalConstraint):
     """The values of the variables in 'array' correspond to a row in 'table'
     """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -267,7 +267,7 @@ class Inverse(GlobalConstraint):
     def value(self):
         fwd = argval(self.args[0])
         rev = argval(self.args[1])
-        return len(fwd) == len(rev) and all(rev[x] == i for i, x in enumerate(fwd))
+        return all(rev[x] == i for i, x in enumerate(fwd))
 
 class Table(GlobalConstraint):
     """The values of the variables in 'array' correspond to a row in 'table'

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -96,6 +96,7 @@
         AllDifferentExcept0
         AllEqual
         Circuit
+        Inverse
         Table
         Minimum
         Maximum
@@ -245,6 +246,23 @@ class Circuit(GlobalConstraint):
             idx = arr[idx]
 
         return pathlen == len(self.args) and idx == 0
+
+class Inverse(GlobalConstraint):
+    """
+       Inverse (aka channeling / assignment) constraint. 'fwd' and
+       'rev' represent inverse functions; that is,
+
+           fwd[i] == x  <==>  rev[x] == i
+
+    """
+    def __init__(self, fwd, rev):
+        assert len(fwd) == len(rev)
+        super().__init__("inverse", [fwd, rev])
+
+    def decompose(self):
+        from .python_builtins import all
+        fwd, rev = self.args
+        return [all(rev[x] == i for i, x in enumerate(fwd))]
 
 class Table(GlobalConstraint):
     """The values of the variables in 'array' correspond to a row in 'table'

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -416,6 +416,15 @@ class CPM_minizinc(SolverInterface):
             str_tbl += "\n|]"  # closing
             return "table({}, {})".format(str_vars, str_tbl)
 
+        # inverse(fwd, rev): unpack args and work around MiniZinc's default 1-based indexing
+        if expr.name == "inverse":
+            def zero_based(array):
+                return "array1d(0..{}, {})".format(len(array)-1, self._convert_expression(array))
+
+            str_fwd = zero_based(expr.args[0])
+            str_rev = zero_based(expr.args[1])
+            return "inverse({}, {})".format(str_fwd, str_rev)
+
         # count: we need the lhs and rhs together
         if isinstance(expr, Comparison) and expr.args[0].name == 'count':
             name = expr.name

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -446,6 +446,10 @@ class CPM_ortools(SolverInterface):
                 # when posting arcs on diagonal (i==j), it would do subcircuit
                 ort_arcs = [(i,j,self.solver_var(b)) for (i,j),b in np.ndenumerate(arcvars) if i != j]
                 return self.ort_model.AddCircuit(ort_arcs)
+            elif cpm_expr.name == 'inverse':
+                assert len(cpm_expr.args) == 2, "inverse() expects two args: fwd, rev"
+                fwd, rev = self.solver_vars(cpm_expr.args)
+                return self.ort_model.AddInverse(fwd, rev)
             elif cpm_expr.name == 'xor':
                 return self.ort_model.AddBoolXOr(self.solver_vars(cpm_expr.args))
             else:

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -453,7 +453,7 @@ class CPM_ortools(SolverInterface):
             elif cpm_expr.name == 'xor':
                 return self.ort_model.AddBoolXOr(self.solver_vars(cpm_expr.args))
             else:
-                # NOT (YET?) MAPPED: Automaton, ForbiddenAssignments, Inverse?,
+                # NOT (YET?) MAPPED: Automaton, ForbiddenAssignments,
                 #    ReservoirConstraint, ReservoirConstraintWithActive
             
                 # global constraint not known, try posting generic decomposition

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -137,6 +137,9 @@ class TestGlobal(unittest.TestCase):
         self.assertTrue(model.solve())
         self.assertEqual(list(rev.value()), expected_inverse)
 
+        # constraint can be used as value
+        self.assertTrue(inv.value())
+
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -115,6 +115,29 @@ class TestGlobal(unittest.TestCase):
         self.assertTrue(model.solve())
         self.assertTrue(cp.Circuit(x).value())
 
+    def test_inverse(self):
+        # Arrays
+        fwd = cp.intvar(0, 9, shape=10)
+        rev = cp.intvar(0, 9, shape=10)
+
+        # Constraints
+        inv = cp.Inverse(fwd, rev)
+        fix_fwd = (fwd == [9, 4, 7, 2, 1, 3, 8, 6, 0, 5])
+
+        # Inverse of the above
+        expected_inverse = [8, 4, 3, 5, 1, 9, 7, 2, 6, 0]
+
+        # Test decomposed model:
+        model = cp.Model(inv.decompose(), fix_fwd)
+        self.assertTrue(model.solve())
+        self.assertEqual(list(rev.value()), expected_inverse)
+
+        # Not decomposed:
+        model = cp.Model(inv, fix_fwd)
+        self.assertTrue(model.solve())
+        self.assertEqual(list(rev.value()), expected_inverse)
+
+
     def test_table(self):
         iv = cp.intvar(-8,8,3)
 


### PR DESCRIPTION
Adds `Inverse(fwd, rev)`, which constrains the arrays `fwd` and `rev` to be inverse maps. 

- CP-SAT uses native `AddInverse()`
- MiniZinc uses `inverse()`, with a bit of caution around 1-based indexing
- Other solvers use the standard decomposition.

Feedback welcome, thank you for the CPMpy library!