### PR TITLE
avoid numpy sum where we are at risk of overflow

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -562,7 +562,9 @@ class Operator(Expression):
             weights, vars = self.args
             bounds = []
             for i, varbounds in enumerate([get_bounds(arg) for arg in vars]):
-                bounds += [(list(weights[i] * x for x in varbounds))]
+                sortbounds = (list(weights[i] * x for x in varbounds))
+                sortbounds.sort()
+                bounds += [sortbounds]
             lbs, ubs = (zip(*bounds))
             lowerbound, upperbound = sum(lbs), sum(ubs)
         elif self.name == 'sub':

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -554,26 +554,28 @@ class Operator(Expression):
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
             bounds = [lb1 * lb2, lb1 * ub2, ub1 * lb2, ub1 * ub2]
-            return min(bounds), max(bounds)
+            lowerbound, upperbound = min(bounds), max(bounds)
         elif self.name == 'sum':
             lbs, ubs = zip(*[get_bounds(x) for x in self.args])
-            return sum(lbs), sum(ubs)
+            lowerbound, upperbound = sum(lbs), sum(ubs)
         elif self.name == 'wsum':
             weights, vars = self.args
-            var_bounds = np.array([get_bounds(arg) for arg in vars]).T
-            bounds = var_bounds * weights
-            return bounds.min(axis=0).sum(), bounds.max(axis=0).sum()  # for every column is axis=0...
+            bounds = []
+            for i, varbounds in enumerate([get_bounds(arg) for arg in vars]):
+                bounds += [(list(weights[i] * x for x in varbounds))]
+            lbs, ubs = (zip(*bounds))
+            lowerbound, upperbound = sum(lbs), sum(ubs)
         elif self.name == 'sub':
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
-            return lb1-ub2, ub1-lb2
+            lowerbound, upperbound = lb1-ub2, ub1-lb2
         elif self.name == 'div':
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
             if lb2 <= 0 <= ub2:
                 raise ZeroDivisionError("division by domain containing 0 is not supported")
             bounds = [lb1 // lb2, lb1 // ub2, ub1 // lb2, ub1 // ub2]
-            return min(bounds), max(bounds)
+            lowerbound, upperbound = min(bounds), max(bounds)
         elif self.name == 'mod':
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
@@ -595,14 +597,18 @@ class Operator(Expression):
                 # E.g., (-2)^2 is positive, but (-2)^1 is negative, so for (-2)^[0,2] we also need to add (-2)^1.
                 bounds += [lb1 ** (ub2 - 1), ub1 ** (ub2 - 1)] 
                 # This approach is safe but not tight (e.g., [-2,-1]^2 will give (-2,4) as range instead of [1,4]).
-            return min(bounds), max(bounds)
+            lowerbound, upperbound = min(bounds), max(bounds)
 
         elif self.name == '-':
             lb1, ub1 = get_bounds(self.args[0])
-            return -ub1, -lb1
-        
-        raise ValueError(f"Bound requested for unknown expression {self}, please report bug on github")
-        
+            lowerbound, upperbound = -ub1, -lb1
+
+        if lowerbound == None:
+            raise ValueError(f"Bound requested for unknown expression {self}, please report bug on github")
+        if lowerbound > upperbound:
+            #overflow happened
+            raise OverflowError('Overflow when calculating bounds, your expression exceeds int64 bounds.')
+        return int(lowerbound), upperbound
 def _wsum_should(arg):
     """ Internal helper: should the arg be in a wsum instead of sum
 

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -610,7 +610,7 @@ class Operator(Expression):
         if lowerbound > upperbound:
             #overflow happened
             raise OverflowError('Overflow when calculating bounds, your expression exceeds integer bounds.')
-        return int(lowerbound), upperbound
+        return lowerbound, upperbound
 def _wsum_should(arg):
     """ Internal helper: should the arg be in a wsum instead of sum
 

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -607,7 +607,7 @@ class Operator(Expression):
             raise ValueError(f"Bound requested for unknown expression {self}, please report bug on github")
         if lowerbound > upperbound:
             #overflow happened
-            raise OverflowError('Overflow when calculating bounds, your expression exceeds int64 bounds.')
+            raise OverflowError('Overflow when calculating bounds, your expression exceeds integer bounds.')
         return int(lowerbound), upperbound
 def _wsum_should(arg):
     """ Internal helper: should the arg be in a wsum instead of sum

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -561,12 +561,13 @@ class Operator(Expression):
         elif self.name == 'wsum':
             weights, vars = self.args
             bounds = []
+            #this may seem like too many lines, but avoiding np.sum avoids overflowing things at int32 bounds
             for i, varbounds in enumerate([get_bounds(arg) for arg in vars]):
                 sortbounds = (list(weights[i] * x for x in varbounds))
                 sortbounds.sort()
                 bounds += [sortbounds]
             lbs, ubs = (zip(*bounds))
-            lowerbound, upperbound = sum(lbs), sum(ubs)
+            lowerbound, upperbound = sum(lbs), sum(ubs) #this is builtins sum, not numpy sum
         elif self.name == 'sub':
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])

--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -96,10 +96,10 @@ def min(iterable):
 def sum(iterable):
     """
         sum() overwrites python built-in,
-        checks if all constants and computes builtins.sum() in that case
+        checks if all constants and computes np.sum() in that case
         otherwise, makes a sum Operator directly on `iterable`
     """
     iterable = list(iterable) # Fix generator polling
     if not builtins.any(isinstance(elem, Expression) for elem in iterable):
-        return builtins.sum(iterable) #numpy sum is only faster on numpy arrays. builtin sum also avoids overflow of int32
+        return np.sum(iterable)
     return Operator("sum", iterable)

--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -96,10 +96,10 @@ def min(iterable):
 def sum(iterable):
     """
         sum() overwrites python built-in,
-        checks if all constants and computes np.sum() in that case
+        checks if all constants and computes builtins.sum() in that case
         otherwise, makes a sum Operator directly on `iterable`
     """
     iterable = list(iterable) # Fix generator polling
     if not builtins.any(isinstance(elem, Expression) for elem in iterable):
-        return np.sum(iterable)
+        return builtins.sum(iterable) #numpy sum is only faster on numpy arrays. builtin sum also avoids overflow of int32
     return Operator("sum", iterable)


### PR DESCRIPTION
Numpy is not able to upcast int32 to int64 when overflowing
numpy does not give a warning when overflowing
numpy sum is only faster on numpy arrays not on python lists

1. change our bound calculations so we don't use numpy arrays, therefor the only things that will still overflow will be things that actually exceed python int bounds

2. check for overflow
