### PR TITLE
Adding Isin constraint to specify non-interval domains

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, in_domain, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, InDomain, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Isin, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Isin, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, in_domain, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -435,7 +435,7 @@ class in_domain(GlobalConstraint):
         expr, arr = self.args
         expressions = any(isinstance(a, Expression) for a in arr)
         if expressions:
-            return [any(expr == a for a in arr)]
+            return [any(expr == a for a in arr)], []
         else:
             # find intervals in the domain given:
             arr = sorted(arr)
@@ -455,7 +455,7 @@ class in_domain(GlobalConstraint):
                 cons.extend([expr >= intervals[0][0], expr <= intervals[-1][1]])
             else:
                 cons.append(False)
-            return cons
+            return cons, []
 
     def value(self):
         return argval(self.args[0]) in argval(self.args[1])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -451,8 +451,13 @@ class in_domain(GlobalConstraint):
 
             # create constraints based on the intervals
             # Create a conjunction of disjunctions
-            cons = [(expr <= intervals[i-1][1]) | (expr >= intervals[i][0]) for i in range(1, len(intervals))]
-            cons.extend([expr >= intervals[0][0], expr <= intervals[-1][1]])
+            cons = []
+            if len(intervals) > 0:
+                cons.extend([(expr <= intervals[i-1][1]) | (expr >= intervals[i][0]) for i in range(1, len(intervals))])
+                cons.extend([expr >= intervals[0][0], expr <= intervals[-1][1]])
+            else:
+                cons.append(False)
+                
             return cons
 
     def value(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -339,7 +339,7 @@ class InDomain(GlobalConstraint):
     def __init__(self, expr, arr):
         assert not (is_boolexpr(expr) or any(is_boolexpr(a) for a in arr)), \
             "The expressions in the InDomain constraint should not be boolean"
-        super().__init__("InDomain", [expr, arr], is_bool=True)
+        super().__init__("InDomain", [expr, arr])
 
     def decompose(self):
         """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -420,15 +420,15 @@ class Maximum(GlobalConstraint):
         bnds = [get_bounds(x) for x in self.args]
         return max(lb for lb,ub in bnds), max(ub for lb,ub in bnds)
 
-class in_domain(GlobalConstraint):
+class InDomain(GlobalConstraint):
     """
-        The "in_domain" constraint, defining non-interval domains for an expression
+        The "InDomain" constraint, defining non-interval domains for an expression
     """
 
     def __init__(self, expr, arr):
         assert not (is_boolexpr(expr) or any(is_boolexpr(a) for a in arr)), \
-            "The expressions in the in_domain constraint should not be boolean"
-        super().__init__("in_domain", [expr, arr], is_bool=True)
+            "The expressions in the InDomain constraint should not be boolean"
+        super().__init__("InDomain", [expr, arr], is_bool=True)
 
     def decompose(self):
         from .python_builtins import any

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -433,7 +433,6 @@ class in_domain(GlobalConstraint):
     def decompose(self):
         from .python_builtins import any
         expr, arr = self.args
-        lb, ub = expr.get_bounds()
         expressions = any(isinstance(a, Expression) for a in arr)
         if expressions:
             return [any(expr == a for a in arr)]
@@ -448,7 +447,6 @@ class in_domain(GlobalConstraint):
                 if i == len(arr) - 1 or arr[i + 1] != arr[i] + 1:
                     end = arr[i]
                     intervals.append((start, end))
-
             # create constraints based on the intervals
             # Create a conjunction of disjunctions
             cons = []
@@ -457,7 +455,6 @@ class in_domain(GlobalConstraint):
                 cons.extend([expr >= intervals[0][0], expr <= intervals[-1][1]])
             else:
                 cons.append(False)
-                
             return cons
 
     def value(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -430,14 +430,10 @@ class Isin(GlobalConstraint):
     def decompose(self):
         cons =[]
         lb, ub = self.expr.get_bounds()
-        #alb, aub = [self.arr.min(), self.arr.max()]
-
         for i in range(lb,ub+1):
             if i not in self.arr:
                 cons.append(self.expr != i)
-
         return cons
-
 
     def value(self):
         return argval(self.expr) in self.arr

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -433,15 +433,12 @@ class in_domain(GlobalConstraint):
     def decompose(self):
         from .python_builtins import any
         expr, arr = self.args
-        # separate expressions and non-expressions in the domain given
-        expressions = [a for a in arr if isinstance(a, Expression)]
-        nonExpressions = [a for a in arr if a not in expressions]
-        # create constraints for the expressions in the domain
-        cons = [any(expr == a for a in expressions)]
-        # create constraints for the non-expressions in the domain
         lb, ub = expr.get_bounds()
-        cons.extend([expr != val for val in range(lb, ub + 1) if val not in nonExpressions])
-        return cons
+        expressions = any(isinstance(a, Expression) for a in arr)
+        if expressions:
+            return [any(expr == a for a in arr)]
+        else:
+            return [expr != val for val in range(lb, ub + 1) if val not in arr]
 
     def value(self):
         return argval(self.args[0]) in argval(self.args[1])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -428,7 +428,6 @@ class in_domain(GlobalConstraint):
     def __init__(self, expr, arr):
         assert not (is_boolexpr(expr) or any(is_boolexpr(a) for a in arr)), \
             "The expressions in the in_domain constraint should not be boolean"
-        assert len(arr) > 1, "The array given must contain more than 1 elements"
         super().__init__("in_domain", [expr, arr], is_bool=True)
 
     def decompose(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -417,16 +417,16 @@ class Maximum(GlobalConstraint):
         bnds = [get_bounds(x) for x in self.args]
         return max(lb for lb,ub in bnds), max(ub for lb,ub in bnds)
 
-class Isin(GlobalConstraint):
+class in_domain(GlobalConstraint):
     """
-        The "isin" constraint, defining non-interval domains for an expression
+        The "in_domain" constraint, defining non-interval domains for an expression
     """
 
     def __init__(self, expr, arr):
         assert not (is_boolexpr(expr) or any(is_boolexpr(a) for a in arr)), \
-            "The expressions in the Isin constraint should not be boolean"
+            "The expressions in the in_domain constraint should not be boolean"
         assert len(arr) > 1, "The array given must contain more than 1 elements"
-        super().__init__("isin", [expr, arr], is_bool=True)
+        super().__init__("in_domain", [expr, arr], is_bool=True)
 
     def decompose(self):
         expr, arr = self.args

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -438,7 +438,22 @@ class in_domain(GlobalConstraint):
         if expressions:
             return [any(expr == a for a in arr)]
         else:
-            return [expr != val for val in range(lb, ub + 1) if val not in arr]
+            # find intervals in the domain given:
+            arr = sorted(arr)
+            intervals = []
+            start = None
+            for i in range(len(arr)):
+                if i == 0 or arr[i] != arr[i - 1] + 1:
+                    start = arr[i]
+                if i == len(arr) - 1 or arr[i + 1] != arr[i] + 1:
+                    end = arr[i]
+                    intervals.append((start, end))
+
+            # create constraints based on the intervals
+            # Create a conjunction of disjunctions
+            cons = [(expr <= intervals[i-1][1]) | (expr >= intervals[i][0]) for i in range(1, len(intervals))]
+            cons.extend([expr >= intervals[0][0], expr <= intervals[-1][1]])
+            return cons
 
     def value(self):
         return argval(self.args[0]) in argval(self.args[1])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -430,13 +430,21 @@ class Isin(GlobalConstraint):
     def decompose(self):
         cons =[]
         lb, ub = self.expr.get_bounds()
-        for i in range(lb,ub+1):
-            if i not in self.arr:
-                cons.append(self.expr != i)
+
+        expressions = all(isinstance(a, Expression) for a in self.arr)
+        if expressions:
+            from .python_builtins import any
+            print(self.arr)
+            cons = [any(self.expr == a for a in self.arr)]
+        else:
+            for i in range(lb,ub+1):
+                if i not in self.arr:
+                    cons.append(self.expr != i)
+
         return cons
 
     def value(self):
-        return argval(self.expr) in self.arr
+        return argval(self.expr) in argval(self.arr)
 
     def __repr__(self):
         if len(self.args) == 2:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -417,6 +417,37 @@ class Maximum(GlobalConstraint):
         bnds = [get_bounds(x) for x in self.args]
         return max(lb for lb,ub in bnds), max(ub for lb,ub in bnds)
 
+class Isin(GlobalConstraint):
+    """
+        The "isin" constraint, defining non-interval domains for an expression
+    """
+
+    def __init__(self, expr, arr):
+        self.expr = expr
+        self.arr = arr
+        super().__init__("isin", [expr, arr], is_bool=True)
+
+    def decompose(self):
+        from .python_builtins import any
+        cons =[]
+        lb, ub = self.expr.get_bounds()
+        #alb, aub = [self.arr.min(), self.arr.max()]
+
+        for i in range(lb,ub+1):
+            if i not in self.arr:
+                cons.append(self.expr != i)
+
+        return cons
+
+
+    def value(self):
+        return argval(self.expr) in self.arr
+
+    def __repr__(self):
+        if len(self.args) == 2:
+            return "{} xor {}".format(*self.args)
+        return "xor({})".format(self.args)
+
 
 def element(arg_list):
     warnings.warn("Deprecated, use Element(arr,idx) instead, will be removed in stable version", DeprecationWarning)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -433,29 +433,14 @@ class InDomain(GlobalConstraint):
     def decompose(self):
         from .python_builtins import any
         expr, arr = self.args
+        lb, ub = expr.get_bounds()
         expressions = any(isinstance(a, Expression) for a in arr)
         if expressions:
             return [any(expr == a for a in arr)], []
         else:
             # find intervals in the domain given:
-            arr = sorted(arr)
-            intervals = []
-            start = None
-            for i in range(len(arr)):
-                if i == 0 or arr[i] != arr[i - 1] + 1:
-                    start = arr[i]
-                if i == len(arr) - 1 or arr[i + 1] != arr[i] + 1:
-                    end = arr[i]
-                    intervals.append((start, end))
-            # create constraints based on the intervals
-            # Create a conjunction of disjunctions
-            cons = []
-            if len(intervals) > 0:
-                cons.extend([(expr <= intervals[i-1][1]) | (expr >= intervals[i][0]) for i in range(1, len(intervals))])
-                cons.extend([expr >= intervals[0][0], expr <= intervals[-1][1]])
-            else:
-                cons.append(False)
-            return cons, []
+            return [expr != val for val in range(lb, ub + 1) if val not in arr]
+
 
     def value(self):
         return argval(self.args[0]) in argval(self.args[1])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -428,7 +428,6 @@ class Isin(GlobalConstraint):
         super().__init__("isin", [expr, arr], is_bool=True)
 
     def decompose(self):
-        from .python_builtins import any
         cons =[]
         lb, ub = self.expr.get_bounds()
         #alb, aub = [self.arr.min(), self.arr.max()]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -447,9 +447,7 @@ class Isin(GlobalConstraint):
         return argval(self.expr) in argval(self.arr)
 
     def __repr__(self):
-        if len(self.args) == 2:
-            return "{} xor {}".format(*self.args)
-        return "xor({})".format(self.args)
+        return "{} in {}".format(self.expr, self.arr)
 
 
 def element(arg_list):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -434,7 +434,6 @@ class Isin(GlobalConstraint):
         expressions = all(isinstance(a, Expression) for a in self.arr)
         if expressions:
             from .python_builtins import any
-            print(self.arr)
             cons = [any(self.expr == a for a in self.arr)]
         else:
             for i in range(lb,ub+1):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -158,15 +158,15 @@ class TestGlobal(unittest.TestCase):
         # constraint can be used as value
         self.assertTrue(inv.value())
 
-    def test_isin(self):
+    def test_in_domain(self):
         iv = cp.intvar(-8, 8)
         iv_arr = cp.intvar(-8, 8, shape=5)
-        constraints = [cp.Isin(iv, iv_arr)]
+        constraints = [cp.in_domain(iv, iv_arr)]
         model = cp.Model(constraints)
         assert model.solve() == True
         assert iv.value() in iv_arr.value()
         vals = [1, 5, 8, -4]
-        constraints = [cp.Isin(iv, vals)]
+        constraints = [cp.in_domain(iv, vals)]
         model = cp.Model(constraints)
         assert model.solve() == True
         assert iv.value() in vals

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -168,20 +168,20 @@ class TestGlobal(unittest.TestCase):
         iv_arr = cp.intvar(-8, 8, shape=5)
         cons = [cp.in_domain(iv, iv_arr)]
         model = cp.Model(cons)
-        assert model.solve() == True
-        assert iv.value() in iv_arr.value()
+        self.assertTrue(model.solve())
+        self.assertIn(iv.value(), iv_arr.value())
         vals = [1, 5, 8, -4]
         cons = [cp.in_domain(iv, vals)]
         model = cp.Model(cons)
-        assert model.solve() == True
-        assert iv.value() in vals
+        self.assertTrue(model.solve())
+        self.assertIn(iv.value(), vals)
         cons = [cp.in_domain(iv, [])]
         model = cp.Model(cons)
-        assert model.solve() == False
+        self.assertFalse(model.solve())
         cons = [cp.in_domain(iv, [1])]
         model = cp.Model(cons)
-        assert model.solve() == True
-        assert iv.value() in [1]
+        self.assertTrue(model.solve())
+        self.assertEqual(iv.value(),1)
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -182,6 +182,9 @@ class TestGlobal(unittest.TestCase):
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         self.assertEqual(iv.value(),1)
+        cons = cp.in_domain(min(iv_arr), vals)
+        model = cp.Model(cons)
+        self.assertTrue(model.solve())
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -166,15 +166,22 @@ class TestGlobal(unittest.TestCase):
     def test_in_domain(self):
         iv = cp.intvar(-8, 8)
         iv_arr = cp.intvar(-8, 8, shape=5)
-        constraints = [cp.in_domain(iv, iv_arr)]
-        model = cp.Model(constraints)
+        cons = [cp.in_domain(iv, iv_arr)]
+        model = cp.Model(cons)
         assert model.solve() == True
         assert iv.value() in iv_arr.value()
         vals = [1, 5, 8, -4]
-        constraints = [cp.in_domain(iv, vals)]
-        model = cp.Model(constraints)
+        cons = [cp.in_domain(iv, vals)]
+        model = cp.Model(cons)
         assert model.solve() == True
         assert iv.value() in vals
+        cons = [cp.in_domain(iv, [])]
+        model = cp.Model(cons)
+        assert model.solve() == False
+        cons = [cp.in_domain(iv, [1])]
+        model = cp.Model(cons)
+        assert model.solve() == True
+        assert iv.value() in [1]
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -180,31 +180,31 @@ class TestGlobal(unittest.TestCase):
         # constraint can be used as value
         self.assertTrue(inv.value())
 
-    def test_in_domain(self):
+    def test_InDomain(self):
         iv = cp.intvar(-8, 8)
         iv_arr = cp.intvar(-8, 8, shape=5)
-        cons = [cp.in_domain(iv, iv_arr)]
+        cons = [cp.InDomain(iv, iv_arr)]
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         self.assertIn(iv.value(), iv_arr.value())
         vals = [1, 5, 8, -4]
-        cons = [cp.in_domain(iv, vals)]
+        cons = [cp.InDomain(iv, vals)]
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         self.assertIn(iv.value(), vals)
-        cons = [cp.in_domain(iv, [])]
+        cons = [cp.InDomain(iv, [])]
         model = cp.Model(cons)
         self.assertFalse(model.solve())
-        cons = [cp.in_domain(iv, [1])]
+        cons = [cp.InDomain(iv, [1])]
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         self.assertEqual(iv.value(),1)
-        cons = cp.in_domain(min(iv_arr), vals)
+        cons = cp.InDomain(min(iv_arr), vals)
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         iv2 = cp.intvar(-8, 8)
         vals = [1, 5, 8, -4, iv2]
-        cons = [cp.in_domain(iv, vals)]
+        cons = [cp.InDomain(iv, vals)]
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         self.assertIn(iv.value(), vals)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -158,6 +158,18 @@ class TestGlobal(unittest.TestCase):
         # constraint can be used as value
         self.assertTrue(inv.value())
 
+    def test_isin(self):
+        iv = cp.intvar(-8, 8)
+        iv_arr = cp.intvar(-8, 8, shape=5)
+        constraints = [cp.Isin(iv, iv_arr)]
+        model = cp.Model(constraints)
+        assert model.solve() == True
+        assert iv.value() in iv_arr.value()
+        vals = [1, 5, 8, -4]
+        constraints = [cp.Isin(iv, vals)]
+        model = cp.Model(constraints)
+        assert model.solve() == True
+        assert iv.value() in vals
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -185,6 +185,12 @@ class TestGlobal(unittest.TestCase):
         cons = cp.in_domain(min(iv_arr), vals)
         model = cp.Model(cons)
         self.assertTrue(model.solve())
+        iv2 = cp.intvar(-8, 8)
+        vals = [1, 5, 8, -4, iv2]
+        cons = [cp.in_domain(iv, vals)]
+        model = cp.Model(cons)
+        self.assertTrue(model.solve())
+        self.assertIn(iv.value(), vals)
 
     def test_table(self):
         iv = cp.intvar(-8,8,3)


### PR DESCRIPTION
Adding Isin constraint to specify non-interval domains. Open to different names for the constraint (e.g. in_domain).

syntax: Isin(expr, array)

The decompose() method takes one by one the values in the domain of the expression given, and adds a constraint expr != val if val not in array.

This leads to a conjuction of != constraints.

An alternative would be to add a disjuntion of "=" constraints for the values in the array. This could be done by replacing the decompose function with the following:
```
    def decompose(self):
        from .python_builtins import any
        return [any(self.expr == i for i in self.arr)]
```

However, based on a discussion in-person with @JoD, we thought that this would not be efficient, and preferred to use the "!=" constraints, leading also to more efficient linearization.

I tried also to overload the built in "in", but this was not possible even if we overload __contains__, as "in" always has to return a bool (True or False) and cannot return an expression.
