### PR TITLE
circumvent gurobi integer division to match cpmpy floordivision

### DIFF
--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -337,11 +337,13 @@ class CPM_gurobi(SolverInterface):
                     #integer division is not the same as floordivision, so we need to use continuous variables
                     cont_a = self.grb_model.addVar(x.lb, x.ub, vtype=GRB.CONTINUOUS, name=str(x.name) + '_cont')
                     cont_rhs = self.grb_model.addVar(rhs.lb, rhs.ub, vtype=GRB.CONTINUOUS, name=str(rhs.name) + '_cont')
+                    abs_rhs = self.grb_model.addVar(rhs.lb, rhs.ub, vtype=GRB.CONTINUOUS, name=str(rhs.name) + '_cont_abs')
                     self.grb_model.addLConstr(cont_a/b, GRB.EQUAL, cont_rhs)
                     self.grb_model.addConstr(cont_a == a)
-                    #grbrhs is the result of integer division, so it's the rounded down version of cont_rhs
-                    self.grb_model.addLConstr(cont_rhs - grbrhs, GRB.LESS_EQUAL, 0.999999) #closest we can get to 1
-                    self.grb_model.addLConstr(grbrhs - cont_rhs, GRB.LESS_EQUAL, 0)
+                    #grbrhs is the result of integer division, so it's the rounded towards 0 version of cont_rhs
+                    self.grb_model.addGenConstrAbs(abs_rhs, cont_rhs)
+                    self.grb_model.addLConstr(abs_rhs - grbrhs, GRB.LESS_EQUAL, 0.99999) #closest we can get to 1
+                    self.grb_model.addLConstr(grbrhs - abs_rhs, GRB.LESS_EQUAL, 0)
 
                 else:
                     # General constraints

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -332,8 +332,16 @@ class CPM_gurobi(SolverInterface):
 
                 elif lhs.name == 'div':
                     assert is_num(lhs.args[1]), "Gurobi only supports division by constants"
+                    x = lhs.args[0]
                     a, b = self.solver_vars(lhs.args)
-                    self.grb_model.addLConstr(a / b, GRB.EQUAL, grbrhs)
+                    #integer division is not the same as floordivision, so we need to use continuous variables
+                    cont_a = self.grb_model.addVar(x.lb, x.ub, vtype=GRB.CONTINUOUS, name=str(x.name) + '_cont')
+                    cont_rhs = self.grb_model.addVar(rhs.lb, rhs.ub, vtype=GRB.CONTINUOUS, name=str(rhs.name) + '_cont')
+                    self.grb_model.addLConstr(cont_a/b, GRB.EQUAL, cont_rhs)
+                    self.grb_model.addConstr(cont_a == a)
+                    #grbrhs is the result of integer division, so it's the rounded down version of cont_rhs
+                    self.grb_model.addLConstr(cont_rhs - grbrhs, GRB.LESS_EQUAL, 0.999999) #closest we can get to 1
+                    self.grb_model.addLConstr(grbrhs - cont_rhs, GRB.LESS_EQUAL, 0)
 
                 else:
                     # General constraints

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -555,3 +555,14 @@ class TestSolvers(unittest.TestCase):
         s = cp.SolverLookup.get("gurobi", model)
         self.assertTrue(s.solve())
         self.assertTrue(iv.value()[idx.value(), idx2.value()] == 8)
+
+    @pytest.mark.skipif(not CPM_gurobi.supported(),
+                        reason="Gurobi not installed")
+    def test_gurobi_element(self):
+        iv = cp.intvar(-1, 3, shape=3)
+        x1 = cp.intvar(0, 3, name="x1")
+        cons = [x1 // 2 == iv, x1 > 0]
+        m = cp.Model(cons)
+        self.assertEqual(m.solveAll('gurobi', solution_limit=90),m.solveAll)
+        print('___')
+        Model(cons).solveAll(display=[x1, iv])


### PR DESCRIPTION
There does not seem to be floordivision in gurobi, so I implemented a workaround using continuous (gurobi) variables.

