### PR TITLE
Remove redundant test for gcc (leftover)

### DIFF
--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -536,20 +536,6 @@ class TestTypeChecks(unittest.TestCase):
         self.assertRaises(TypeError, cp.Cumulative, [x,y],[x,y],[x,y],1,x)
         self.assertRaises(TypeError, cp.Cumulative, [x,y],[x,y],[x,y],x,False)
 
-    def test_gcc(self):
-        x = cp.intvar(0, 1)
-        z = cp.intvar(-8, 8)
-        q = cp.intvar(-8, 8)
-        y = cp.intvar(-7, -1)
-        b = cp.boolvar()
-        a = cp.boolvar()
-
-        self.assertTrue(cp.Model([cp.GlobalCardinalityCount([x,y],[z,q])]).solve())
-        self.assertRaises(TypeError, cp.GlobalCardinalityCount, [x,y],[x,False])
-        self.assertRaises(TypeError, cp.GlobalCardinalityCount, [x,y,q],[z,x])
-        self.assertRaises(TypeError, cp.GlobalCardinalityCount, [x,y],[z,b])
-        self.assertRaises(TypeError, cp.GlobalCardinalityCount, [b,a],[a,b])
-
     def test_count(self):
         x = cp.intvar(0, 1)
         z = cp.intvar(-8, 8)


### PR DESCRIPTION
For some reason we had 2 different test functions for gcc, the test_global_cardinality_count and the test_gcc. They were doing the same thing. I had only noticed and changed the test_global_cardinality_count in my PR that was merged, and the test_gcc redundant test was left same as in the previous version, and thus now fails with the new syntax. 

In this PR I just remove the redundant test test_gcc, as we already have tests in test_global_cardinality_count