### PR TITLE
Updated tuner

### DIFF
--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -544,7 +544,7 @@ class CPM_ortools(SolverInterface):
     def tunable_params(cls):
         """
             Suggestion of tunable hyperparameters of the solver.
-            List compiled based on Laurents feedback (issue #138)
+            List compiled based on a conversation with OR-tools' Laurent Perron (issue #138).
         """
         return {
             'use_branching_in_lp': [False, True],

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -542,28 +542,40 @@ class CPM_ortools(SolverInterface):
 
     @classmethod
     def tunable_params(cls):
+        """
+            Suggestion of tunable hyperparameters of the solver.
+            List compiled based on Laurents feedback (issue #138)
+        """
         return {
-            'cp_model_probing_level': [0, 1, 2],
-            'preferred_variable_order': [0, 1, 2],
+            'use_branching_in_lp': [False, True],
+            'optimize_with_core' : [False, True],
+            'search_branching': [0,1,2,3,4,5,6],
+            'boolean_encoding_level' : [0,1,2,3],
             'linearization_level': [0, 1, 2],
-            'symmetry_level': [0, 1, 2],
-            'minimization_algorithm': [0, 1, 2],
-            'search_branching': [0, 1, 2, 3, 4, 5, 6],
-            'optimize_with_core': [False, True],
-            'use_erwa_heuristic': [False, True]
+            'minimize_core' : [False, True],
+            'cp_model_probing_level': [0, 1, 2, 3],
+            'cp_model_presolve' : [False, True],
+            'clause_cleanup_ordering' : [0,1],
+            'binary_minimization_algorithm' : [0,1,2,3,4],
+            'minimization_algorithm' : [0,1,2,3],
+            'use_phase_saving' : [False, True]
         }
 
     @classmethod
     def default_params(cls):
         return {
-            'cp_model_probing_level': 2,
-            'preferred_variable_order': 0,
-            'linearization_level': 1,
-            'symmetry_level': 2,
-            'minimization_algorithm': 2,
-            'search_branching': 0,
+            'use_branching_in_lp': False,
             'optimize_with_core': False,
-            'use_erwa_heuristic': False
+            'search_branching': 0,
+            'boolean_encoding_level': 1,
+            'linearization_level': 1,
+            'minimize_core': True,
+            'cp_model_probing_level': 2,
+            'cp_model_presolve': True,
+            'clause_cleanup_ordering': 0,
+            'binary_minimization_algorithm': 1,
+            'minimization_algorithm': 2,
+            'use_phase_saving': True
         }
 
 

--- a/cpmpy/tools/__init__.py
+++ b/cpmpy/tools/__init__.py
@@ -2,5 +2,5 @@
     Set of independent tools that users might appreciate.
 """
 
-from .tune_solver import ParameterTuner
+from .tune_solver import ParameterTuner, GridSearchTuner
 from .mus import mus

--- a/cpmpy/tools/tune_solver.py
+++ b/cpmpy/tools/tune_solver.py
@@ -139,7 +139,7 @@ class GridSearchTuner(ParameterTuner):
         self.base_runtime = solver.status().runtime
         self.best_runtime = self.base_runtime
 
-        # Add default's runtime as first entry in configs
+        # Get all possible hyperparameter configurations
         combos = list(param_combinations(self.all_params))
         shuffle(combos) # test in random order
 

--- a/cpmpy/tools/tune_solver.py
+++ b/cpmpy/tools/tune_solver.py
@@ -103,10 +103,10 @@ class ParameterTuner:
 
     def _get_score(self, combos):
         """
-            Return score for every parameter config in combos
+            Return the hamming distance for each remaining configuration to the current best config.
+            Lower score means better configuration, so exploit the current best configuration by only allowing small changes.
         """
-        mtrx = np.tile(self._best_config, len(combos)).reshape(combos.shape)
-        return np.count_nonzero(combos != mtrx, axis=1)
+        return np.count_nonzero(combos != self._best_config, axis=1)
 
     def _params_to_np(self,combos):
         arr = [[params[key] for key in self._param_order] for params in combos]

--- a/cpmpy/tools/tune_solver.py
+++ b/cpmpy/tools/tune_solver.py
@@ -15,7 +15,7 @@
     Searching and time-out start at the default configuration for a solver (if available in the solver class)
 """
 import time
-from random import randint
+from random import shuffle
 
 import numpy as np
 
@@ -141,16 +141,14 @@ class GridSearchTuner(ParameterTuner):
 
         # Add default's runtime as first entry in configs
         combos = list(param_combinations(self.all_params))
+        shuffle(combos) # test in random order
 
-        i = 0
-        if max_tries is None:
-            max_tries = len(combos)
-        while len(combos) and i < max_tries:
+        if max_tries is not None:
+            combos = combos[:max_tries]
+
+        for params_dict in combos:
             # Make new solver
             solver = SolverLookup.get(self.solvername, self.model)
-            # Pick random config to test next
-            config_idx = randint(0, len(combos)-1)
-            params_dict = combos.pop(config_idx)
             # set fixed params
             params_dict |= fix_params
             timeout = self.best_runtime
@@ -166,7 +164,6 @@ class GridSearchTuner(ParameterTuner):
 
             if time_limit is not None and (time.time() - start_time) >= time_limit:
                 break
-            i += 1
 
         return self.best_params
 

--- a/docs/solver_parameters.md
+++ b/docs/solver_parameters.md
@@ -81,7 +81,7 @@ defaults = {
     "FlowCoverCuts": -1
 }
 
-tuner = ParameterTuner("pysat", model, tunables, defaults)
+tuner = ParameterTuner("gurobi", model, tunables, defaults)
 print(f"Tuner reduced runtime from {tuner.base_runtime}s to {tuner.best_runtime}s")
 
 best_params = tuner.tune(time_limit=10)

--- a/docs/solver_parameters.md
+++ b/docs/solver_parameters.md
@@ -47,25 +47,45 @@ The parameter tuner is based on the following publication:
 >Programming, Artificial Intelligence, and Operations Research. CPAIOR 2022. Lecture Notes in Computer Science,
 >vol 13292. Springer, Cham. https://doi.org/10.1007/978-3-031-08011-1_6
 
-Solver interfaces not providing the set of tunable parameters can still be tuned by using this utility and providing the parameter (values) yourself.
-
+In the following example, we tune the OR-tools solver.
 ```python
 from cpmpy import *
 from cpmpy.tools import ParameterTuner
 
 model = Model(...)
 
-tunables = {
-    "search_branching":[0,1,2],
-    "linearization_level":[0,1],
-    'symmetry_level': [0,1,2]}
+tuner = ParameterTuner("ortools", model)
+best_params = tuner.tune(max_tries=100)
+print(f"Tuner reduced runtime from {tuner.base_runtime}s to {tuner.best_runtime}s")
+
+# now solve (a slightly different?) model using the best parameters
+solver = SolverLookup.get("ortools", model)
+solver.solve(**best_params)
+```
+
+However, solverinterfaces are not required to present a list of tunable parameters and the tool allows you to define the set of tunable parameters (and values) yourself.
+```python
+from cpmpy import *
+from cpmpy.tools import ParameterTuner
+
+model = Model(...)
+
+tunables ={
+   "MIPFocus": [0,1,2,3],
+   "Method" : [-1, 0, 1,2,3,4,5],
+   "FlowCoverCuts" :[-1,0,1,2]
+}
 defaults = {
-    "search_branching": 0,
-    "linearization_level": 1,
-    'symmetry_level': 2
+    "MIPFocus": 0,
+    "Method": -1,
+    "FlowCoverCuts": -1
 }
 
-tuner = ParameterTuner("ortools", model, tunables, defaults)
-best_params = tuner.tune(max_tries=100)
-best_runtime = tuner.best_runtime
+tuner = ParameterTuner("pysat", model, tunables, defaults)
+print(f"Tuner reduced runtime from {tuner.base_runtime}s to {tuner.best_runtime}s")
+
+best_params = tuner.tune(time_limit=10)
+
+solver = SolverLookup.get("gurobi", model)
+solver.solve(**best_params)
 ```

--- a/tests/test_tools_tuner.py
+++ b/tests/test_tools_tuner.py
@@ -2,7 +2,8 @@ import time
 from unittest import TestCase
 
 from cpmpy import *
-from cpmpy.tools import ParameterTuner
+from cpmpy.tools import ParameterTuner, GridSearchTuner
+
 
 
 class TunerTests(TestCase):
@@ -14,10 +15,13 @@ class TunerTests(TestCase):
         ])
 
         tuner = ParameterTuner("ortools", model)
-
         self.assertIsNotNone(tuner.tune(max_tries=100, fix_params={"num_search_workers":1}))
         self.assertLessEqual(tuner.best_runtime, tuner.base_runtime)
 
+        # run again with grid search tuner
+        tuner = GridSearchTuner("ortools", model)
+        self.assertIsNotNone(tuner.tune(max_tries=100, fix_params={"num_search_workers": 1}))
+        self.assertLessEqual(tuner.best_runtime, tuner.base_runtime)
 
     def test_ortools_custom(self):
 
@@ -35,9 +39,14 @@ class TunerTests(TestCase):
         }
 
         tuner = ParameterTuner("ortools", model, tunables, defaults)
-
         self.assertIsNotNone(tuner.tune(max_tries=100, fix_params={"num_search_workers":1}))
         self.assertLessEqual(tuner.best_runtime, tuner.base_runtime)
+
+        # run again with grid search tuner
+        tuner = GridSearchTuner("ortools", model, tunables, defaults)
+        self.assertIsNotNone(tuner.tune(max_tries=100, fix_params={"num_search_workers": 1}))
+        self.assertLessEqual(tuner.best_runtime, tuner.base_runtime)
+
 
 
     def test_ortools_timelimit(self):
@@ -50,6 +59,17 @@ class TunerTests(TestCase):
 
         start = time.time()
         self.assertIsNotNone(tuner.tune(max_tries=100, fix_params={"num_search_workers":1}))
+        end = time.time()
+
+        self.assertLessEqual(10, 1.05 * end - start)
+        self.assertLessEqual(tuner.best_runtime, tuner.base_runtime)
+
+
+        # run again with grid search tuner
+        tuner = GridSearchTuner("ortools", model)
+
+        start = time.time()
+        self.assertIsNotNone(tuner.tune(max_tries=100, fix_params={"num_search_workers": 1}))
         end = time.time()
 
         self.assertLessEqual(10, 1.05 * end - start)


### PR DESCRIPTION
Update our hyperparameter tuner and added some more documentation.
Also implemented a more naive grid search so we can easily compare the implementations.
The new hyperparameters for OR-tools are chosen according to issue #138. However, for some parameters no upper bound is given by the [sat_parameters.proto](https://github.com/google/or-tools/blob/5425dedcfbb22cb74c636c1374a9b5ad684b1eb5/ortools/sat/sat_parameters.proto#LL469C4-L470C61) file... (i.e., for example `cp_model_probing_level`).
