### PR TITLE
Solution hinting fix, when giving N-D variables and values

### DIFF
--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -588,6 +588,15 @@ class CPM_exact(SolverInterface):
         :param cpm_vars: list of CPMpy variables
         :param vals: list of (corresponding) values for the variables
         """
+
+        if not hasattr(cpm_vars, "flat"):
+            cpm_vars = np.array(cpm_vars)
+        cpm_vars=cpm_vars.flat
+
+        if not hasattr(vals, "flat"):
+            vals = np.array(vals)
+        vals=vals.flat
+        
         try:
             pkg_resources.require("exact>=1.1.5")
             self.xct_solver.setSolutionHints(self.solver_vars(cpm_vars), vals)

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -592,9 +592,8 @@ class CPM_exact(SolverInterface):
         """
 
         cpm_vars = flatlist(cpm_vars)
-
         vals = flatlist(vals)
-        
+        assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
         try:
             pkg_resources.require("exact>=1.1.5")
             self.xct_solver.setSolutionHints(self.solver_vars(cpm_vars), vals)

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -37,6 +37,8 @@ from ..transformations.reification import only_bv_implies, reify_rewrite
 from ..transformations.normalize import toplevel_list
 from ..expressions.globalconstraints import DirectConstraint
 from ..exceptions import NotSupportedError
+from ..expressions.utils import flatlist
+
 import numpy as np
 import numbers
 
@@ -589,13 +591,9 @@ class CPM_exact(SolverInterface):
         :param vals: list of (corresponding) values for the variables
         """
 
-        if not hasattr(cpm_vars, "flat"):
-            cpm_vars = np.array(cpm_vars)
-        cpm_vars=cpm_vars.flat
+        cpm_vars = flatlist(cpm_vars)
 
-        if not hasattr(vals, "flat"):
-            vals = np.array(vals)
-        vals=vals.flat
+        vals = flatlist(vals)
         
         try:
             pkg_resources.require("exact>=1.1.5")

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -32,7 +32,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.globalconstraints import DirectConstraint
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, boolvar
 from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.utils import is_num, is_any_list, eval_comparison
+from ..expressions.utils import is_num, is_any_list, eval_comparison, flatlist
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective
@@ -521,13 +521,9 @@ class CPM_ortools(SolverInterface):
         """
         self.ort_model.ClearHints() # because add just appends
 
-        if not hasattr(cpm_vars, "flat"):
-            cpm_vars = np.array(cpm_vars)
-        cpm_vars=cpm_vars.flat
+        cpm_vars = flatlist(cpm_vars)
 
-        if not hasattr(vals, "flat"):
-            vals = np.array(vals)
-        vals=vals.flat
+        vals = flatlist(vals)
 
         assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -521,15 +521,13 @@ class CPM_ortools(SolverInterface):
         """
         self.ort_model.ClearHints() # because add just appends
 
-        if hasattr(cpm_vars, "flat"):
-            cpm_vars= cpm_vars.flat
-        else:
-            cpm_vars = np.concatenate(cpm_vars).flat
+        if not hasattr(cpm_vars, "flat"):
+            cpm_vars = np.array(cpm_vars)
+        cpm_vars=cpm_vars.flat
 
-        if hasattr(vals, "flat"):
-            vals = vals.flat
-        else:
-            vals = np.concatenate(vals).flat
+        if not hasattr(vals, "flat"):
+            vals = np.array(vals)
+        vals=vals.flat
 
         assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -520,6 +520,19 @@ class CPM_ortools(SolverInterface):
         :param vals: list of (corresponding) values for the variables
         """
         self.ort_model.ClearHints() # because add just appends
+
+        if hasattr(cpm_vars, "flat"):
+            cpm_vars= cpm_vars.flat
+        else:
+            cpm_vars = np.concatenate(cpm_vars).flat
+
+        if hasattr(vals, "flat"):
+            vals = vals.flat
+        else:
+            vals = np.concatenate(vals).flat
+
+        assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
+
         for (cpm_var, val) in zip(cpm_vars, vals):
             self.ort_model.AddHint(self.solver_var(cpm_var), val)
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -522,11 +522,8 @@ class CPM_ortools(SolverInterface):
         self.ort_model.ClearHints() # because add just appends
 
         cpm_vars = flatlist(cpm_vars)
-
         vals = flatlist(vals)
-
         assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
-
         for (cpm_var, val) in zip(cpm_vars, vals):
             self.ort_model.AddHint(self.solver_var(cpm_var), val)
 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -314,6 +314,15 @@ class CPM_pysat(SolverInterface):
         :param cpm_vars: list of CPMpy variables
         :param vals: list of (corresponding) values for the variables
         """
+
+        if not hasattr(cpm_vars, "flat"):
+            cpm_vars = np.array(cpm_vars)
+        cpm_vars=cpm_vars.flat
+
+        if not hasattr(vals, "flat"):
+            vals = np.array(vals)
+        vals=vals.flat
+
         literals = []
         for (cpm_var, val) in zip(cpm_vars, vals):
             lit = self.solver_var(cpm_var)

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -317,8 +317,8 @@ class CPM_pysat(SolverInterface):
         """
 
         cpm_vars = flatlist(cpm_vars)
-
         vals = flatlist(vals)
+        assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
 
         literals = []
         for (cpm_var, val) in zip(cpm_vars, vals):

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -34,7 +34,7 @@ from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.variables import _BoolVarImpl, NegBoolView, boolvar
 from ..expressions.globalconstraints import DirectConstraint
-from ..expressions.utils import is_any_list, is_int
+from ..expressions.utils import is_any_list, is_int, flatlist
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint
@@ -316,13 +316,9 @@ class CPM_pysat(SolverInterface):
         :param vals: list of (corresponding) values for the variables
         """
 
-        if not hasattr(cpm_vars, "flat"):
-            cpm_vars = np.array(cpm_vars)
-        cpm_vars=cpm_vars.flat
+        cpm_vars = flatlist(cpm_vars)
 
-        if not hasattr(vals, "flat"):
-            vals = np.array(vals)
-        vals=vals.flat
+        vals = flatlist(vals)
 
         literals = []
         for (cpm_var, val) in zip(cpm_vars, vals):

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -34,7 +34,7 @@ from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.variables import _BoolVarImpl, NegBoolView, boolvar
 from ..expressions.globalconstraints import DirectConstraint
-from ..expressions.utils import is_any_list, is_int, flatlist
+from ..expressions.utils import is_int, flatlist
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -40,6 +40,7 @@ from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint
 from ..transformations.normalize import toplevel_list
 from ..transformations.reification import only_bv_implies
+import numpy as np
 
 class CPM_pysat(SolverInterface):
     """

--- a/tests/test_solvers_solhint.py
+++ b/tests/test_solvers_solhint.py
@@ -32,6 +32,9 @@ class TestSolutionHinting(unittest.TestCase):
                 slv.solution_hint([a,b], [True,True])
                 self.assertTrue(slv.solve(**args)) # should also work with an UNSAT hint
 
+                slv.solution_hint([a,[b]], [[[False]], True]) # check nested lists
+                self.assertTrue(slv.solve(**args))
+
             except NotSupportedError:
                 continue
 


### PR DESCRIPTION
Connected to issue #407 

Flattening the variables and values first, before moving to the for loop of adding the hints.

Covering cases that vars and values are NDVarArrays, ndarrays or anything that has a .flat attribute + cases that the user may give lists for hinting.