### PR TITLE
test comparisons between bool and int variables

### DIFF
--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -61,13 +61,15 @@ def only_bv_implies(constraints):
                 # BVar0 == BVar1 special case, no need to re-transform
                 newcons.append(a0.implies(a1))
                 newcons.append(a1.implies(a0))
+            elif not a1.is_bool():
+                # if a rhs integer is involved with a lhs bool,
+                # then it is actually an integer expression, keep
+                newcons.append(cpm_expr)
             else:
                 # BE0 == BVar1 :: ~BVar1 -> ~BE0, BVar1 -> BE0
                 newexprs = ((~a1).implies(negated_normal(a0)), a1.implies(a0))
                 #newexprs = ((~a1).implies(~a0), a1.implies(a0))  # XXX when push_down_neg is separate, negated_normal no longer needed separately
                 newcons.extend(only_bv_implies(flatten_constraint(newexprs)))
-            # XXX there used to be a weird
-            # BE0 == IVar1 :: IVar1 = BVarX, ~BVarX -> ~BE, BVarX -> BE
         else:
             # all other flat normal form expressions are fine
             newcons.append(cpm_expr)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -71,7 +71,7 @@ def numexprs(solver):
         elif name == "div" or name == "pow":
             operator_args = [NN_VAR,2]
         elif name == "mod":
-            operator_args = [NUM_ARGS[0],POS_VAR]
+            operator_args = [NN_VAR,POS_VAR]
         elif arity != 0:
             operator_args = NUM_ARGS[:arity]
         else:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -92,19 +92,19 @@ def comp_constraints(solver):
     """
     for comp_name in Comparison.allowed:
         for numexpr in numexprs(solver):
-            for rhs in [NUM_VAR, 1, BoolVal(True)]:
+            for rhs in [NUM_VAR, BOOL_VAR, 1, BoolVal(True)]:
                 yield Comparison(comp_name, numexpr, rhs)
 
     for comp_name in Comparison.allowed:
         for glob_expr in global_constraints(solver):
             if not glob_expr.is_bool():
-                for rhs in [NUM_VAR,1, BoolVal(True)]:
+                for rhs in [NUM_VAR, BOOL_VAR, 1, BoolVal(True)]:
                     yield Comparison(comp_name, glob_expr, rhs)
 
     if solver == "z3":
         for comp_name in Comparison.allowed:
             for boolexpr in bool_exprs(solver):
-                for rhs in [NUM_VAR, 1, BoolVal(True)]:
+                for rhs in [NUM_VAR, BOOL_VAR, 1, BoolVal(True)]:
                     if comp_name == '>':
                         # >1 is unsat for boolean expressions, so change it to 0
                         if isinstance(rhs, int) and rhs == 1:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -7,6 +7,29 @@ from cpmpy.expressions import *
 from cpmpy.expressions.variables import NDVarArray
 from cpmpy.expressions.core import Operator, Expression
 
+class TestComparison(unittest.TestCase):
+    def test_comps(self):
+        # from the docs
+        # XXX is this the right place? it should be tested with all solvers...
+        import cpmpy as cp
+
+        bv = cp.boolvar()
+        iv = cp.intvar(0, 10)
+
+        m = cp.Model(
+            bv == True,         # allowed
+            bv > 0,             # allowed but silly
+            iv > 0,             # allowed
+            iv != 1,            # allowed
+            iv == True,         # allowed but means `iv == 1`, avoid
+            (iv != 0) == True,  # allowed
+            iv == bv,           # allowed but means `(iv == 1) == bv`, avoid
+            # bv & iv,          # not allowed, choose one of:
+            bv & (iv == 1),     # allowed
+            bv & (iv != 0),     # allowed
+        )
+        for c in m.constraints:
+            self.assertTrue(cp.Model(c).solve())
 
 class TestSum(unittest.TestCase):
 


### PR DESCRIPTION
from doc_rework, the test is literally from the new docs (was failing for ortools, includes fix)

I had a look at adding it to test_constraints, but the generator to which to add these cases is not clear to me...

if there is a way to simply test this with all solvers, without having to add it to test_constraints, that would also be fine for me. Even these as is just for ortools is already something.