### PR TITLE
simplify output for get or make var in specific circumstances

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -338,8 +338,7 @@ def get_or_make_var(expr):
 
         if isinstance(flatexpr,_BoolVarImpl):
             #avoids unnecessary bv == bv or bv == ~bv assignments
-            #return flatexpr,flatcons
-            pass
+            return flatexpr,flatcons
         bvar = _BoolVarImpl()
         return (bvar, [flatexpr == bvar]+flatcons)
 

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -336,6 +336,10 @@ def get_or_make_var(expr):
         # normalize expr into a boolexpr LHS, reify LHS == bvar
         (flatexpr, flatcons) = normalized_boolexpr(expr)
 
+        if isinstance(flatexpr,_BoolVarImpl):
+            #avoids unnecessary bv == bv or bv == ~bv assignments
+            #return flatexpr,flatcons
+            pass
         bvar = _BoolVarImpl()
         return (bvar, [flatexpr == bvar]+flatcons)
 

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -115,6 +115,8 @@ class TestFlattenExpr(unittest.TestCase):
         self.assertEqual( str(get_or_make_var( (a > 10) )), "(BV26, [(IV0 > 10) == (BV26)])" )
         self.assertEqual( str(get_or_make_var( (a > 10)&x&y )), "(BV28, [(and([BV27, BV0, BV1])) == (BV28), (IV0 > 10) == (BV27)])" )
 
+        self.assertEqual( str(get_or_make_var(Operator('not',[x]) == y) ), '(BV29, [((~BV0) == (BV1)) == (BV29)])' )
+
     def test_get_or_make_var__num(self):
         (a,b,c,d,e) = self.ivars[:5]
 

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -217,3 +217,5 @@ class TestFlattenExpr(unittest.TestCase):
 
         # != in boolexpr, bug #170
         self.assertEqual( str(normalized_boolexpr(x != (a == 1))), "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])" )
+        #simplify output
+        self.assertEqual( str(normalized_boolexpr(Operator('not',[x]) == y)), "((~BV0) == (BV1), [])" )

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -115,7 +115,7 @@ class TestFlattenExpr(unittest.TestCase):
         self.assertEqual( str(get_or_make_var( (a > 10) )), "(BV26, [(IV0 > 10) == (BV26)])" )
         self.assertEqual( str(get_or_make_var( (a > 10)&x&y )), "(BV28, [(and([BV27, BV0, BV1])) == (BV28), (IV0 > 10) == (BV27)])" )
 
-        self.assertEqual( str(get_or_make_var(Operator('not',[x]) == y) ), '(BV29, [((~BV0) == (BV1)) == (BV29)])' )
+        self.assertEqual( str(get_or_make_var(Operator('not', [x]) == y)), '(BV29, [((~BV0) == (BV1)) == (BV29)])' )
 
     def test_get_or_make_var__num(self):
         (a,b,c,d,e) = self.ivars[:5]


### PR DESCRIPTION
I think this is a case that only started existing since the introduction of our not-operator, but the output of get_or_make_var can be reduced.

```python
get_or_make_var(Operator('not',[x]) == y)  : 
(BV4, [((BV3) == (y)) == (BV4), (~x) == (BV3)])
can be reduced to 
(BV3, [((~x) == (y)) == (BV3)])
```

Maybe we will have to wait for our push down negation transformation to see if this case will occur