### PR TITLE
fix: decompose_global: mark inverse as supported

### DIFF
--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -329,7 +329,7 @@ class CPM_ortools(SolverInterface):
         :return: list of Expression
         """
         cpm_cons = toplevel_list(cpm_expr)
-        supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "cumulative", "circuit"}
+        supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "cumulative", "circuit", "inverse"}
         cpm_cons = decompose_in_tree(cpm_cons, supported)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification


### PR DESCRIPTION
Hi there, good day! In #252, I added `Inverse` as a global constraint, with or-tools support. Since then, ortools's `decompose_global` forgot that it's supported, and decomposes it instead of passing it through natively.

This change should restore support for native inverse. Thanks!