### PR TITLE
Globalfunctions seperated from global constraints

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -10,6 +10,7 @@
         variables
         core
         globalconstraints
+        globalfunctions
         python_builtins
         utils
 
@@ -20,7 +21,8 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Minimum, Maximum, Element, Xor, Cumulative, IfThenElse, Count, GlobalCardinalityCount, DirectConstraint
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Xor, Cumulative, IfThenElse, GlobalCardinalityCount, DirectConstraint
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
+from .globalfunctions import Maximum, Minimum, Element, Count
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -125,7 +125,7 @@ class GlobalConstraint(Expression):
     """
 
     def is_bool(self):
-        """ is it a Boolean (return type) Operator? Should always be bool now
+        """ is it a Boolean (return type) Operator?
         """
         return True
 

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -28,7 +28,7 @@
     This is the burden of the CPMpy framework, not of the user who wants to express a problem formulation.
 
 
-    Subclassing GlobalConstraint
+    Subclassing GlobalFunction
     ----------------------------
 
     If you do wish to add a GlobalFunction, because it is supported by solvers or because you will do

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+##
+## globalfunctions.py
+##
+"""
+
+    Using global functions
+    ------------------------
+
+    If a solver does not support such a global function (see solvers/), then it will be automatically
+    decomposed by calling its `.decompose_comparison()` function.
+
+    CPMpy GlobalFunctions does not exactly match what is implemented in the solvers.
+    Solvers can have specialised implementations for global functions, when used in a comparison, as global constraints.
+    These global functions will be treated as global constraints in such cases.
+
+    For example solvers may implement the global constraint `Minimum(iv1, iv2, iv3) == iv4` through an API
+    call `addMinimumEquals([iv1,iv2,iv3], iv4)`.
+
+    However, CPMpy also wishes to support the expressions `Minimum(iv1, iv2, iv3) > iv4` as well as
+    `iv4 + Minimum(iv1, iv2, iv3)`.
+
+    Hence, the CPMpy global functions only capture the `Minimum(iv1, iv2, iv3)` part, whose return type
+    is numeric and can be used in any other CPMpy expression. Only at the time of transforming the CPMpy
+    model to the solver API, will the expressions be decomposed and auxiliary variables introduced as needed
+    such that the solver only receives `Minimum(iv1, iv2, iv3) == ivX` expressions.
+    This is the burden of the CPMpy framework, not of the user who wants to express a problem formulation.
+
+
+    Subclassing GlobalConstraint
+    ----------------------------
+
+    If you do wish to add a GlobalFunction, because it is supported by solvers or because you will do
+    advanced analysis and rewriting on it, then preferably define it with a standard comparison decomposition,
+    e.g.:
+
+    .. code-block:: python
+
+        class my_global(GlobalFunction):
+            def __init__(self, args):
+                super().__init__("my_global", args)
+
+            def decompose_comparison(self):
+                return [self.args[0] + self.args[1]] # your decomposition
+
+    Also, implement `.value()` accordingly.
+
+    ===============
+    List of classes
+    ===============
+
+    .. autosummary::
+        :nosignatures:
+
+        Minimum
+        Maximum
+        Element
+        Count
+
+"""
+import copy
+import warnings  # for deprecation warning
+import numpy as np
+from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
+from .core import Expression, Operator, Comparison
+from .variables import boolvar, intvar, cpm_array, _NumVarImpl
+from .utils import flatlist, all_pairs, argval, is_num, eval_comparison, is_any_list, is_boolexpr, get_bounds
+
+
+class GlobalFunction(Expression):
+    """
+        Abstract superclass of GlobalFunction
+
+        Like all expressions it has a `.name` and `.args` property.
+        Overwrites the `.is_bool()` method.
+    """
+
+    def is_bool(self):
+        """ is it a Boolean (return type) Operator? No
+        """
+        return False
+
+    def decompose_comparison(self, cmp_op, cmp_rhs):
+        """
+            Returns a decomposition into smaller constraints.
+
+            The decomposition might create auxiliary variables
+            and use other global constraints as long as
+            it does not create a circular dependency.
+        """
+        raise NotImplementedError("Decomposition for", self, "not available")
+
+    def get_bounds(self):
+        """
+        Returns the bounds of the global function
+        """
+        return NotImplementedError("Bounds calculation for", self, "not available")
+
+    def is_total(self):
+        """
+            Returns whether it is a total function.
+            If true, its value is defined for all arguments
+        """
+        return True
+
+
+class Minimum(GlobalFunction):
+    """
+        Computes the minimum value of the arguments
+    """
+
+    def __init__(self, arg_list):
+        super().__init__("min", flatlist(arg_list))
+
+    def value(self):
+        argvals = [argval(a) for a in self.args]
+        if any(val is None for val in argvals):
+            return None
+        else:
+            return min(argvals)
+
+    def decompose_comparison(self, cpm_op, cpm_rhs):
+        """
+        Decomposition if it's part of a comparison
+        """
+        from .python_builtins import any, all
+        lb, ub = self.get_bounds()
+        _min = intvar(lb, ub)
+        return [any(x <= _min for x in self.args), all(x >= _min for x in self.args),
+                eval_comparison(cpm_op, _min, cpm_rhs)]
+
+    def get_bounds(self):
+        """
+        Returns the bounds of the (numerical) global constraint
+        """
+        bnds = [get_bounds(x) for x in self.args]
+        return min(lb for lb, ub in bnds), min(ub for lb, ub in bnds)
+
+
+class Maximum(GlobalFunction):
+    """
+        Computes the maximum value of the arguments
+
+        It is a 'functional' global constraint which implicitly returns a numeric variable
+    """
+
+    def __init__(self, arg_list):
+        super().__init__("max", flatlist(arg_list))
+
+    def value(self):
+        argvals = [argval(a) for a in self.args]
+        if any(val is None for val in argvals):
+            return None
+        else:
+            return max(argvals)
+
+    def decompose_comparison(self, cpm_op, cpm_rhs):
+        """
+        Decomposition if it's part of a comparison
+        """
+        from .python_builtins import any, all
+        lb, ub = self.get_bounds()
+        _max = intvar(lb, ub)
+        return [any(x >= _max for x in self.args), all(x <= _max for x in self.args),
+                eval_comparison(cpm_op, _max, cpm_rhs)]
+
+    def get_bounds(self):
+        """
+        Returns the bounds of the (numerical) global constraint
+        """
+        bnds = [get_bounds(x) for x in self.args]
+        return max(lb for lb, ub in bnds), max(ub for lb, ub in bnds)
+
+
+def element(arg_list):
+    warnings.warn("Deprecated, use Element(arr,idx) instead, will be removed in stable version", DeprecationWarning)
+    assert (len(arg_list) == 2), "Element expression takes 2 arguments: Arr, Idx"
+    return Element(arg_list[0], arg_list[1])
+class Element(GlobalFunction):
+    """
+        The 'Element' global constraint enforces that the result equals Arr[Idx]
+        with 'Arr' an array of constants of variables (the first argument)
+        and 'Idx' an integer decision variable, representing the index into the array.
+
+        Solvers implement it as Arr[Idx] == Y, but CPMpy will automatically derive or create
+        an appropriate Y. Hence, you can write expressions like Arr[Idx] + 3 <= Y
+
+        Element is a CPMpy built-in global constraint, so the class implements a few more
+        extra things for convenience (.value() and .__repr__()). It is also an example of
+        a 'numeric' global constraint.
+    """
+
+    def __init__(self, arr, idx):
+        if is_boolexpr(idx):
+            raise TypeError("index cannot be a boolean expression: {}".format(idx))
+        super().__init__("element", [arr, idx])
+
+    def value(self):
+        arr, idx = self.args
+        idxval = argval(idx)
+        if idxval is not None:
+            if idxval >= 0 and idxval < len(arr):
+                return argval(arr[idxval])
+            raise IncompleteFunctionError(
+                f"Index {idxval} out of range for array of length {len(arr)} while calculating value for expression {self}")
+        return None  # default
+
+    def decompose_comparison(self, cpm_op, cpm_rhs):
+        """
+            `Element(arr,ix)` represents the array lookup itself (a numeric variable)
+            It is not a constraint itself, so it can not have a decompose().
+            However, when used in a comparison relation: Element(arr,idx) <CMP_OP> CMP_RHS
+            it is a constraint, and that one can be decomposed.
+            That is what this function does
+            (for now only used in transformations/reification.py)
+        """
+        from .python_builtins import any
+
+        arr, idx = self.args
+        return [(idx == i).implies(eval_comparison(cpm_op, arr[i], cpm_rhs)) for i in range(len(arr))] + \
+               [idx >= 0, idx < len(arr)]
+
+    def is_total(self):
+        arr, idx = self.args
+        lb, ub = get_bounds(idx)
+        return lb >= 0 & idx.ub < len(arr)
+
+    def __repr__(self):
+        return "{}[{}]".format(self.args[0], self.args[1])
+
+    def get_bounds(self):
+        """
+        Returns the bounds of the (numerical) global constraint
+        """
+        arr, idx = self.args
+        bnds = [get_bounds(x) for x in arr]
+        return min(lb for lb, ub in bnds), max(ub for lb, ub in bnds)
+
+
+class Count(GlobalFunction):
+    """
+    The Count (numerical) global constraint represents the number of occurrences of val in arr
+    """
+
+    def __init__(self,arr,val):
+        if is_any_list(val) or not is_any_list(arr):
+            raise TypeError("count takes an array and a value as input, not: {} and {}".format(arr,val))
+        super().__init__("count", [arr,val])
+
+    def decompose_comparison(self, cmp_op, cmp_rhs):
+        """
+        Count(arr,val) can only be decomposed if it's part of a comparison
+        """
+        arr, val = self.args
+        return [eval_comparison(cmp_op, Operator('sum',[ai==val for ai in arr]), cmp_rhs)]
+
+    def value(self):
+        arr, val = self.args
+        val = argval(val)
+        return sum([argval(a) == val for a in arr])
+
+    def get_bounds(self):
+        """
+        Returns the bounds of the (numerical) global constraint
+        """
+        arr, val = self.args
+        return 0, len(arr)

--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -24,7 +24,7 @@ import builtins  # to use the original Python-builtins
 from .utils import is_false_cst, is_true_cst
 from .variables import NDVarArray
 from .core import Expression, Operator
-from .globalconstraints import Minimum, Maximum
+from .globalfunctions import Minimum, Maximum
 
 # Overwriting all/any python built-ins
 # all: listwise 'and'

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -535,7 +535,7 @@ class NDVarArray(Expression, np.ndarray):
         """
             overwrite np.max(NDVarArray) as people might use it
         """
-        from .globalconstraints import Maximum
+        from .globalfunctions import Maximum
         if out is not None:
             raise NotImplementedError()
 
@@ -556,7 +556,7 @@ class NDVarArray(Expression, np.ndarray):
         """
             overwrite np.min(NDVarArray) as people might use it
         """
-        from .globalconstraints import Minimum
+        from .globalfunctions import Minimum
         if out is not None:
             raise NotImplementedError()
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -433,7 +433,7 @@ class NDVarArray(Expression, np.ndarray):
         return super().__repr__()
 
     def __getitem__(self, index):
-        from .globalconstraints import Element # here to avoid circular
+        from .globalfunctions import Element # here to avoid circular
         # array access, check if variables are used in the indexing
 
         # index is single expression: direct element

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -1,9 +1,6 @@
 import copy
 import warnings  # for deprecation warning
 
-from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.globalfunctions import GlobalFunction
-from ..expressions.core import Expression, Comparison, Operator
 from .normalize import toplevel_list
 from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint
 from ..expressions.globalfunctions import GlobalFunction
@@ -68,6 +65,7 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
                 newlist.append(expr)
             else:
                 if expr.is_bool():
+                    assert isinstance(expr, GlobalConstraint)
                     # boolean global constraints
                     dec = expr.decompose()
                     if not isinstance(dec, tuple):
@@ -81,7 +79,8 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
                     newlist.append(all(decomposed))
 
                 else:
-                    # numeric global constraint, replace by a fresh variable and decompose the equality to this
+                    # global function, replace by a fresh variable and decompose the equality to this
+                    assert isinstance(expr, GlobalFunction)
                     lb,ub = expr.get_bounds()
                     aux = intvar(lb, ub)
 
@@ -100,9 +99,8 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
             lhs, rhs = expr.args
             exprname = expr.name  # can change when rhs needs decomp
 
-            # TODO: change hasattr to global functions class check
-            decomp_lhs = hasattr(lhs, "decompose_comparison") and not lhs.name in supported
-            decomp_rhs = hasattr(rhs, "decompose_comparison") and not rhs.name in supported
+            decomp_lhs = isinstance(lhs, GlobalFunction) and not lhs.name in supported
+            decomp_rhs = isinstance(rhs, GlobalFunction) and not rhs.name in supported
 
             if not decomp_lhs:
                 if not decomp_rhs:
@@ -175,13 +173,12 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
 
     """
     def _is_supported(cpm_expr, reified):
-        if isinstance(cpm_expr, GlobalConstraint) or isinstance(cpm_expr, GlobalFunction):
+        if isinstance(cpm_expr, GlobalConstraint):
             if reified and cpm_expr.name not in supported_reif:
                 return False
             if not reified and cpm_expr.name not in supported:
                 return False
-        if isinstance(cpm_expr, Comparison) and (isinstance(cpm_expr.args[0], GlobalFunction)
-                                                 or isinstance(cpm_expr.args[0], GlobalConstraint)):
+        if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalFunction):
             if not cpm_expr.args[0].name in supported:
                 # reified numerical global constraints can be rewritten to non-reified versions
                 #  so only have to check for 'supported' set

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -32,7 +32,6 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
     """
     def _is_supported(cpm_expr, reified):
         if isinstance(cpm_expr, GlobalConstraint):
-            print("here ? is_supported")
             if reified and cpm_expr.name not in supported_reif:
                 return False
             if not reified and cpm_expr.name not in supported:
@@ -61,7 +60,6 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
         decomp_idx = None
 
         if hasattr(cpm_expr, "decompose") and not _is_supported(cpm_expr, reified=False):
-            print("not here?")
             cpm_expr = cpm_expr.decompose() # base boolean global constraints
         elif isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -1,6 +1,7 @@
 import copy
 
 from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.core import Expression, Comparison, Operator
 from ..expressions.utils import is_any_list, eval_comparison
 from ..expressions.python_builtins import all
@@ -30,12 +31,12 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
 
     """
     def _is_supported(cpm_expr, reified):
-        if isinstance(cpm_expr, GlobalConstraint) and cpm_expr.is_bool():
+        if isinstance(cpm_expr, GlobalConstraint):
             if reified and cpm_expr.name not in supported_reif:
                 return False
             if not reified and cpm_expr.name not in supported:
                 return False
-        if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalConstraint):
+        if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalFunction):
             if not cpm_expr.args[0].name in supported:
                 # reified numerical global constraints can be rewritten to non-reified versions
                 #  so only have to check for 'supported' set

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -32,11 +32,13 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
     """
     def _is_supported(cpm_expr, reified):
         if isinstance(cpm_expr, GlobalConstraint):
+            print("here ? is_supported")
             if reified and cpm_expr.name not in supported_reif:
                 return False
             if not reified and cpm_expr.name not in supported:
                 return False
-        if isinstance(cpm_expr, Comparison) and isinstance(cpm_expr.args[0], GlobalFunction):
+        if isinstance(cpm_expr, Comparison) and (isinstance(cpm_expr.args[0], GlobalFunction)
+                                                 or isinstance(cpm_expr.args[0], GlobalConstraint)):
             if not cpm_expr.args[0].name in supported:
                 # reified numerical global constraints can be rewritten to non-reified versions
                 #  so only have to check for 'supported' set
@@ -59,6 +61,7 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
         decomp_idx = None
 
         if hasattr(cpm_expr, "decompose") and not _is_supported(cpm_expr, reified=False):
+            print("not here?")
             cpm_expr = cpm_expr.decompose() # base boolean global constraints
         elif isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -54,7 +54,7 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
             args = decompose_in_tree(expr.args, supported, supported_reified, _toplevel, nested=True)
             newlist.append(Operator(expr.name, args))
 
-        elif isinstance(expr, GlobalConstraint):
+        elif isinstance(expr, GlobalConstraint) or isinstance(expr, GlobalFunction):
             # first create a fresh version and recurse into arguments
             expr = copy.copy(expr)
             expr.args = decompose_in_tree(expr.args, supported, supported_reified, _toplevel, nested=True)
@@ -175,7 +175,7 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
 
     """
     def _is_supported(cpm_expr, reified):
-        if isinstance(cpm_expr, GlobalConstraint):
+        if isinstance(cpm_expr, GlobalConstraint) or isinstance(cpm_expr, GlobalFunction):
             if reified and cpm_expr.name not in supported_reif:
                 return False
             if not reified and cpm_expr.name not in supported:

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -276,7 +276,7 @@ def flatten_constraint(expr):
 
         elif isinstance(expr, GlobalConstraint):
             """
-    - Global constraint (Boolean): global([Var]*)          (CPMpy class 'GlobalConstraint', is_bool())
+    - Global constraint: global([Var]*)          (CPMpy class 'GlobalConstraint')
             """
             (con, flatcons) = normalized_boolexpr(expr)
             newlist.append(con)
@@ -375,7 +375,7 @@ def normalized_boolexpr(expr):
         Currently, this is the case for subexpr:
         - Boolean operators: and([Var]), or([Var])             (CPMpy class 'Operator', is_bool())
         - Boolean equality: Var == Var                         (CPMpy class 'Comparison')
-        - Global constraint (Boolean): global([Var]*)          (CPMpy class 'GlobalConstraint', is_bool())
+        - Global constraint: global([Var]*)                    (CPMpy class 'GlobalConstraint')
         - Comparison constraint (see elsewhere)                (CPMpy class 'Comparison')
 
         output: (base_expr, base_cons) with:

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -1,6 +1,7 @@
 import copy
 from ..expressions.core import Operator, Comparison, Expression
-from ..expressions.globalconstraints import GlobalConstraint, Element
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalfunctions import Element
 from ..expressions.variables import _BoolVarImpl, _NumVarImpl
 from ..expressions.python_builtins import all
 from ..expressions.utils import is_any_list

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,5 +1,6 @@
 from cpmpy import Model, SolverLookup, BoolVal
 from cpmpy.expressions.globalconstraints import *
+from cpmpy.expressions.globalfunctions import *
 
 import pytest
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -2,6 +2,7 @@ import copy
 import unittest
 import cpmpy as cp
 from cpmpy.expressions.globalconstraints import GlobalConstraint
+from cpmpy.expressions.globalfunctions import GlobalFunction
 from cpmpy.exceptions import TypeError
 
 class TestGlobal(unittest.TestCase):
@@ -240,15 +241,15 @@ class TestGlobal(unittest.TestCase):
     def test_minimax_python(self):
         from cpmpy import min,max
         iv = cp.intvar(1,9, 10)
-        self.assertIsInstance(min(iv), GlobalConstraint) 
-        self.assertIsInstance(max(iv), GlobalConstraint) 
+        self.assertIsInstance(min(iv), GlobalFunction)
+        self.assertIsInstance(max(iv), GlobalFunction)
 
     def test_minimax_cpm(self):
         iv = cp.intvar(1,9, 10)
         mi = cp.min(iv)
         ma = cp.max(iv)
-        self.assertIsInstance(mi, GlobalConstraint) 
-        self.assertIsInstance(ma, GlobalConstraint)
+        self.assertIsInstance(mi, GlobalFunction)
+        self.assertIsInstance(ma, GlobalFunction)
         
         def solve_return(model):
             model.solve()


### PR DESCRIPTION
Based on the discussion in #343, I did split the GlobalConstraint and NumericGlobalConstraint classes. I renamed the NumericGlobalConstraint to GlobalFunctions, as this was the main point of splitting them, that they are not really constraints. I have strong feelings about keeping the name GlobalConstraint for the boolean global expressions, as it is a well-established name in CP community.

I think this PR has to be merged before #335 so the necessary changes can be done there to.