### PR TITLE
Improving global constraints

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount, GlobalCardinality, DirectConstraint
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount, GlobalCardinality, DirectConstraint
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -594,7 +594,7 @@ class GlobalCardinalityCount(GlobalConstraint):
     """
 
     def __init__(self, vars, vals, occ):
-        super().__init__("gc", [vars,vals,occ])
+        super().__init__("gcc", [vars,vals,occ])
 
     def decompose(self):
         vars, vals, occ = self.args

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -589,26 +589,7 @@ class Cumulative(GlobalConstraint):
 
 class GlobalCardinalityCount(GlobalConstraint):
     """
-        GlobalCardinalityCount(a,gcc): Collect the number of occurrences of each value 0..a.ub in gcc.
-    The array gcc must have elements 0..ub (so of size ub+1).
-        """
-
-    def __init__(self, a, gcc):
-        ub = max([get_bounds(v)[1] for v in a])
-        assert (len(gcc) == ub + 1), f"GCC: length of gcc variables {len(gcc)} must be ub+1 {ub + 1}"
-        super().__init__("gcc", [a,gcc])
-
-    def decompose(self):
-        a, gcc = self.args
-        return [Count(a, i) == v for i, v in enumerate(gcc)]
-
-    def value(self):
-        from .python_builtins import all
-        return all(self.decompose()).value()
-
-class GlobalCardinality(GlobalConstraint):
-    """
-    GlobalCardinality(vars,vals,occ): The number of occurrences of each value vals[i] in the list of variables
+    GlobalCardinalityCount(vars,vals,occ): The number of occurrences of each value vals[i] in the list of variables
     must be equal to occ[i].
     """
 
@@ -622,6 +603,7 @@ class GlobalCardinality(GlobalConstraint):
     def value(self):
         from .python_builtins import all
         return all(self.decompose()).value()
+
 
 class Count(GlobalConstraint):
     """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -279,8 +279,13 @@ class Circuit(GlobalConstraint):
         should return something in negated normal form, since flatten_model.negated_normal() returns this
         '''
         from .python_builtins import all
-        decomp = self.decompose()
-        return [~all(decomp[:2])] + decomp[3:]
+        succ = cpm_array(self.args)
+        n = len(succ)
+        order = intvar(0,n-1, shape=n)
+        return [
+            (~AllDifferent(succ) | ~AllDifferent(order)), # negated condition on successors or orders
+            # assignemt to auxiliary variables should hold
+            order[0] == succ[0]] + [order[i] == succ[order[i-1]] for i in range(1,n)]
 
 class Inverse(GlobalConstraint):
     """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -274,18 +274,8 @@ class Circuit(GlobalConstraint):
         should return something in negated normal form, since flatten_model.negated_normal() returns this
         '''
         from .python_builtins import all
-        succ = cpm_array(self.args)
-        n = len(succ)
-        order = intvar(0, n - 1, shape=n)
-        return [~all([AllDifferent(succ),
-                # different orders
-                AllDifferent(order)
-                    ]),
-                # not negating following constraints since they involve the auxiliary variables
-                # loop: first one is successor of '0'
-                order[0] == succ[0]
-                ] + [order[i] == succ[order[i - 1]] for i in range(1, n)]
-
+        decomp = self.decompose()
+        return [~all(decomp[:2])] + decomp[3:]
 
 class Inverse(GlobalConstraint):
     """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -190,6 +190,7 @@ class AllDifferentExcept0(GlobalConstraint):
         super().__init__("alldifferent_except0", flatlist(args))
 
     def decompose(self):
+        # equivalent to (var1 == 0) | (var2 == 0) | (var1 != var2)
         return [(var1 == var2).implies(var1 == 0) for var1, var2 in all_pairs(self.args)]
 
     def value(self):
@@ -209,6 +210,7 @@ class AllEqual(GlobalConstraint):
     def decompose(self):
         """Returns the decomposition
         """
+        # arg0 == arg1, arg1 == arg2, arg2 == arg3... no need to post n^2 equalities
         return [var1 == var2 for var1, var2 in zip(self.args[:-1], self.args[1:])]
 
     def value(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -606,6 +606,22 @@ class GlobalCardinalityCount(GlobalConstraint):
         from .python_builtins import all
         return all(self.decompose()).value()
 
+class GlobalCardinality(GlobalConstraint):
+    """
+    GlobalCardinality(vars,vals,occ): The number of occurrences of each value vals[i] in the list of variables
+    must be equal to occ[i].
+    """
+
+    def __init__(self, vars, vals, occ):
+        super().__init__("gc", [vars,vals,occ])
+
+    def decompose(self):
+        vars, vals, occ = self.args
+        return [Count(vars, i) == v for i, v in zip(vals, occ)]
+
+    def value(self):
+        from .python_builtins import all
+        return all(self.decompose()).value()
 
 class Count(GlobalConstraint):
     """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -190,7 +190,7 @@ class AllDifferentExcept0(GlobalConstraint):
         super().__init__("alldifferent_except0", flatlist(args))
 
     def decompose(self):
-        return [((var1 != 0) & (var2 != 0)).implies(var1 != var2) for var1, var2 in all_pairs(self.args)]
+        return [(var1 == var2).implies(var1 == 0) for var1, var2 in all_pairs(self.args)]
 
     def value(self):
         vals = [a.value() for a in self.args if a.value() != 0]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -209,7 +209,7 @@ class AllEqual(GlobalConstraint):
     def decompose(self):
         """Returns the decomposition
         """
-        return [var1 == var2 for var1, var2 in all_pairs(self.args)]
+        return [var1 == var2 for var1, var2 in zip(self.args[:-1], self.args[1:])]
 
     def value(self):
         return len(set(a.value() for a in self.args)) == 1

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -579,7 +579,7 @@ class Cumulative(GlobalConstraint):
 
 class GlobalCardinalityCount(GlobalConstraint):
     """
-    GlobalCardinalityCount(vars,vals,occ): The number of occurrences of each value vals[i] in the list of variables
+    GlobalCardinalityCount(vars,vals,occ): The number of occurrences of each value vals[i] in the list of variables vars
     must be equal to occ[i].
     """
 

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -540,12 +540,11 @@ class CPM_minizinc(SolverInterface):
                                                         self._convert_expression(fal))
 
         elif expr.name == "gcc":
-            a, gcc = expr.args
-            cover = [x for x in range(len(gcc))]
-            a = self._convert_expression(a)
-            gcc = self._convert_expression(gcc)
-            cover = self._convert_expression(cover)
-            return "global_cardinality_closed({},{},{})".format(a,cover,gcc)
+            vars, vals, occ = expr.args
+            vars = self._convert_expression(vars)
+            vals = self._convert_expression(vals)
+            occ = self._convert_expression(occ)
+            return "global_cardinality({},{},{})".format(vars,vals,occ)
 
         # a direct constraint, treat differently for MiniZinc, a text-based language
         # use the name as, unpack the arguments from the argument tuple

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -326,7 +326,7 @@ class CPM_ortools(SolverInterface):
         :return: list of Expression
         """
         cpm_cons = flatten_constraint(cpm_expr)  # flat normal form
-        cpm_cons = decompose_global(cpm_cons, supported={"min","max","element","alldifferent","xor","table", "cumulative","circuit"})
+        cpm_cons = decompose_global(cpm_cons, supported={"min","max","element","alldifferent","xor","table","cumulative","circuit","inverse"})
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=
         cpm_cons = only_bv_implies(cpm_cons) # everything that can create

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -309,37 +309,38 @@ class TestGlobal(unittest.TestCase):
         self.assertFalse(cp.Model(constraints).solve())
 
     def test_global_cardinality_count(self):
-        iv = cp.intvar(-8, 8, shape=3)
-        gcc = cp.intvar(0, 10, shape=iv[0].ub + 1)
-        self.assertTrue(cp.Model([cp.GlobalCardinalityCount(iv, gcc), iv == [5,5,4]]).solve())
-        self.assertEqual( str(gcc.value()), '[0 0 0 0 1 2 0 0 0]')
-        self.assertTrue(cp.GlobalCardinalityCount(iv, gcc).value())
-
-        self.assertTrue(cp.Model([cp.GlobalCardinalityCount(iv, gcc).decompose(), iv == [5, 5, 4]]).solve())
-        self.assertEqual(str(gcc.value()), '[0 0 0 0 1 2 0 0 0]')
-        self.assertTrue(cp.GlobalCardinalityCount(iv, gcc).value())
-
-        self.assertTrue(cp.GlobalCardinalityCount([iv[0],iv[2],iv[1]], gcc).value())
-
-    def test_not_global_cardinality_count(self):
-        iv = cp.intvar(-8, 8, shape=3)
-        gcc = cp.intvar(0, 10, shape=iv[0].ub + 1)
-        self.assertTrue(cp.Model([~cp.GlobalCardinalityCount(iv, gcc), iv == [5, 5, 4]]).solve())
-        self.assertNotEqual(str(gcc.value()), '[0 0 0 0 1 2 0 0 0]')
-        self.assertFalse(cp.GlobalCardinalityCount(iv, gcc).value())
-
-        self.assertFalse(cp.Model([~cp.GlobalCardinalityCount(iv, gcc), iv == [5, 5, 4],
-                                   gcc == [0, 0, 0, 0, 1, 2, 0, 0, 0]]).solve())
+        iv = cp.intvar(-8, 8, shape=5)
+        val = cp.intvar(-3, 3, shape=3)
+        occ = cp.intvar(0, len(iv), shape=3)
+        self.assertTrue(cp.Model([cp.GlobalCardinalityCount(iv, val, occ), cp.AllDifferent(val)]).solve())
+        self.assertTrue(cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertTrue(all(cp.Count(iv, val[i]).value() == occ[i].value() for i in range(len(val))))
+        val = [1, 4, 5]
+        self.assertTrue(cp.Model([cp.GlobalCardinalityCount(iv, val, occ)]).solve())
+        self.assertTrue(cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertTrue(all(cp.Count(iv, val[i]).value() == occ[i].value() for i in range(len(val))))
+        occ = [2, 3, 0]
+        self.assertTrue(cp.Model([cp.GlobalCardinalityCount(iv, val, occ)]).solve())
+        self.assertTrue(cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertTrue(all(cp.Count(iv, val[i]).value() == occ[i] for i in range(len(val))))
+        self.assertTrue(cp.GlobalCardinalityCount([iv[0],iv[2],iv[1],iv[4],iv[3]], val, occ).value())
 
     def test_not_global_cardinality_count(self):
-        iv = cp.intvar(-8, 8, shape=3)
-        gcc = cp.intvar(0, 10, shape=iv[0].ub + 1)
-        self.assertTrue(cp.Model([~cp.GlobalCardinalityCount(iv, gcc), iv == [5, 5, 4]]).solve())
-        self.assertNotEqual(str(gcc.value()), '[0 0 0 0 1 2 0 0 0]')
-        self.assertFalse(cp.GlobalCardinalityCount(iv, gcc).value())
-
-        self.assertFalse(cp.Model([~cp.GlobalCardinalityCount(iv, gcc), iv == [5, 5, 4],
-                                   gcc == [0, 0, 0, 0, 1, 2, 0, 0, 0]]).solve())
+        iv = cp.intvar(-8, 8, shape=5)
+        val = cp.intvar(-3, 3, shape=3)
+        occ = cp.intvar(0, len(iv), shape=3)
+        self.assertTrue(cp.Model([~cp.GlobalCardinalityCount(iv, val, occ), cp.AllDifferent(val)]).solve())
+        self.assertTrue(~cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertFalse(all(cp.Count(iv, val[i]).value() == occ[i].value() for i in range(len(val))))
+        val = [1, 4, 5]
+        self.assertTrue(cp.Model([~cp.GlobalCardinalityCount(iv, val, occ)]).solve())
+        self.assertTrue(~cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertFalse(all(cp.Count(iv, val[i]).value() == occ[i].value() for i in range(len(val))))
+        occ = [2, 3, 0]
+        self.assertTrue(cp.Model([~cp.GlobalCardinalityCount(iv, val, occ)]).solve())
+        self.assertTrue(~cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertFalse(all(cp.Count(iv, val[i]).value() == occ[i] for i in range(len(val))))
+        self.assertTrue(~cp.GlobalCardinalityCount([iv[0],iv[2],iv[1],iv[4],iv[3]], val, occ).value())
 
     def test_count(self):
         iv = cp.intvar(-8, 8, shape=3)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -404,6 +404,27 @@ class TestSolvers(unittest.TestCase):
         self.assertTrue(solver.solve())
         self.assertEqual(list(rev.value()), expected_inverse)
 
+    @pytest.mark.skipif(not CPM_minizinc.supported(),
+                        reason="MiniZinc not installed")
+    def test_minizinc_gcc(self):
+        from cpmpy.solvers.minizinc import CPM_minizinc
+
+        iv = cp.intvar(-8, 8, shape=5)
+        occ = cp.intvar(0, len(iv), shape=3)
+        val = [1, 4, 5]
+        model = cp.Model([cp.GlobalCardinalityCount(iv, val, occ)])
+        solver = CPM_minizinc(model)
+        self.assertTrue(solver.solve())
+        self.assertTrue(cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertTrue(all(cp.Count(iv, val[i]).value() == occ[i].value() for i in range(len(val))))
+        occ = [2, 3, 0]
+        model = cp.Model([cp.GlobalCardinalityCount(iv, val, occ), cp.AllDifferent(val)])
+        solver = CPM_minizinc(model)
+        self.assertTrue(solver.solve())
+        self.assertTrue(cp.GlobalCardinalityCount(iv, val, occ).value())
+        self.assertTrue(all(cp.Count(iv, val[i]).value() == occ[i] for i in range(len(val))))
+        self.assertTrue(cp.GlobalCardinalityCount([iv[0],iv[2],iv[1],iv[4],iv[3]], val, occ).value())
+
     @pytest.mark.skipif(not CPM_z3.supported(),
                         reason="Z3 not installed")
     def test_z3(self):


### PR DESCRIPTION
Based on the discussion in #256, changed the global cardinality constraint (GlobalCardinalityCount()) to make it more general.

Specifically,  in the previous version the user had to define the exact amount of times all values appear, and could not define it only for a subset of them.

The new GlobalCardinalityCount() of this PR is in align with http://sofdem.github.io/gccat/gccat/Cglobal_cardinality.html and also with what minizinc has https://www.minizinc.org/doc-2.5.5/en/lib-globals.html. In addition, the new version complies with hakan's description in http://www.hakank.org/bprolog/global_cardinality.pl

I also checked in all the examples, if we used anywhere the GlobalCardinalityCount constraint, in order to change to the new syntax, but did not find any case.