### PR TITLE
bounds of a numerical value should always be tight

### DIFF
--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -134,7 +134,7 @@ def eval_comparison(str_op, lhs, rhs):
 
 
 def get_bounds(expr):
-    # can return floats, use floor and ceil when creating an intvar!
+    # returns appropriately rounded integers
     from cpmpy.expressions.core import Expression
     if isinstance(expr,Expression):
         return expr.get_bounds()

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -139,4 +139,4 @@ def get_bounds(expr):
         return expr.get_bounds()
     else:
         assert is_num(expr), f"All Expressions should have a get_bounds function, `{expr}`"
-        return expr, expr
+        return int(expr), int(expr)

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -139,6 +139,4 @@ def get_bounds(expr):
         return expr.get_bounds()
     else:
         assert is_num(expr), f"All Expressions should have a get_bounds function, `{expr}`"
-        if is_bool(expr):
-            return 0, 1
         return expr, expr

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -139,4 +139,6 @@ def get_bounds(expr):
         return expr.get_bounds()
     else:
         assert is_num(expr), f"All Expressions should have a get_bounds function, `{expr}`"
-        return int(expr), int(expr)
+        if is_bool(expr):
+            return int(expr), int(expr)
+        return expr, expr

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -20,8 +20,6 @@
 
         CPM_z3
 """
-from z3 import BoolRef
-
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
@@ -330,38 +328,38 @@ class CPM_z3(SolverInterface):
             # 'sub'/2, 'mul'/2, 'div'/2, 'pow'/2, 'mod'/2
             elif cpm_con.name == 'sub':
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     rhs = z3.If(rhs,1,0)
                 return lhs - rhs
             elif cpm_con.name == "mul":
                 assert len(cpm_con.args) == 2, "Currently only support multiplication with 2 vars"
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     lhs = z3.If(rhs,1,0)
                 return lhs * rhs
             elif cpm_con.name == "div":
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     lhs = z3.If(rhs,1,0)
                 return lhs / rhs
             elif cpm_con.name == "pow":
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     lhs = z3.If(rhs,1,0)
                 return lhs ** rhs
             elif cpm_con.name == "mod":
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     rhs = z3.If(lhs,1,0)
                 return lhs % rhs
 

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -345,7 +345,7 @@ def get_or_make_var(expr):
         (flatexpr, flatcons) = normalized_numexpr(expr)
 
         lb, ub = flatexpr.get_bounds()
-        ivar = _IntVarImpl(math.floor(lb), math.ceil(ub))
+        ivar = _IntVarImpl(lb, ub)
         return (ivar, [flatexpr == ivar]+flatcons)
 
 def get_or_make_var_or_list(expr):


### PR DESCRIPTION
When calling get_bounds on a boolean value, the bounds were loose. While calling the get_bounds on other numerical values was giving tight bounds