### PR TITLE
Allow description for a constraint

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -107,13 +107,18 @@ class Expression(object):
         assert (is_any_list(arg_list)), "_list_ of arguments required, even if of length one e.g. [arg]"
         self.args = arg_list
 
-    def set_description(self, txt):
+    def set_description(self, txt, override_print=True, full_print=False):
         self.desc = txt
+        self._override_print = override_print
+        self._full_print = full_print
 
     def __str__(self):
-        if hasattr(self, "desc"):
-            return self.desc
-        return self.__repr__()
+        if not hasattr(self, "desc") or self._override_print is False:
+            return self.__repr__()
+        out = self.desc
+        if self._full_print:
+            out += " -- "+self.__repr__()
+        return out
 
 
     def __repr__(self):

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -107,6 +107,15 @@ class Expression(object):
         assert (is_any_list(arg_list)), "_list_ of arguments required, even if of length one e.g. [arg]"
         self.args = arg_list
 
+    def set_description(self, txt):
+        self.desc = txt
+
+    def __str__(self):
+        if hasattr(self, "desc"):
+            return self.desc
+        return self.__repr__()
+
+
     def __repr__(self):
         strargs = []
         for arg in self.args:
@@ -119,7 +128,7 @@ class Expression(object):
         return "{}({})".format(self.name, ",".join(strargs))
 
     def __hash__(self):
-        return hash(self.__str__())
+        return hash(self.__repr__())
 
     def is_bool(self):
         """ is it a Boolean (return type) Operator?

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -358,11 +358,6 @@ class NegBoolView(_BoolVarImpl):
         """
         self._bv.clear()
 
-    def __str__(self):
-        if hasattr(self._bv, "desc"):
-            return f"not({self._bv.desc})"
-        return self.__repr__()
-
     def __repr__(self):
         return "~{}".format(self._bv.name)
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -358,6 +358,11 @@ class NegBoolView(_BoolVarImpl):
         """
         self._bv.clear()
 
+    def __str__(self):
+        if hasattr(self._bv, "desc"):
+            return f"not({self._bv.desc})"
+        return self.__repr__()
+
     def __repr__(self):
         return "~{}".format(self._bv.name)
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -366,7 +366,7 @@ class NegBoolView(_BoolVarImpl):
 
 
 # subclass numericexpression for operators (first), ndarray for all the rest
-class NDVarArray(Expression, np.ndarray):
+class NDVarArray(np.ndarray, Expression):
     """
     N-dimensional numpy array of variables.
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -467,10 +467,10 @@ class TestBounds(unittest.TestCase):
 
         a,b = cp.boolvar(name="a"), cp.boolvar(name="b")
         cons = a ^ b
-        cons.set_description("either a or be should be true, but not both")
+        cons.set_description("either a or b should be true, but not both")
 
         self.assertEqual(repr(cons), "a xor b")
-        self.assertEqual(str(cons), "either a or be should be true, but not both")
+        self.assertEqual(str(cons), "either a or b should be true, but not both")
 
         # ensure nothing goes wrong due to calling __str__ on a constraint with a custom description
         for solver,cls in cp.SolverLookup.base_solvers():
@@ -478,6 +478,21 @@ class TestBounds(unittest.TestCase):
                 continue
             print("Testing", solver)
             self.assertTrue(cp.Model(cons).solve(solver=solver))
+
+        ## test extra attributes of set_description
+        cons = a ^ b
+        cons.set_description("either a or b should be true, but not both",
+                             override_print=False)
+
+        self.assertEqual(repr(cons), "a xor b")
+        self.assertEqual(str(cons), "a xor b")
+
+        cons = a ^ b
+        cons.set_description("either a or b should be true, but not both",
+                             full_print=True)
+
+        self.assertEqual(repr(cons), "a xor b")
+        self.assertEqual(str(cons), "either a or b should be true, but not both -- a xor b")
 
 
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -462,5 +462,26 @@ class TestBounds(unittest.TestCase):
         self.assertTrue(cp.Model([~~p == ~q]).solve())
         self.assertTrue(cp.Model([Operator('not',[p]) == q]).solve())
         self.assertTrue(cp.Model([Operator('not',[p])]).solve())
+
+    def test_description(self):
+
+        a,b = cp.boolvar(name="a"), cp.boolvar(name="b")
+        cons = a ^ b
+        cons.set_description("either a or be should be true, but not both")
+
+        self.assertEqual(repr(cons), "a xor b")
+        self.assertEqual(str(cons), "either a or be should be true, but not both")
+
+        # ensure nothing goes wrong due to calling __str__ on a constraint with a custom description
+        for solver,cls in cp.SolverLookup.base_solvers():
+            if not cls.supported():
+                continue
+            print("Testing", solver)
+            self.assertTrue(cp.Model(cons).solve(solver=solver))
+
+
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For explanation techniques, its usefull to have a human-intepretable representation for a constraint.
This pull request allows a user to create a constraint and then set its description, when the constraint is printed, the description is taken instead of the `__repr__` method.

I guess we should take extra care for Minzinc for this one as we might convert an expression based on its string representation? But I could not see this happening anywhere.
