### PR TITLE
solver interfaces: make add directly call transform, simpler and more explicit

### DIFF
--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -250,7 +250,6 @@ class CPM_gurobi(SolverInterface):
         raise NotImplementedError("gurobi: Not a known supported numexpr {}".format(cpm_expr))
 
 
-    # `__add__()` from the superclass first calls `transform()` then `_post_constraint()`, just implement the latter
     def transform(self, cpm_expr):
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
@@ -276,19 +275,31 @@ class CPM_gurobi(SolverInterface):
         cpm_cons = only_positive_bv(cpm_cons)  # after linearization, rewrite ~bv into 1-bv
         return cpm_cons
 
-    def _post_constraint(self, cpm_expr):
-        """
-            Post a supported CPMpy constraint directly to the underlying solver's API
+    def __add__(self, cpm_expr_orig):
+      """
+            Eagerly add a constraint to the underlying solver.
 
-            What 'supported' means depends on the solver capabilities, and in effect on what transformations
-            are applied in `transform()`.
+            Any CPMpy expression given is immediately transformed (throught `transform()`)
+            and then posted to the solver in this function.
 
-            Solvers can raise 'NotImplementedError' for any constraint not supported after transformation
-        """
-        from gurobipy import GRB
-        # True or False
-        if isinstance(cpm_expr, BoolVal):
-            return self.grb_model.addConstr(cpm_expr.args[0])
+            This can raise 'NotImplementedError' for any constraint not supported after transformation
+
+            The variables used in expressions given to add are stored as 'user variables'. Those are the only ones
+            the user knows and cares about (and will be populated with a value after solve). All other variables
+            are auxiliary variables created by transformations.
+
+        :param cpm_expr: CPMpy expression, or list thereof
+        :type cpm_expr: Expression or list of Expression
+
+        :return: self
+      """
+      from gurobipy import GRB
+
+      # add new user vars to the set
+      get_variables(cpm_expr_orig, collect=self.user_vars)
+
+      # transform and post the constraints
+      for cpm_expr in self.transform(cpm_expr_orig):
 
         # Comparisons: only numeric ones as 'only_bv_implies()' has removed the '==' reification for Boolean expressions
         # numexpr `comp` bvar|const
@@ -299,45 +310,49 @@ class CPM_gurobi(SolverInterface):
             # Thanks to `only_numexpr_equality()` only supported comparisons should remain
             if cpm_expr.name == '<=':
                 grblhs = self._make_numexpr(lhs)
-                return self.grb_model.addLConstr(grblhs, GRB.LESS_EQUAL, grbrhs)
+                self.grb_model.addLConstr(grblhs, GRB.LESS_EQUAL, grbrhs)
             elif cpm_expr.name == '>=':
                 grblhs = self._make_numexpr(lhs)
-                return self.grb_model.addLConstr(grblhs, GRB.GREATER_EQUAL, grbrhs)
+                self.grb_model.addLConstr(grblhs, GRB.GREATER_EQUAL, grbrhs)
             elif cpm_expr.name == '==':
                 if isinstance(lhs, _NumVarImpl) \
                         or (isinstance(lhs, Operator) and (lhs.name == 'sum' or lhs.name == 'wsum' or lhs.name == "sub")):
                     # a BoundedLinearExpression LHS, special case, like in objective
                     grblhs = self._make_numexpr(lhs)
-                    return self.grb_model.addLConstr(grblhs, GRB.EQUAL, grbrhs)
+                    self.grb_model.addLConstr(grblhs, GRB.EQUAL, grbrhs)
 
                 elif lhs.name == 'mul':
                     assert len(lhs.args) == 2, "Gurobi only supports multiplication with 2 variables"
                     a, b = self.solver_vars(lhs.args)
                     self.grb_model.setParam("NonConvex", 2)
-                    return self.grb_model.addConstr(a * b == grbrhs)
+                    self.grb_model.addConstr(a * b == grbrhs)
 
                 elif lhs.name == 'div':
                     assert is_num(lhs.args[1]), "Gurobi only supports division by constants"
                     a, b = self.solver_vars(lhs.args)
-                    return self.grb_model.addLConstr(a / b, GRB.EQUAL, grbrhs)
+                    self.grb_model.addLConstr(a / b, GRB.EQUAL, grbrhs)
 
-                # General constraints
-                # grbrhs should be a variable for gurobi in the subsequent, fake it
-                if is_num(grbrhs):
-                    grbrhs = self.solver_var(intvar(lb=grbrhs, ub=grbrhs))
+                else:
+                    # General constraints
+                    # grbrhs should be a variable for gurobi in the subsequent, fake it
+                    if is_num(grbrhs):
+                        grbrhs = self.solver_var(intvar(lb=grbrhs, ub=grbrhs))
 
-                if lhs.name == 'min':
-                    return self.grb_model.addGenConstrMin(grbrhs, self.solver_vars(lhs.args))
-                elif lhs.name == 'max':
-                    return self.grb_model.addGenConstrMax(grbrhs, self.solver_vars(lhs.args))
-                elif lhs.name == 'abs':
-                    return self.grb_model.addGenConstrAbs(grbrhs, self.solver_var(lhs.args[0]))
-                elif lhs.name == 'pow':
-                    x, a = self.solver_vars(lhs.args)
-                    assert a == 2, "Gurobi: 'pow', only support quadratic constraints (x**2)"
-                    return self.grb_model.addGenConstrPow(x, grbrhs, a)
-
-            raise NotImplementedError(
+                    if lhs.name == 'min':
+                        self.grb_model.addGenConstrMin(grbrhs, self.solver_vars(lhs.args))
+                    elif lhs.name == 'max':
+                        self.grb_model.addGenConstrMax(grbrhs, self.solver_vars(lhs.args))
+                    elif lhs.name == 'abs':
+                        self.grb_model.addGenConstrAbs(grbrhs, self.solver_var(lhs.args[0]))
+                    elif lhs.name == 'pow':
+                        x, a = self.solver_vars(lhs.args)
+                        assert a == 2, "Gurobi: 'pow', only support quadratic constraints (x**2)"
+                        self.grb_model.addGenConstrPow(x, grbrhs, a)
+                    else:
+                        raise NotImplementedError(
+                        "Not a known supported gurobi comparison '{}' {}".format(lhs.name, cpm_expr))
+            else:
+                raise NotImplementedError(
                 "Not a known supported gurobi comparison '{}' {}".format(lhs.name, cpm_expr))
 
         elif isinstance(cpm_expr, Operator) and cpm_expr.name == "->":
@@ -357,17 +372,26 @@ class CPM_gurobi(SolverInterface):
             else:
                 raise Exception(f"Unknown linear expression {lhs} on right side of indicator constraint: {cpm_expr}")
             if sub_expr.name == "<=":
-                return self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.LESS_EQUAL, self.solver_var(rhs))
-            if sub_expr.name == ">=":
-                return self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.GREATER_EQUAL, self.solver_var(rhs))
-            if sub_expr.name == "==":
-                return self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.EQUAL, self.solver_var(rhs))
+                self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.LESS_EQUAL, self.solver_var(rhs))
+            elif sub_expr.name == ">=":
+                self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.GREATER_EQUAL, self.solver_var(rhs))
+            elif sub_expr.name == "==":
+                self.grb_model.addGenConstrIndicator(cond, bool_val, lin_expr, GRB.EQUAL, self.solver_var(rhs))
+            else:
+                raise Exception(f"Unknown linear expression {sub_expr} name")
+
+        # True or False
+        elif isinstance(cpm_expr, BoolVal):
+            self.grb_model.addConstr(cpm_expr.args[0])
 
         # a direct constraint, pass to solver
         elif isinstance(cpm_expr, DirectConstraint):
-            return cpm_expr.callSolver(self, self.grb_model)
+            cpm_expr.callSolver(self, self.grb_model)
 
-        raise NotImplementedError(cpm_expr)  # if you reach this... please report on github
+        else:
+            raise NotImplementedError(cpm_expr)  # if you reach this... please report on github
+
+      return self
 
     def solveAll(self, display=None, time_limit=None, solution_limit=None, call_from_model=False, **kwargs):
         """

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -328,6 +328,8 @@ class CPM_minizinc(SolverInterface):
             return str(cpm_var)
 
         if cpm_var not in self._varmap:
+            # we assume all variables are user variables (because no transforms)
+            self.user_vars.add(cpm_var)
             # clean the varname
             varname = cpm_var.name
             mzn_var = varname.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '')
@@ -359,7 +361,7 @@ class CPM_minizinc(SolverInterface):
 
             'objective()' can be called multiple times, only the last one is stored
         """
-        get_variables(expr, collect=self.user_vars)  # add objvars to vars
+        #get_variables(expr, collect=self.user_vars)  # add objvars to vars  # all are user vars
 
         # make objective function or variable and post
         obj = self._convert_expression(expr)
@@ -372,7 +374,6 @@ class CPM_minizinc(SolverInterface):
     def has_objective(self):
         return self.mzn_txt_solve != "solve satisfy;"
 
-    # `__add__()` from the superclass first calls `transform()` then `_post_constraint()`, just implement the latter
     def transform(self, cpm_expr):
         """
             No transformations, just ensure it is a list of constraints
@@ -384,13 +385,33 @@ class CPM_minizinc(SolverInterface):
         """
         return toplevel_list(cpm_expr)
 
-    def _post_constraint(self, cpm_con):
+    def __add__(self, cpm_expr):
         """
             Translate a CPMpy constraint to MiniZinc string and add it to the solver
+
+            Any CPMpy expression given is immediately transformed (throught `transform()`)
+            and then posted to the solver in this function.
+
+            This can raise 'NotImplementedError' for any constraint not supported after transformation
+
+            The variables used in expressions given to add are stored as 'user variables'. Those are the only ones
+            the user knows and cares about (and will be populated with a value after solve). All other variables
+            are auxiliary variables created by transformations.
+
+        :param cpm_expr: CPMpy expression, or list thereof
+        :type cpm_expr: Expression or list of Expression
+
+        :return: self
         """
-        # Get text expression, add to the solver
-        mzn_str = f"constraint {self._convert_expression(cpm_con)};\n"
-        self.mzn_model.add_string(mzn_str)
+        # all variables are user variables, handled in `solver_var()`
+
+        # transform and post the constraints
+        for cpm_con in self.transform(cpm_expr):
+            # Get text expression, add to the solver
+            mzn_str = f"constraint {self._convert_expression(cpm_con)};\n"
+            self.mzn_model.add_string(mzn_str)
+
+        return self
 
     def _convert_expression(self, expr) -> str:
         """

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -310,7 +310,6 @@ class CPM_ortools(SolverInterface):
         raise NotImplementedError("ORTools: Not a known supported numexpr {}".format(cpm_expr))
 
 
-    # `__add__()` from the superclass first calls `transform()` then `_post_constraint()`, just implement the latter
     def transform(self, cpm_expr):
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
@@ -333,6 +332,38 @@ class CPM_ortools(SolverInterface):
                                              # reified expr must go before this
         return cpm_cons
 
+    def __add__(self, cpm_expr):
+        """
+            Eagerly add a constraint to the underlying solver.
+
+            Any CPMpy expression given is immediately transformed (throught `transform()`)
+            and then posted to the solver in this function.
+
+            This can raise 'NotImplementedError' for any constraint not supported after transformation
+
+            The variables used in expressions given to add are stored as 'user variables'. Those are the only ones
+            the user knows and cares about (and will be populated with a value after solve). All other variables
+            are auxiliary variables created by transformations.
+
+        :param cpm_expr: CPMpy expression, or list thereof
+        :type cpm_expr: Expression or list of Expression
+
+        :return: self
+        """
+        # add new user vars to the set
+        get_variables(cpm_expr, collect=self.user_vars)
+
+        # transform and post the constraints
+        for con in self.transform(cpm_expr):
+            self._post_constraint(con)
+
+        return self
+
+    # TODO: 'reifiable' is an artefact from the early days
+    # only 3 constraints support it (and,or,sum),
+    # we can just add reified support for those and not need `reifiable` or returning the constraint
+    # then we can remove _post_constraint and have its code inside the for loop of __add__
+    # like for other solvers
     def _post_constraint(self, cpm_expr, reifiable=False):
         """
             Post a supported CPMpy constraint directly to the underlying solver's API

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -168,31 +168,6 @@ class SolverInterface(object):
             return [self.solver_vars(v) for v in cpm_vars]
         return self.solver_var(cpm_vars)
 
-    # most solvers can inherit this function as is, just implement `transform()` and `__post_constraint()` below
-    def __add__(self, cpm_expr):
-        """
-            Eagerly add a constraint to the underlying solver.
-
-            Any CPMpy expression given is immediately transformed (throught `transform()`)
-            and then posted to the solver (through `_post_constraint()`).
-
-            The variables used in expressions given to add are stored as 'user variables'. Those are the only ones
-            the user knows and cares about. All other variables are auxiliary variables created by transformations.
-
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
-
-        :return: self
-        """
-        # add new user vars to the set
-        get_variables(cpm_expr, collect=self.user_vars)
-
-        # transform and post the constraints
-        for con in self.transform(cpm_expr):
-            self._post_constraint(con)
-
-        return self
-
     def transform(self, cpm_expr):
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
@@ -207,21 +182,34 @@ class SolverInterface(object):
 
         :return: list of Expression
         """
-        return list(cpm_expr)  # overwrite this function and call the transformations you need
+        return toplevel_list(cpm_expr)  # replace by the transformations your solver needs
 
-    def _post_constraint(self, cpm_expr):
+    def __add__(self, cpm_expr):
         """
-            Post a supported CPMpy constraint directly to the underlying solver's API
+            Eagerly add a constraint to the underlying solver.
 
-            What 'supported' means depends on the solver capabilities, and in effect on what transformations
-            are applied in `transform()`.
+            Any CPMpy expression given is immediately transformed (throught `transform()`)
+            and then posted to the solver in this function.
 
-            Solvers can raise 'NotImplementedError' for any constraint not supported after transformation
+            This can raise 'NotImplementedError' for any constraint not supported after transformation
 
-        :param cpm_expr: list of CPMpy expressions
-        :type cpm_expr: list of Expression
+            The variables used in expressions given to add are stored as 'user variables'. Those are the only ones
+            the user knows and cares about (and will be populated with a value after solve). All other variables
+            are auxiliary variables created by transformations.
+
+        :param cpm_expr: CPMpy expression, or list thereof
+        :type cpm_expr: Expression or list of Expression
+
+        :return: self
         """
-        raise NotImplementedError("solver _post_constraint(): abstract function, overwrite")
+        # add new user vars to the set
+        get_variables(cpm_expr, collect=self.user_vars)
+
+        # transform and post the constraints
+        for con in self.transform(cpm_expr):
+            raise NotImplementedError("solver __add__(): abstract function, overwrite")
+
+        return self
 
 
     # OPTIONAL functions

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -8,7 +8,6 @@ import pytest
 #   make sure that `SolverLookup.get(solver)` works
 # also add exclusions to the 3 EXCLUDE_* below as needed
 SOLVERNAMES = [name for name, solver in SolverLookup.base_solvers() if solver.supported()]
-SOLVERNAMES = ["ortools"]
 
 # Exclude some global constraints for solvers
 # Can be used when .value() method is not implemented/contains bugs


### PR DESCRIPTION
removes the need for an inbetween _post_constraint function (well, ortools for now still needs it)

For some solvers I did a 'two space indent' hack to not make it look like all code has changed.

At a future refactor, we can use 4 spaces indent everywhere again...