### PR TITLE
Multi dimentional element constraint

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -439,6 +439,11 @@ class Element(GlobalConstraint):
     def __init__(self, arr, idx):
         super().__init__("element", [arr, idx], is_bool=False)
 
+    def __getitem__(self, index):
+        idx = self.args[1]
+        idx = idx*get_bounds(idx)[1] + index
+        return Element(self.args[0], idx)
+
     def value(self):
         arr, idx = self.args
         idxval = argval(idx)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -440,9 +440,7 @@ class Element(GlobalConstraint):
         super().__init__("element", [arr, idx], is_bool=False)
 
     def __getitem__(self, index):
-        idx = self.args[1]
-        idx = idx*get_bounds(idx)[1] + index
-        return Element(self.args[0], idx)
+        raise CPMpyException("For using multiple dimensions in the Element constraint use comma separated indices")
 
     def value(self):
         arr, idx = self.args

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -437,10 +437,11 @@ class Element(GlobalConstraint):
     """
 
     def __init__(self, arr, idx):
+        assert not is_any_list(idx), "For using multiple dimensions in the Element constraint, use comma-separated indices"
         super().__init__("element", [arr, idx], is_bool=False)
 
     def __getitem__(self, index):
-        raise CPMpyException("For using multiple dimensions in the Element constraint use comma separated indices")
+        raise CPMpyException("For using multiple dimensions in the Element constraint use comma-separated indices")
 
     def value(self):
         arr, idx = self.args

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -46,7 +46,6 @@
     Module details
     ==============
 """
-
 from collections.abc import Iterable
 import warnings # for deprecation warning
 import numpy as np
@@ -418,15 +417,17 @@ class NDVarArray(Expression, np.ndarray):
         if isinstance(index, tuple) and \
            any(isinstance(el, Expression) for el in index):
             index_rest = list(index) # mutable view
-            var = [] # collector of variables
+            dim_lengths = list(self.shape)
+            # for calculating the index combining the vars given
+            dim_lengths.append(1)
+            new_index = 0
             for i in range(len(index)):
                 if isinstance(index[i], Expression):
-                    index_rest[i] = Ellipsis # selects all remaining dimensions
-                    var.append(index[i])
-            assert (len(var)==1), "variable indexing (element) only supported with 1 variable at this moment"
-            # single var, so flatten rest array
+                    index_rest[i] = slice(0,dim_lengths[i]) # selects all remaining dimensions
+                    new_index += dim_lengths[i+1]*index[i] #  combine the vars given in one index
+            # using index as single var, so flatten rest array
             array_rest = self[tuple(index_rest)] # non-var array selection
-            return Element(array_rest, var[0])
+            return Element(array_rest, new_index)
 
         ret = super().__getitem__(index)
         # this is a bit ugly,

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -174,7 +174,7 @@ def intvar(lb, ub, shape=1, name=None):
     return NDVarArray(shape, dtype=object, buffer=data)
 
 def cparray(arr):
-    warnings.warn("Deprecated, use boolvar() instead, will be removed in stable version", DeprecationWarning)
+    warnings.warn("Deprecated, use cpm_array() instead, will be removed in stable version", DeprecationWarning)
     return cpm_array(arr)
 def cpm_array(arr):
     """

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -238,7 +238,12 @@ class TestGlobal(unittest.TestCase):
         self.assertTrue(model.solve())
         self.assertTrue(cons.value())
         self.assertEqual(iv.value()[a.value(), b.value()], 8)
-
+        arr = cp.cpm_array([[1, 2, 3], [4, 5, 6]])
+        cons = arr[a,b] == 1
+        model = cp.Model(cons)
+        self.assertTrue(model.solve())
+        self.assertTrue(cons.value())
+        self.assertEqual(arr[a.value(), b.value()], 1)
 
     def test_xor(self):
         bv = cp.boolvar(5)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -227,8 +227,8 @@ class TestGlobal(unittest.TestCase):
         self.assertTrue(cp.Element(iv, idx).value() == 8)
         # test 2-D
         iv = cp.intvar(-8, 8, shape=(3, 3))
-        idx = cp.intvar(-8, 8)
-        idx2 = cp.intvar(-8, 8)
+        idx = cp.intvar(0, 3)
+        idx2 = cp.intvar(0, 3)
         constraints = [iv[idx,idx2] == 8]
         model = cp.Model(constraints)
         self.assertTrue(model.solve())

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -214,25 +214,26 @@ class TestGlobal(unittest.TestCase):
         iv = cp.intvar(-8, 8, 3)
         idx = cp.intvar(-8, 8)
         # test directly the constraint
-        constraints = [cp.Element(iv,idx) == 8]
-        model = cp.Model(constraints)
+        cons = cp.Element(iv,idx) == 8
+        model = cp.Model(cons)
         self.assertTrue(model.solve())
-        self.assertTrue(iv.value()[idx.value()] == 8)
-        self.assertTrue(cp.Element(iv,idx).value() == 8)
+        self.assertTrue(cons.value())
+        self.assertEqual(iv.value()[idx.value()], 8)
         # test through __get_item__
-        constraints = [iv[idx] == 8]
-        model = cp.Model(constraints)
+        cons = iv[idx] == 8
+        model = cp.Model(cons)
         self.assertTrue(model.solve())
-        self.assertTrue(iv.value()[idx.value()] == 8)
-        self.assertTrue(cp.Element(iv, idx).value() == 8)
+        self.assertTrue(cons.value())
+        self.assertEqual(iv.value()[idx.value()], 8)
         # test 2-D
         iv = cp.intvar(-8, 8, shape=(3, 3))
-        idx = cp.intvar(0, 3)
-        idx2 = cp.intvar(0, 3)
-        constraints = [iv[idx,idx2] == 8]
-        model = cp.Model(constraints)
+        a,b = cp.intvar(0, 3, shape=2)
+        cons = iv[a,b] == 8
+        model = cp.Model(cons)
         self.assertTrue(model.solve())
-        self.assertTrue(iv.value()[idx.value(), idx2.value()] == 8)
+        self.assertTrue(cons.value())
+        self.assertEqual(iv.value()[a.value(), b.value()], 8)
+
 
     def test_xor(self):
         bv = cp.boolvar(5)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -210,13 +210,29 @@ class TestGlobal(unittest.TestCase):
         self.assertNotEqual(str(max(iv.value())), '4')
 
     def test_element(self):
+        # test 1-D
         iv = cp.intvar(-8, 8, 3)
         idx = cp.intvar(-8, 8)
+        # test directly the constraint
         constraints = [cp.Element(iv,idx) == 8]
         model = cp.Model(constraints)
         self.assertTrue(model.solve())
         self.assertTrue(iv.value()[idx.value()] == 8)
         self.assertTrue(cp.Element(iv,idx).value() == 8)
+        # test through __get_item__
+        constraints = [iv[idx] == 8]
+        model = cp.Model(constraints)
+        self.assertTrue(model.solve())
+        self.assertTrue(iv.value()[idx.value()] == 8)
+        self.assertTrue(cp.Element(iv, idx).value() == 8)
+        # test 2-D
+        iv = cp.intvar(-8, 8, shape=(3, 3))
+        idx = cp.intvar(-8, 8)
+        idx2 = cp.intvar(-8, 8)
+        constraints = [iv[idx,idx2] == 8]
+        model = cp.Model(constraints)
+        self.assertTrue(model.solve())
+        self.assertTrue(iv.value()[idx.value(), idx2.value()] == 8)
 
     def test_xor(self):
         bv = cp.boolvar(5)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -6,6 +6,7 @@ import cpmpy as cp
 from cpmpy.solvers.pysat import CPM_pysat
 from cpmpy.solvers.z3 import CPM_z3
 from cpmpy.solvers.minizinc import CPM_minizinc
+from cpmpy.solvers.gurobi import CPM_gurobi
 
 from cpmpy.exceptions import MinizincNameException
 
@@ -466,3 +467,32 @@ class TestSolvers(unittest.TestCase):
             if cls.supported():
                 self.assertFalse(m.solve(solver=name))
 
+    @pytest.mark.skipif(not CPM_gurobi.supported(),
+                        reason="Gurobi not installed")
+    def test_gurobi_element(self):
+        # test 1-D
+        iv = cp.intvar(-8, 8, 3)
+        idx = cp.intvar(-8, 8)
+        # test directly the constraint
+        constraints = [cp.Element(iv,idx) == 8]
+        model = cp.Model(constraints)
+        s = cp.SolverLookup.get("gurobi", model)
+        self.assertTrue(s.solve())
+        self.assertTrue(iv.value()[idx.value()] == 8)
+        self.assertTrue(cp.Element(iv,idx).value() == 8)
+        # test through __get_item__
+        constraints = [iv[idx] == 8]
+        model = cp.Model(constraints)
+        s = cp.SolverLookup.get("gurobi", model)
+        self.assertTrue(s.solve())
+        self.assertTrue(iv.value()[idx.value()] == 8)
+        self.assertTrue(cp.Element(iv, idx).value() == 8)
+        # test 2-D
+        iv = cp.intvar(-8, 8, shape=(3, 3))
+        idx = cp.intvar(0, 3)
+        idx2 = cp.intvar(0, 3)
+        constraints = [iv[idx,idx2] == 8]
+        model = cp.Model(constraints)
+        s = cp.SolverLookup.get("gurobi", model)
+        self.assertTrue(s.solve())
+        self.assertTrue(iv.value()[idx.value(), idx2.value()] == 8)


### PR DESCRIPTION
Extended the element constraint to accept multiple dimentions, with multiple vars/expressions instead of only 1.

Basically, in NDVarArray's __getitem__, where the array to be considered is found (based on the constant values in the indices) and flattened, an new index expression is created based on the ones given and the dimentions of the array.

Then, this new expression is given as index to the Element constraint, along with the flattened array.

In addition, if the user writes [x1][x2] instead of [x1,x2], i.e., does not use comma-seperated indexing, an exception is thrown.