### PR TITLE
NegBoolView was using IntVarImpl init and not BoolVarImpl init

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -349,7 +349,7 @@ class NegBoolView(_BoolVarImpl):
     def __init__(self, bv):
         #assert(isinstance(bv, _BoolVarImpl))
         self._bv = bv
-        _IntVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
+        _BoolVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
 
     def value(self):
         v = self._bv.value()

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -349,7 +349,10 @@ class NegBoolView(_BoolVarImpl):
     def __init__(self, bv):
         #assert(isinstance(bv, _BoolVarImpl))
         self._bv = bv
-        _BoolVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
+        # as it is always created using the ~ operator (only available for _BoolVarImpl)
+        # it already comply with the asserts of the __init__ of _BoolVarImpl and can use 
+        # __init__ from _IntVarImpl
+        _IntVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
 
     def value(self):
         v = self._bv.value()


### PR DESCRIPTION
This creates the check (using the asserts during the init of BoolVarImpl) that bv should have a domain subset of {0,1}.
Using NegBoolVarView on an IntVarImpl with domain subset of {0,1} would still pass tho, but using it on other IntVar would now trigger assert.