### PR TITLE
EQ and NEQ with bool and bool expr

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -308,11 +308,11 @@ class _BoolVarImpl(_IntVarImpl):
     def __eq__(self, other):
         # (BV == 1) <-> BV
         # if other == 1: XXX: dangerous because "=="" is overloaded 
-        if (is_int(other) and other == 1) or \
+        if (is_num(other) and other == 1) or \
                 other is True or \
                 other is np.bool_(True):
             return self
-        if (is_int(other) and other == 0) or \
+        if (is_num(other) and other == 0) or \
                 other is False or \
                 other is np.bool_(False):
             return ~self
@@ -320,11 +320,11 @@ class _BoolVarImpl(_IntVarImpl):
     def __ne__(self, other):
         # (BV == 0) <-> BV
         # if other == 1: XXX: dangerous because "=="" is overloaded 
-        if (is_int(other) and other == 1) or \
+        if (is_num(other) and other == 1) or \
                 other is True or \
                 other is np.bool_(True):
             return ~self
-        if (is_int(other) and other == 0) or \
+        if (is_num(other) and other == 0) or \
                 other is False or \
                 other is np.bool_(False):
             return self

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -319,24 +319,6 @@ class _BoolVarImpl(_IntVarImpl):
     def __invert__(self):
         return NegBoolView(self)
 
-    def __eq__(self, other):
-        # (BV == 1) <-> BV
-        # if other == 1: XXX: dangerous because "=="" is overloaded
-        if (is_num(other) and other == 1) or is_true_cst(other):
-            return self
-        if (is_num(other) and other == 0) or is_false_cst(other):
-            return ~self
-        return super().__eq__(other)
-
-    def __ne__(self, other):
-        if (is_num(other) and other == 1) or \
-                is_true_cst(other):
-            return ~self
-        if (is_num(other) and other == 0) or \
-                is_false_cst(other):
-            return self
-        return super().__ne__(other)
-
     def __abs__(self):
         return self
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -51,7 +51,7 @@ from collections.abc import Iterable
 import warnings # for deprecation warning
 import numpy as np
 from .core import Expression, Operator
-from .utils import is_num, is_int, flatlist, is_true_cst
+from .utils import is_num, is_int, flatlist, is_true_cst, is_false_cst
 
 
 def BoolVar(shape=1, name=None):
@@ -323,9 +323,18 @@ class _BoolVarImpl(_IntVarImpl):
         if (is_num(other) and other == 1) or \
                 is_true_cst(other):
             return self
+        if (is_num(other) and other == 0) or \
+                is_false_cst(other):
+            return ~self
         return super().__eq__(other)
 
     def __ne__(self, other):
+        if (is_num(other) and other == 1) or \
+                is_true_cst(other):
+            return ~self
+        if (is_num(other) and other == 0) or \
+                is_false_cst(other):
+            return self
         return super().__ne__(other)
 
     def __abs__(self):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -318,18 +318,12 @@ class _BoolVarImpl(_IntVarImpl):
         return NegBoolView(self)
 
     def __eq__(self, other):
+        if (is_num(other) and other == 0) or \
+                is_false_cst(other):
+            return ~self
         return super().__eq__(other)
 
     def __ne__(self, other):
-        # (BV == 0) <-> BV
-        # if other == 1: XXX: dangerous because "=="" is overloaded
-        if (is_num(other) and other == 1) or \
-                other is True or \
-                other is np.bool_(True):
-            return ~self
-        if (is_num(other) and other == 0) or \
-                is_false_cst(other):
-            return self
         return super().__ne__(other)
 
     def __abs__(self):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -51,7 +51,7 @@ from collections.abc import Iterable
 import warnings # for deprecation warning
 import numpy as np
 from .core import Expression, Operator
-from .utils import is_num, is_int, flatlist, is_false_cst
+from .utils import is_num, is_int, flatlist, is_true_cst
 
 
 def BoolVar(shape=1, name=None):
@@ -318,9 +318,11 @@ class _BoolVarImpl(_IntVarImpl):
         return NegBoolView(self)
 
     def __eq__(self, other):
-        if (is_num(other) and other == 0) or \
-                is_false_cst(other):
-            return ~self
+        # (BV == 1) <-> BV
+        # if other == 1: XXX: dangerous because "=="" is overloaded
+        if (is_num(other) and other == 1) or \
+                is_true_cst(other):
+            return self
         return super().__eq__(other)
 
     def __ne__(self, other):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -318,29 +318,9 @@ class _BoolVarImpl(_IntVarImpl):
         return NegBoolView(self)
 
     def __eq__(self, other):
-        # (BV == 1) <-> BV
-        # if other == 1: XXX: dangerous because "=="" is overloaded 
-        if (is_num(other) and other == 1) or \
-                other is True or \
-                other is np.bool_(True):
-            return self
-        if (is_num(other) and other == 0) or \
-                other is False or \
-                other is np.bool_(False):
-            return ~self
         return super().__eq__(other)
 
     def __ne__(self, other):
-        # (BV == 0) <-> BV
-        # if other == 1: XXX: dangerous because "=="" is overloaded 
-        if (is_num(other) and other == 1) or \
-                other is True or \
-                other is np.bool_(True):
-            return ~self
-        if (is_num(other) and other == 0) or \
-                other is False or \
-                other is np.bool_(False):
-            return self
         return super().__ne__(other)
 
     def __abs__(self):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -51,7 +51,7 @@ from collections.abc import Iterable
 import warnings # for deprecation warning
 import numpy as np
 from .core import Expression, Operator
-from .utils import is_num, is_int, flatlist
+from .utils import is_num, is_int, flatlist, is_false_cst
 
 
 def BoolVar(shape=1, name=None):
@@ -321,6 +321,15 @@ class _BoolVarImpl(_IntVarImpl):
         return super().__eq__(other)
 
     def __ne__(self, other):
+        # (BV == 0) <-> BV
+        # if other == 1: XXX: dangerous because "=="" is overloaded
+        if (is_num(other) and other == 1) or \
+                other is True or \
+                other is np.bool_(True):
+            return ~self
+        if (is_num(other) and other == 0) or \
+                is_false_cst(other):
+            return self
         return super().__ne__(other)
 
     def __abs__(self):

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -20,8 +20,6 @@
 
         CPM_z3
 """
-from z3 import BoolRef
-
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
@@ -330,38 +328,38 @@ class CPM_z3(SolverInterface):
             # 'sub'/2, 'mul'/2, 'div'/2, 'pow'/2, 'mod'/2
             elif cpm_con.name == 'sub':
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     rhs = z3.If(rhs,1,0)
                 return lhs - rhs
             elif cpm_con.name == "mul":
                 assert len(cpm_con.args) == 2, "Currently only support multiplication with 2 vars"
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     lhs = z3.If(rhs,1,0)
                 return lhs * rhs
             elif cpm_con.name == "div":
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     lhs = z3.If(rhs,1,0)
                 return lhs / rhs
             elif cpm_con.name == "pow":
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     lhs = z3.If(rhs,1,0)
                 return lhs ** rhs
             elif cpm_con.name == "mod":
                 lhs , rhs = self._z3_expr(cpm_con.args)
-                if isinstance(lhs, BoolRef):
+                if isinstance(lhs, z3.BoolRef):
                     lhs = z3.If(lhs,1,0)
-                if isinstance(rhs, BoolRef):
+                if isinstance(rhs, z3.BoolRef):
                     rhs = z3.If(lhs,1,0)
                 return lhs % rhs
 

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -300,6 +300,7 @@ def flatten_objective(expr, supported=frozenset(["sum","wsum"])):
         # one source of errors is sum(v) where v is a matrix, use v.sum() instead
         raise Exception(f"Objective expects a single variable/expression, not a list of expressions")
 
+    expr = simplify_boolean([expr])[0]
     (flatexpr, flatcons) = normalized_numexpr(expr)  # might rewrite expr into a (w)sum
     if isinstance(flatexpr, Expression) and flatexpr.name in supported:
         return (flatexpr, flatcons)

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ..expressions.core import BoolVal, Expression, Comparison, Operator
 from ..expressions.utils import eval_comparison, is_false_cst, is_true_cst, is_boolexpr, is_num
-from ..expressions.variables import NDVarArray, _BoolVarImpl, _IntVarImpl
+from ..expressions.variables import NDVarArray
 from ..exceptions import NotSupportedError
 from ..expressions.globalconstraints import GlobalConstraint
 
@@ -142,9 +142,9 @@ def simplify_boolean(lst_of_expr, num_context=False):
                     if name == "!=":
                         newlist.append(BoolVal(True))
                     if name == "<" or name == "<=":
-                        newlist.append(~lhs)
+                        newlist.append(recurse_negation(lhs))
                     if name == ">" or name == ">=":
-                        newlist.append(lhs) # TODO: add recuse_negation here after merging #310
+                        newlist.append(lhs)
                 elif rhs == 1:
                     if name == "==" or name == ">=":
                         newlist.append(lhs)

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -47,16 +47,16 @@ class TransSimplify(unittest.TestCase):
         self.assertEqual(str(self.transform(expr)), '[1 + (iv[0]) >= 0]')
 
     def test_boolvar_comps(self):
-        num_args = {"<0": -1, "0": 0, "1": 1, ">0": 2}
+        num_args = {"<0": -1, "0": 0, "]0..1[": 0.5, "1": 1, ">0": 2}
         # test table from github (#add url)
         bv = self.bvs[0]
         test_dict = {
-            "==": {"<0": False,"0": ~bv,  "1": bv,   ">0": False},
-            "!=": {"<0": True, "0": bv,   "1": ~bv,  ">0": True},
-            ">":  {"<0": True, "0": bv,   "1": False,">0": False},
-            "<":  {"<0": False,"0": False,"1": ~bv,  ">0": True},
-            ">=": {"<0": True, "0": True, "1": bv,   ">0": False},
-            "<=": {"<0": False,"0": ~bv,  "1": True, ">0": True}
+            "==": {"<0": False,"0": ~bv,  "]0..1[":False,"1": bv,   ">0": False},
+            "!=": {"<0": True, "0": bv,   "]0..1[":True, "1": ~bv,  ">0": True},
+            ">":  {"<0": True, "0": bv,   "]0..1[":bv,   "1": False,">0": False},
+            "<":  {"<0": False,"0": False,"]0..1[":~bv,  "1": ~bv,  ">0": True},
+            ">=": {"<0": True, "0": True, "]0..1[":bv,   "1": bv,   ">0": False},
+            "<=": {"<0": False,"0": ~bv,  "]0..1[":~bv,  "1": True, ">0": True}
         }
 
         for op in test_dict:
@@ -83,4 +83,20 @@ class TransSimplify(unittest.TestCase):
         # very nested one
         expr = Operator("and", self.bvs[:1].tolist() + [BoolVal(False)]) == Operator("or", self.bvs)
         self.assertEqual(str(self.transform(expr)), '[not([or([bv[0], bv[1], bv[2]])])]')
+
+    # issue #322
+    def test_with_floats(self):
+        expr = self.bvs[0] == 1.0
+        self.assertEqual(str(self.transform(expr)), "[bv[0]]")
+        expr = cp.AllDifferent(self.ivs) == 4.2
+        self.assertEqual(str(self.transform(expr)), '[boolval(False)]')
+        expr = 0.0 == cp.AllDifferent(self.ivs)
+        self.assertEqual(str(self.transform(expr)), '[not([alldifferent(iv[0],iv[1],iv[2])])]')
+
+        expr = (self.ivs[0] <= self.ivs[1]) < 0.8
+        self.assertEqual(str(self.transform(expr)), '[not([(iv[0]) <= (iv[1])])]')
+
+        expr = (self.ivs[0] == self.ivs[1]) == 1.0
+        self.assertEqual(str(self.transform(expr)), '[(iv[0]) == (iv[1])]')
+
 

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -94,7 +94,7 @@ class TransSimplify(unittest.TestCase):
         self.assertEqual(str(self.transform(expr)), '[not([alldifferent(iv[0],iv[1],iv[2])])]')
 
         expr = (self.ivs[0] <= self.ivs[1]) < 0.8
-        self.assertEqual(str(self.transform(expr)), '[not([(iv[0]) <= (iv[1])])]')
+        self.assertEqual(str(self.transform(expr)), '[(iv[0]) > (iv[1])]')
 
         expr = (self.ivs[0] == self.ivs[1]) == 1.0
         self.assertEqual(str(self.transform(expr)), '[(iv[0]) == (iv[1])]')


### PR DESCRIPTION
The __eq__ and __neq__ in boolvarimpl should allow the value to be a float also (ie, BV == 1.0).

Also, I think this should be removed from this class and put into the __eq__ and __neq__ of the Expression (they are not handled symmetrically there, so I also thing cases are already missing).
(I didn't do it yet because I think there are more cases when it's tested on expression)