### PR TITLE
UUID

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -347,6 +347,7 @@ class NegBoolView(_BoolVarImpl):
         # it already comply with the asserts of the __init__ of _BoolVarImpl and can use 
         # __init__ from _IntVarImpl
         _IntVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
+        self.id = bv.id
 
     def value(self):
         """ the negation of the value obtained in the last solve call by the viewed variable

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -47,6 +47,7 @@
     ==============
 """
 import math
+import uuid
 from collections.abc import Iterable
 import warnings # for deprecation warning
 from functools import reduce
@@ -238,6 +239,7 @@ class _NumVarImpl(Expression):
         self.lb = lb
         self.ub = ub
         self.name = name
+        self.id = uuid.uuid4()
         self._value = None
 
     def is_bool(self):
@@ -263,9 +265,9 @@ class _NumVarImpl(Expression):
     def __repr__(self):
         return self.name
 
-    # for sets/dicts. Because names are unique, so is the str repr
+    # for sets/dicts. Because id's are unique, so is the str repr
     def __hash__(self):
-        return hash(self.name)
+        return hash(self.id)
 
 
 class _IntVarImpl(_NumVarImpl):
@@ -285,6 +287,8 @@ class _IntVarImpl(_NumVarImpl):
             _IntVarImpl.counter = _IntVarImpl.counter + 1 # static counter
 
         super().__init__(int(lb), int(ub), name=name) # explicit cast: can be numpy
+
+
 
     # special casing for intvars (and boolvars)
     def __abs__(self):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## variables.py
 ##
@@ -49,7 +49,7 @@
 import math
 import uuid
 from collections.abc import Iterable
-import warnings # for deprecation warning
+import warnings  # for deprecation warning
 from functools import reduce
 
 import numpy as np
@@ -115,7 +115,7 @@ def boolvar(shape=1, name=None):
         return _BoolVarImpl(name=name)
 
     # create base data
-    data = np.array([_BoolVarImpl(name=_genname(name, idxs)) for idxs in np.ndindex(shape)]) # repeat new instances
+    data = np.array([_BoolVarImpl(name=_genname(name, idxs)) for idxs in np.ndindex(shape)])  # repeat new instances
     # insert into custom ndarray
     return NDVarArray(shape, dtype=object, buffer=data)
 
@@ -176,7 +176,8 @@ def intvar(lb, ub, shape=1, name=None):
         return _IntVarImpl(lb, ub, name=name)
 
     # create base data
-    data = np.array([_IntVarImpl(lb, ub, name=_genname(name, idxs)) for idxs in np.ndindex(shape)]) # repeat new instances
+    data = np.array(
+        [_IntVarImpl(lb, ub, name=_genname(name, idxs)) for idxs in np.ndindex(shape)])  # repeat new instances
     # insert into custom ndarray
     return NDVarArray(shape, dtype=object, buffer=data)
 
@@ -218,6 +219,7 @@ class NullShapeError(Exception):
     """
     Error returned when providing an empty or size 0 shape for numpy arrays of variables
     """
+
     def __init__(self, shape, message="Shape should be non-zero"):
         self.shape = shape
         self.message = message
@@ -233,6 +235,7 @@ class _NumVarImpl(Expression):
 
     Abstract class, only mean to be subclassed
     """
+
     def __init__(self, lb, ub, name):
         assert (is_num(lb) and is_num(ub))
         assert (lb <= ub)
@@ -267,6 +270,9 @@ class _NumVarImpl(Expression):
 
     # for sets/dicts. Because id's are unique, so is the str repr
     def __hash__(self):
+        # for backwards compatability
+        if not hasattr(self, 'id'):
+            self.id = self.id = uuid.uuid4()
         return hash(self.id)
 
 
@@ -284,11 +290,9 @@ class _IntVarImpl(_NumVarImpl):
 
         if name is None:
             name = "IV{}".format(_IntVarImpl.counter)
-            _IntVarImpl.counter = _IntVarImpl.counter + 1 # static counter
+            _IntVarImpl.counter = _IntVarImpl.counter + 1  # static counter
 
-        super().__init__(int(lb), int(ub), name=name) # explicit cast: can be numpy
-
-
+        super().__init__(int(lb), int(ub), name=name)  # explicit cast: can be numpy
 
     # special casing for intvars (and boolvars)
     def __abs__(self):
@@ -307,12 +311,12 @@ class _BoolVarImpl(_IntVarImpl):
     counter = 0
 
     def __init__(self, lb=0, ub=1, name=None):
-        assert(lb == 0 or lb == 1)
-        assert(ub == 0 or ub == 1)
+        assert (lb == 0 or lb == 1)
+        assert (ub == 0 or ub == 1)
 
         if name is None:
             name = "BV{}".format(_BoolVarImpl.counter)
-            _BoolVarImpl.counter = _BoolVarImpl.counter + 1 # static counter
+            _BoolVarImpl.counter = _BoolVarImpl.counter + 1  # static counter
         _IntVarImpl.__init__(self, lb, ub, name=name)
 
     def is_bool(self):
@@ -340,13 +344,14 @@ class NegBoolView(_BoolVarImpl):
 
         Do not create this object directly, use the `~` operator instead: `~bv`
     """
+
     def __init__(self, bv):
-        #assert(isinstance(bv, _BoolVarImpl))
+        # assert(isinstance(bv, _BoolVarImpl))
         self._bv = bv
         # as it is always created using the ~ operator (only available for _BoolVarImpl)
         # it already comply with the asserts of the __init__ of _BoolVarImpl and can use 
         # __init__ from _IntVarImpl
-        _IntVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
+        _IntVarImpl.__init__(self, 1 - bv.ub, 1 - bv.lb, name=str(self))
         self.id = bv.id
 
     def value(self):
@@ -377,6 +382,7 @@ class NDVarArray(Expression, np.ndarray):
 
     Do not create this object directly, use one of the functions in this module
     """
+
     def __init__(self, shape, **kwargs):
         # TODO: global name?
         # this is nice and sneaky, 'self' is the list_of_arguments!
@@ -414,7 +420,7 @@ class NDVarArray(Expression, np.ndarray):
         return super().__repr__()
 
     def __getitem__(self, index):
-        from .globalfunctions import Element # here to avoid circular
+        from .globalfunctions import Element  # here to avoid circular
         # array access, check if variables are used in the indexing
 
         # index is single expression: direct element
@@ -424,14 +430,14 @@ class NDVarArray(Expression, np.ndarray):
         # multi-dimensional index
         if isinstance(index, tuple) and any(isinstance(el, Expression) for el in index):
             # find dimension of expression in index
-            expr_dim = next(dim for dim,idx in enumerate(index) if isinstance(idx, Expression))
-            arr = self[tuple(index[:expr_dim])] # select remaining dimensions
+            expr_dim = next(dim for dim, idx in enumerate(index) if isinstance(idx, Expression))
+            arr = self[tuple(index[:expr_dim])]  # select remaining dimensions
             index = index[expr_dim:]
 
             # calculate index for flat array
             flat_index = index[-1]
             for dim, idx in enumerate(index[:-1]):
-                flat_index += idx * math.prod(arr.shape[dim+1:])
+                flat_index += idx * math.prod(arr.shape[dim + 1:])
             # using index expression as single var for flat array
             return Element(arr.flatten(), flat_index)
 
@@ -447,12 +453,13 @@ class NDVarArray(Expression, np.ndarray):
     """
     make the given array the first dimension in the returned array
     """
+
     def __axis(self, axis):
 
         arr = self
 
         # correct type and value checks
-        if not isinstance(axis,int):
+        if not isinstance(axis, int):
             raise TypeError("Axis keyword argument in .sum() should always be an integer")
         if axis >= arr.ndim:
             raise ValueError("Axis out of range")
@@ -476,7 +483,7 @@ class NDVarArray(Expression, np.ndarray):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the sum over the whole array
+        if axis is None:  # simple case where we want the sum over the whole array
             arr = self.flatten()
             return Operator("sum", arr)
 
@@ -489,7 +496,6 @@ class NDVarArray(Expression, np.ndarray):
         # return the NDVarArray that contains the sum constraints
         return out
 
-
     def prod(self, axis=None, out=None):
         """
             overwrite np.prod(NDVarArray) as people might use it
@@ -497,7 +503,7 @@ class NDVarArray(Expression, np.ndarray):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the product over the whole array
+        if axis is None:  # simple case where we want the product over the whole array
             arr = self.flatten()
             return reduce(lambda a, b: a * b, arr)
 
@@ -518,7 +524,7 @@ class NDVarArray(Expression, np.ndarray):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the maximum over the whole array
+        if axis is None:  # simple case where we want the maximum over the whole array
             arr = self.flatten()
             return Maximum(arr)
 
@@ -539,7 +545,7 @@ class NDVarArray(Expression, np.ndarray):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the Minimum over the whole array
+        if axis is None:  # simple case where we want the Minimum over the whole array
             arr = self.flatten()
             return Minimum(arr)
 
@@ -564,7 +570,7 @@ class NDVarArray(Expression, np.ndarray):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the .any() over the whole array
+        if axis is None:  # simple case where we want the .any() over the whole array
             arr = self.flatten()
             return any(arr)
 
@@ -586,7 +592,7 @@ class NDVarArray(Expression, np.ndarray):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the .all() over the whole array
+        if axis is None:  # simple case where we want the .all() over the whole array
             arr = self.flatten()
             return all(arr)
 
@@ -602,10 +608,10 @@ class NDVarArray(Expression, np.ndarray):
     # VECTORIZED master function (delegate)
     def _vectorized(self, other, attr):
         if not isinstance(other, Iterable):
-            other = [other]*len(self)
+            other = [other] * len(self)
         # this is a bit cryptic, but it calls 'attr' on s with o as arg
         # s.__eq__(o) <-> getattr(s, '__eq__')(o)
-        return cpm_array([getattr(s,attr)(o) for s,o in zip(self, other)])
+        return cpm_array([getattr(s, attr)(o) for s, o in zip(self, other)])
 
     # VECTORIZED comparisons
     def __eq__(self, other):
@@ -704,12 +710,12 @@ class NDVarArray(Expression, np.ndarray):
     def implies(self, other):
         return self._vectorized(other, 'implies')
 
-    #in	  __contains__(self, value) 	Check membership
+    # in	  __contains__(self, value) 	Check membership
     # CANNOT meaningfully overwrite, python always returns True/False
     # regardless of what you return in the __contains__ function
 
     # TODO?
-    #object.__matmul__(self, other)
+    # object.__matmul__(self, other)
 
 
 def _genname(basename, idxs):
@@ -725,5 +731,4 @@ def _genname(basename, idxs):
     if basename == None:
         return None
     stridxs = ",".join(map(str, idxs))
-    return f"{basename}[{stridxs}]" # "<name>[<idx0>,<idx1>,...]"
-
+    return f"{basename}[{stridxs}]"  # "<name>[<idx0>,<idx1>,...]"

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -290,7 +290,7 @@ class CPM_exact(SolverInterface):
             return self._varmap[cpm_var]
 
         # create if it does not exist
-        revar = str(cpm_var)
+        revar = str(cpm_var) + str(cpm_var.id)
         if isinstance(cpm_var, _BoolVarImpl):
             self.xct_solver.addVariable(revar,0,1)
         elif isinstance(cpm_var, _IntVarImpl):

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -185,9 +185,9 @@ class CPM_gurobi(SolverInterface):
         if cpm_var not in self._varmap:
             from gurobipy import GRB
             if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.grb_model.addVar(vtype=GRB.BINARY, name=cpm_var.name)
+                revar = self.grb_model.addVar(vtype=GRB.BINARY, name=cpm_var.name+str(cpm_var.id))
             elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.grb_model.addVar(cpm_var.lb, cpm_var.ub, vtype=GRB.INTEGER, name=str(cpm_var))
+                revar = self.grb_model.addVar(cpm_var.lb, cpm_var.ub, vtype=GRB.INTEGER, name=cpm_var.name+str(cpm_var.id))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
             self._varmap[cpm_var] = revar

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -335,15 +335,13 @@ class CPM_minizinc(SolverInterface):
             # we assume all variables are user variables (because no transforms)
             self.user_vars.add(cpm_var)
             # clean the varname
-            varname = cpm_var.name
-            mzn_var = varname.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '')
+            varname = cpm_var.name + str(cpm_var.id)
+            mzn_var = varname.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '').replace('-','_')
 
             #test if the name is a valid minizinc identifier
             if not self.mzn_name_pattern.search(mzn_var):
                 raise MinizincNameException("Minizinc only accept names with alphabetic characters, digits and underscores. "
-                                "First character must be an alphabetic character")
-            if mzn_var in self.keywords:
-                raise MinizincNameException(f"This variable name is a disallowed keyword in MiniZinc: {mzn_var}")
+                                "First character must be an alphabetic character" + mzn_var)
 
             if isinstance(cpm_var, _BoolVarImpl):
                 self.mzn_model.add_string(f"var bool: {mzn_var};\n")

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -243,9 +243,9 @@ class CPM_ortools(SolverInterface):
         # create if it does not exist
         if cpm_var not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.ort_model.NewBoolVar(str(cpm_var))
+                revar = self.ort_model.NewBoolVar(str(cpm_var)+str(cpm_var.id))
             elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var)+str(cpm_var.id))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
             self._varmap[cpm_var] = revar

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -206,9 +206,9 @@ class CPM_pysat(SolverInterface):
         # work directly on var inside the view
         if isinstance(cpm_var, NegBoolView):
             # just a view, get actual var identifier, return -id
-            return -self.pysat_vpool.id(cpm_var._bv.name)
+            return -self.pysat_vpool.id(cpm_var._bv.name + str(cpm_var.id))
         elif isinstance(cpm_var, _BoolVarImpl):
-            return self.pysat_vpool.id(cpm_var.name)
+            return self.pysat_vpool.id(cpm_var.name + str(cpm_var.id))
         else:
             raise NotImplementedError(f"CPM_pysat: variable {cpm_var} not supported")
 

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -195,9 +195,9 @@ class CPM_z3(SolverInterface):
             # we assume al variables are user variables (because nested expressions)
             self.user_vars.add(cpm_var)
             if isinstance(cpm_var, _BoolVarImpl):
-                revar = z3.Bool(str(cpm_var))
+                revar = z3.Bool(str(cpm_var) + str(cpm_var.id))
             elif isinstance(cpm_var, _IntVarImpl):
-                revar = z3.Int(str(cpm_var))
+                revar = z3.Int(str(cpm_var) + str(cpm_var.id))
                 # set bounds
                 self.z3_solver.add(revar >= cpm_var.lb)
                 self.z3_solver.add(revar <= cpm_var.ub)


### PR DESCRIPTION
Added an ID fields to variables, using uuid to get unique id's.
Naming stays the same, for display/print reasons.
When posting to the solver I decided to use name + id because
- it will still be unique
- minizinc names have to start with a letter, this ensures that and makes it consistent for all solvers
- might make debugging easier as the var name is still part of the solver var name

Let me know if you think this is silly.