### PR TITLE
Canonical_comparison and only_bv_reifies

### DIFF
--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -33,7 +33,7 @@ from ..transformations.flatten_model import flatten_constraint, flatten_objectiv
 from ..transformations.get_variables import get_variables
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.linearize import linearize_constraint, only_positive_bv
-from ..transformations.reification import only_bv_implies, reify_rewrite
+from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.normalize import toplevel_list
 from ..expressions.globalconstraints import DirectConstraint
 from ..exceptions import NotSupportedError
@@ -407,7 +407,8 @@ class CPM_exact(SolverInterface):
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]))  # supports >, <, !=
-        cpm_cons = only_bv_implies(cpm_cons)  # anything that can create full reif should go above...
+        cpm_cons = only_bv_reifies(cpm_cons)
+        cpm_cons = only_implies(cpm_cons)  # anything that can create full reif should go above...
         cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum","wsum"}))  # the core of the MIP-linearization
         cpm_cons = only_positive_bv(cpm_cons)  # after linearisation, rewrite ~bv into 1-bv
         return cpm_cons
@@ -481,7 +482,7 @@ class CPM_exact(SolverInterface):
 
         # transform and post the constraints
         for cpm_expr in self.transform(cpm_expr_orig):
-            # Comparisons: only numeric ones as 'only_bv_implies()' has removed the '==' reification for Boolean expressions
+            # Comparisons: only numeric ones as 'only_implies()' has removed the '==' reification for Boolean expressions
             # numexpr `comp` bvar|const
             if isinstance(cpm_expr, Comparison):
                 lhs, rhs = cpm_expr.args

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -36,7 +36,7 @@ from ..transformations.flatten_model import flatten_constraint, flatten_objectiv
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, only_positive_bv
 from ..transformations.normalize import toplevel_list
-from ..transformations.reification import only_bv_implies, reify_rewrite
+from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 
 try:
     import gurobipy as gp
@@ -273,7 +273,8 @@ class CPM_gurobi(SolverInterface):
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=
-        cpm_cons = only_bv_implies(cpm_cons)  # anything that can create full reif should go above...
+        cpm_cons = only_bv_reifies(cpm_cons)
+        cpm_cons = only_implies(cpm_cons)  # anything that can create full reif should go above...
         cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum", "wsum","sub","min","max","mul","abs","pow","div"}))  # the core of the MIP-linearization
         cpm_cons = only_positive_bv(cpm_cons)  # after linearization, rewrite ~bv into 1-bv
         return cpm_cons
@@ -304,7 +305,7 @@ class CPM_gurobi(SolverInterface):
       # transform and post the constraints
       for cpm_expr in self.transform(cpm_expr_orig):
 
-        # Comparisons: only numeric ones as 'only_bv_implies()' has removed the '==' reification for Boolean expressions
+        # Comparisons: only numeric ones as 'only_implies()' has removed the '==' reification for Boolean expressions
         # numexpr `comp` bvar|const
         if isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -73,7 +73,6 @@ class CPM_minizinc(SolverInterface):
     @staticmethod
     def supported():
         # try to import the package
-        return False
         try:
             import minizinc
             return True

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -73,6 +73,7 @@ class CPM_minizinc(SolverInterface):
     @staticmethod
     def supported():
         # try to import the package
+        return False
         try:
             import minizinc
             return True

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -37,7 +37,7 @@ from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective
 from ..transformations.normalize import toplevel_list
-from ..transformations.reification import only_bv_implies, reify_rewrite
+from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.comparison import only_numexpr_equality
 
 class CPM_ortools(SolverInterface):
@@ -334,7 +334,8 @@ class CPM_ortools(SolverInterface):
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=
-        cpm_cons = only_bv_implies(cpm_cons) # everything that can create
+        cpm_cons = only_bv_reifies(cpm_cons)
+        cpm_cons = only_implies(cpm_cons)  # everything that can create
                                              # reified expr must go before this
         return cpm_cons
 
@@ -408,7 +409,7 @@ class CPM_ortools(SolverInterface):
                 raise NotImplementedError("Not a known supported ORTools Operator '{}' {}".format(
                         cpm_expr.name, cpm_expr))
 
-        # Comparisons: only numeric ones as the `only_bv_implies()` transformation
+        # Comparisons: only numeric ones as the `only_implies()` transformation
         # has removed the '==' reification for Boolean expressions
         # numexpr `comp` bvar|const
         elif isinstance(cpm_expr, Comparison):

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -39,7 +39,8 @@ from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint
 from ..transformations.normalize import toplevel_list
-from ..transformations.reification import only_bv_implies
+from ..transformations.reification import only_implies, only_bv_reifies
+
 
 class CPM_pysat(SolverInterface):
     """
@@ -230,7 +231,8 @@ class CPM_pysat(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = decompose_in_tree(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)
-        cpm_cons = only_bv_implies(cpm_cons)
+        cpm_cons = only_bv_reifies(cpm_cons)
+        cpm_cons = only_implies(cpm_cons)
         return cpm_cons
 
     def __add__(self, cpm_expr_orig):
@@ -258,7 +260,7 @@ class CPM_pysat(SolverInterface):
         if cpm_expr.name == 'or':
             self.pysat_solver.add_clause(self.solver_vars(cpm_expr.args))
 
-        elif cpm_expr.name == '->':  # BV -> BE only thanks to only_bv_implies
+        elif cpm_expr.name == '->':  # BV -> BE only thanks to only_bv_reifies
             a0,a1 = cpm_expr.args
 
             # BoolVar() -> BoolVar()

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -277,10 +277,10 @@ def canonical_comparison(lst_of_expr):
                 elif isinstance(rhs, Operator) and rhs.name == "sum":
                     if isinstance(lhs, Operator) and lhs.name == "sum":
                         lhs, rhs = sum([1 * a for a in lhs.args] + [-1 * b for b in rhs.args
-                                    if isinstance(b, _NumVarImpl)]), sum(b for b in rhs.args if is_num(b))
+                                    if (isinstance(b, _NumVarImpl) or isinstance(b, Operator))]), sum(b for b in rhs.args if is_num(b))
                     elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
                         lhs, rhs = lhs + [-1 * b for b in rhs.args
-                                    if isinstance(b, _NumVarImpl)], sum(b for b in rhs.args if is_num(b))
+                                    if (isinstance(b, _NumVarImpl) or isinstance(b, Operator))], sum(b for b in rhs.args if is_num(b))
                 elif isinstance(rhs, Operator) and rhs.name == "wsum":
                     if isinstance(lhs, Operator) and lhs.name == "sum":
                         lhs, rhs = sum([1 * a for a in lhs.args] + [-a * b for a, b in zip(rhs.args[0], rhs.args[1])

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -108,52 +108,22 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum"}, reified=False):
             if lhs.name == "sub":
                 # convert to wsum
                 lhs = sum([1 * lhs.args[0] + -1 * lhs.args[1]])
+                cpm_expr = eval_comparison(cpm_expr.name, lhs, rhs)
 
             # linearize unsupported operators
             elif isinstance(lhs, Operator) and lhs.name not in supported: # TODO: add mul, (abs?), (mod?), (pow?)
 
                 if lhs.name == "mul" and is_num(lhs.args[0]):
                     lhs = Operator("wsum",[[lhs.args[0]], [lhs.args[1]]])
+                    cpm_expr = eval_comparison(cpm_expr.name, lhs, rhs)
                 else:
                     raise TransformationNotImplementedError(f"lhs of constraint {cpm_expr} cannot be linearized, should be any of {supported | set(['sub'])} but is {lhs}. Please report on github")
 
             elif isinstance(lhs, GlobalConstraint) and lhs.name not in supported:
                 raise ValueError("Linearization of `lhs` not supported, run `cpmpy.transformations.decompose_global.decompose_global() first")
 
-            if is_num(lhs) or isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name in {"sum","wsum"}):
-                # bring all vars to lhs
-                if isinstance(rhs, _NumVarImpl):
-                    if isinstance(lhs, Operator) and lhs.name == "sum":
-                        lhs, rhs = sum([1 * a for a in lhs.args]+[-1 * rhs]), 0
-                    elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
-                        lhs, rhs = lhs + -1*rhs, 0
-                    else:
-                        raise ValueError(f"unexpected expression on lhs of expression, should be sum,wsum or intvar but got {lhs}")
-
-                assert not is_num(lhs), "lhs cannot be an integer at this point!"
-                # bring all const to rhs
-                if lhs.name == "sum":
-                    new_args = []
-                    for i, arg in enumerate(lhs.args):
-                        if is_num(arg):
-                            rhs -= arg
-                        else:
-                            new_args.append(arg)
-                    lhs = Operator("sum", new_args)
-
-                elif lhs.name == "wsum":
-                    new_weights, new_args = [],[]
-                    for i, (w, arg) in enumerate(zip(*lhs.args)):
-                        if is_num(arg):
-                            rhs -= w * arg
-                        else:
-                            new_weights.append(w)
-                            new_args.append(arg)
-                    lhs = Operator("wsum",[new_weights, new_args])
-
-            if isinstance(lhs, Operator) and lhs.name == "mul" and len(lhs.args) == 2 and is_num(lhs.args[0]):
-                # convert to wsum
-                lhs = Operator("wsum",[[lhs.args[0]],[lhs.args[1]]])
+            [cpm_expr] = canonical_comparison([cpm_expr])  # just transforms the constraint, not introducing new ones
+            lhs, rhs = cpm_expr.args
 
             # now fix the comparisons themselves
             if cpm_expr.name == "<":
@@ -280,5 +250,52 @@ def only_positive_bv(lst_of_expr):
 
         else:
             raise Exception(f"{cpm_expr} is not linear or is not supported. Please report on github")
+
+    return newlist
+
+def canonical_comparison(lst_of_expr):
+
+    newlist = []
+    for cpm_expr in lst_of_expr:
+
+        if isinstance(cpm_expr, Comparison):
+            lhs, rhs = cpm_expr.args
+
+            if is_num(lhs) or isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name in {"sum", "wsum"}):
+                # bring all vars to lhs
+                if isinstance(rhs, _NumVarImpl):
+                    if isinstance(lhs, Operator) and lhs.name == "sum":
+                        lhs, rhs = sum([1 * a for a in lhs.args] + [-1 * rhs]), 0
+                    elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
+                        lhs, rhs = lhs + -1 * rhs, 0
+                    else:
+                        raise ValueError(
+                            f"unexpected expression on lhs of expression, should be sum,wsum or intvar but got {lhs}")
+
+                assert not is_num(lhs), "lhs cannot be an integer at this point!"
+
+                # bring all const to rhs
+                if lhs.name == "sum":
+                    new_args = []
+                    for i, arg in enumerate(lhs.args):
+                        if is_num(arg):
+                            rhs -= arg
+                        else:
+                            new_args.append(arg)
+                    lhs = Operator("sum", new_args)
+
+                elif lhs.name == "wsum":
+                    new_weights, new_args = [], []
+                    for i, (w, arg) in enumerate(zip(*lhs.args)):
+                        if is_num(arg):
+                            rhs -= w * arg
+                        else:
+                            new_weights.append(w)
+                            new_args.append(arg)
+                    lhs = Operator("wsum", [new_weights, new_args])
+
+            newlist.append(eval_comparison(cpm_expr.name, lhs, rhs))
+        else:
+            newlist.append(cpm_expr)
 
     return newlist

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -264,34 +264,28 @@ def canonical_comparison(lst_of_expr):
         if isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args
 
-            # bring all vars to lhs
             if is_num(lhs) or isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name in {"sum", "wsum"}):
+                # bring all vars to lhs
+                lhs2 = []
                 if isinstance(rhs, _NumVarImpl):
-                    if isinstance(lhs, Operator) and lhs.name == "sum":
-                        lhs, rhs = sum([1 * a for a in lhs.args] + [-1 * rhs]), 0
-                    elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
-                        lhs, rhs = lhs + -1 * rhs, 0
-                    else:
-                        raise ValueError(
-                            f"unexpected expression on lhs of expression, should be sum,wsum or intvar but got {lhs}")
+                    lhs2, rhs = [-1 * rhs], 0
                 elif isinstance(rhs, Operator) and rhs.name == "sum":
-                    if isinstance(lhs, Operator) and lhs.name == "sum":
-                        lhs, rhs = sum([1 * a for a in lhs.args] + [-1 * b for b in rhs.args
-                                    if (isinstance(b, _NumVarImpl) or isinstance(b, Operator))]), sum(b for b in rhs.args if is_num(b))
-                    elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
-                        lhs, rhs = lhs + [-1 * b for b in rhs.args
-                                    if (isinstance(b, _NumVarImpl) or isinstance(b, Operator))], sum(b for b in rhs.args if is_num(b))
+                    lhs2, rhs = [-1 * b if isinstance(b, _NumVarImpl) else 1 * b for b in rhs.args
+                                 if isinstance(b, _NumVarImpl) or isinstance(b, Operator)], \
+                                 sum(b for b in rhs.args if is_num(b))
                 elif isinstance(rhs, Operator) and rhs.name == "wsum":
-                    if isinstance(lhs, Operator) and lhs.name == "sum":
-                        lhs, rhs = sum([1 * a for a in lhs.args] + [-a * b for a, b in zip(rhs.args[0], rhs.args[1])
-                                    if isinstance(b, _NumVarImpl)]), \
-                                   sum(-a * b for a, b in zip(rhs.args[0], rhs.args[1])
-                                     if not isinstance(b, _NumVarImpl))
-                    elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
-                        lhs, rhs = lhs + sum([-a * b for a, b in zip(rhs.args[0], rhs.args[1])
-                                    if isinstance(b, _NumVarImpl)]), \
-                                   sum(-a * b for a, b in zip(rhs.args[0], rhs.args[1])
+                    lhs2, rhs = [-a * b for a, b in zip(rhs.args[0], rhs.args[1])
+                                    if isinstance(b, _NumVarImpl)], \
+                                    sum(-a * b for a, b in zip(rhs.args[0], rhs.args[1])
                                     if not isinstance(b, _NumVarImpl))
+
+                if isinstance(lhs, Operator) and lhs.name == "sum":
+                    lhs, rhs = sum([1 * a for a in lhs.args] + lhs2), rhs
+                elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):
+                    lhs, rhs = lhs + lhs2, rhs
+                else:
+                    raise ValueError(
+                        f"unexpected expression on lhs of expression, should be sum,wsum or intvar but got {lhs}")
 
                 assert not is_num(lhs), "lhs cannot be an integer at this point!"
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -270,7 +270,7 @@ def canonical_comparison(lst_of_expr):
                 if isinstance(rhs, _NumVarImpl):
                     lhs2, rhs = [-1 * rhs], 0
                 elif isinstance(rhs, Operator) and rhs.name == "sum":
-                    lhs2, rhs = [-1 * b if isinstance(b, _NumVarImpl) else 1 * b for b in rhs.args
+                    lhs2, rhs = [-1 * b if isinstance(b, _NumVarImpl) else 1 * b.args[0] for b in rhs.args
                                  if isinstance(b, _NumVarImpl) or isinstance(b, Operator)], \
                                  sum(b for b in rhs.args if is_num(b))
                 elif isinstance(rhs, Operator) and rhs.name == "wsum":
@@ -278,7 +278,6 @@ def canonical_comparison(lst_of_expr):
                                     if isinstance(b, _NumVarImpl)], \
                                     sum(-a * b for a, b in zip(rhs.args[0], rhs.args[1])
                                     if not isinstance(b, _NumVarImpl))
-
                 if isinstance(lhs, Operator) and lhs.name == "sum":
                     lhs, rhs = sum([1 * a for a in lhs.args] + lhs2), rhs
                 elif isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name == "wsum"):

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -19,7 +19,8 @@ from .negation import recurse_negation
   Using logical operations, they can be decomposed and rewritten to each other.
 
   This file implements:
-    - only_bv_implies():    transforms all reifications to BV -> BE form
+    - only_bv_reifies():    transforms all reifications to BV -> BE or BV == BE
+    - only_implies():       transforms all reifications to BV -> BE form
     - reify_rewrite():      rewrites reifications not supported by a solver to ones that are
 """
 
@@ -32,7 +33,8 @@ def only_bv_reifies(constraints):
                     isinstance(a1, _BoolVarImpl):
                 # BE -> BV :: ~BV -> ~BE
                 if cpm_expr.name == '->':
-                    newexpr = [(~a1).implies(recurse_negation(a0))]
+                    newexpr = (~a1).implies(recurse_negation(a0))
+                    newexpr = only_bv_reifies(flatten_constraint(newexpr))
                 else:
                     newexpr = [a1 == a0]  # BE == BV :: BV == BE
                     if not a0.is_bool():
@@ -44,19 +46,20 @@ def only_bv_reifies(constraints):
             newcons.append(cpm_expr)
     return newcons
 
-def only_bv_implies(constraints):
+def only_implies(constraints):
     """
         Transforms all reifications to BV -> BE form
 
         More specifically:
-            BE -> BV :: ~BV -> ~BE
-            BE == BV :: ~BV -> ~BE, BV -> BE
+            BV0 -> BV2 == BV3 :: BV0 -> (BV2->BV3 & BV3->BV2)
+                              :: BV0 -> (BV2->BV3) & BV0 -> (BV3->BV2)
+                              :: BV0 -> (~BV2|BV3) & BV0 -> (~BV3|BV2)
+            BV == BE :: ~BV -> ~BE, BV -> BE
 
-        Assumes all constraints are in 'flat normal form'. Hence only apply
-        AFTER `flatten()`
+        Assumes all constraints are in 'flat normal form' and all reifications have a variable in lhs. Hence, only apply
+        AFTER `flatten()` and 'only_bv_reifies()'.
     """
     newcons = []
-    constraints = flatten_constraint(only_bv_reifies(constraints))
 
     for cpm_expr in constraints:
         # Operators: check BE -> BV
@@ -69,11 +72,11 @@ def only_bv_implies(constraints):
                 #                   :: BV0 -> (~BV2|BV3) & BV0 -> (~BV3|BV2)
                 bv2,bv3 = a1.args
                 newexpr = [a0.implies(~bv2|bv3), a0.implies(~bv3|bv2)]
-                newcons.extend(only_bv_implies(flatten_constraint(newexpr)))
+                newcons.extend(only_implies(flatten_constraint(newexpr)))
             else:
                 newcons.append(cpm_expr)
 
-        # Comparisons: check BE == BV
+        # Comparisons: transform bV == BE
         elif cpm_expr.name == '==' and cpm_expr.args[0].is_bool():
             a0,a1 = cpm_expr.args
             if isinstance(a0, _BoolVarImpl) and isinstance(a1, _BoolVarImpl):
@@ -85,12 +88,12 @@ def only_bv_implies(constraints):
                 # then it is actually an integer expression, keep
                 newcons.append(cpm_expr)
             else:
-                # BE0 == BVar1 :: ~BVar1 -> ~BE0, BVar1 -> BE0
-                newexprs = ((~a1).implies(recurse_negation(a0)), a1.implies(a0))
-                if isinstance(a0, GlobalConstraint):
+                # BVar1 == BE0 :: ~BVar1 -> ~BE0, BVar1 -> BE0
+                newexprs = ((~a0).implies(recurse_negation(a1)), a0.implies(a1))
+                if isinstance(a1, GlobalConstraint):
                     newcons.extend(newexprs)
                 else:
-                    newcons.extend(only_bv_implies(flatten_constraint(newexprs)))
+                    newcons.extend(only_implies(only_bv_reifies(flatten_constraint(newexprs))))
         else:
             # all other flat normal form expressions are fine
             newcons.append(cpm_expr)

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -1,6 +1,6 @@
 from ..expressions.core import Operator, Comparison
 from ..expressions.variables import _BoolVarImpl, NegBoolView
-from .reification import only_bv_implies
+from .reification import only_implies
 from .flatten_model import flatten_constraint
 """
   Converts the logical constraints into disjuctions using the tseitin transform,
@@ -32,7 +32,7 @@ def to_cnf(constraints):
         - supported: (frozen)set of global constraint names that do not need to be decomposed
     """
     fnf = flatten_constraint(constraints)
-    fnf = only_bv_implies(fnf)
+    fnf = only_implies(fnf)
     return flat2cnf(fnf)
 
 def flat2cnf(constraints):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -3,7 +3,7 @@ import unittest
 import cpmpy as cp
 from cpmpy.expressions import boolvar, intvar
 from cpmpy.expressions.core import Operator
-from cpmpy.transformations.linearize import linearize_constraint
+from cpmpy.transformations.linearize import linearize_constraint, canonical_comparison
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
 
 
@@ -189,4 +189,64 @@ class TestVarsLhs(unittest.TestCase):
         cons = linearize_constraint(cons, supported={"alldifferent"})[0]
         self.assertEqual("alldifferent(a,b,c)", str(cons))
 
+class testCanonical_comparison(unittest.TestCase):
+    def test_sum(self):
+        a,b,c = [cp.intvar(0,10,name=n) for n in "abc"]
+        rhs = 5
+
+        cons = canonical_comparison([cp.sum([a,b,c,10]) <= rhs])[0]
+        self.assertEqual("sum([a, b, c]) <= -5", str(cons))
+
+        rhs = cp.sum([b,c])
+        cons = canonical_comparison([cp.sum([a, b]) <= rhs])[0]
+        self.assertEqual("sum([1, 1, -1, -1] * [a, b, b, c]) <= 0", str(cons))
+
+    def test_div(self):
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = 5
+
+        cons = canonical_comparison([ a / b <= rhs])[0]
+        self.assertEqual("(a) // (b) <= 5", str(cons))
+
+        #when adding division
+        #cons = canonical_comparison([a / b <= c / rhs])[0]
+        #cons = canonical_comparison([a + b <= c/rhs])[0]
+
+
+    def test_wsum(self):
+        a, b, c = [cp.intvar(0, 10,name=n) for n in "abc"]
+        rhs = 5
+
+        cons = [Operator("wsum",[[1,2,3,-1],[a,b,c,10]]) <= rhs]
+        cons = canonical_comparison(cons)[0]
+        self.assertEqual("sum([1, 2, 3] * [a, b, c]) <= 15", str(cons))
+
+    def test_impl(self):
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = 5
+        cond = cp.boolvar(name="bv")
+
+        cons = [cond.implies(Operator("wsum",[[1,2,3,-1],[a,b,c,10]]) <= rhs)]
+        cons = canonical_comparison(cons)[0]
+        #if we make canonical comparison recursive:
+        #self.assertEqual("(bv) -> (sum([1, 2, 3] * [a, b, c]) <= 15)", str(cons))
+        self.assertEqual("(bv) -> (sum([1, 2, 3, -1] * [a, b, c, 10]) <= 5)", str(cons))
+
+        cons = [(~cond).implies(Operator("wsum",[[1,2,3,-1],[a,b,c,10]]) <= rhs)]
+        cons = canonical_comparison(cons)[0]
+        #recursive: self.assertEqual("(~bv) -> (sum([1, 2, 3] * [a, b, c]) <= 15)", str(cons))
+        self.assertEqual("(~bv) -> (sum([1, 2, 3, -1] * [a, b, c, 10]) <= 5)", str(cons))
+
+    def test_others(self):
+
+        a, b, c = [cp.intvar(0, 10, name=n) for n in "abc"]
+        rhs = intvar(0, 10, name="r")
+
+        cons = [cp.max([a,b,c,5]) <= rhs]
+        cons = canonical_comparison(cons)[0]
+        self.assertEqual("(max(a,b,c,5)) <= (r)", str(cons))
+
+        cons = [cp.AllDifferent([a, b, c])]
+        cons = canonical_comparison(cons)[0]
+        self.assertEqual("alldifferent(a,b,c)", str(cons))
 

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -12,26 +12,6 @@ class TestTransfReif(unittest.TestCase):
         _IntVarImpl.counter = 0
         _BoolVarImpl.counter = 0
 
-    def test_only_bv_implies(self):
-        a,b,c = [boolvar(name=n) for n in "abc"]
-        
-        cases = [((a).implies(b), "[(a) -> (b)]"),
-                 ((~a).implies(b), "[(~a) -> (b)]"),
-                 ((a).implies(b|c), "[(a) -> ((b) or (c))]"),
-                 ((a).implies(b&c), "[(a) -> ((b) and (c))]"),
-                 ((b|c).implies(a), "[(~a) -> (~b), (~a) -> (~c)]"),
-                 ((b&c).implies(a), "[(~a) -> ((~b) or (~c))]"),
-                 ((a)==(b), "[(a) -> (b), (b) -> (a)]"),
-                 ((~a)==(b), "[(~a) -> (b), (b) -> (~a)]"),
-                 ((b|c)==(a), "[(~a) -> (~b), (~a) -> (~c), (a) -> ((b) or (c))]"),
-                 ((b&c)==(a), "[(~a) -> ((~b) or (~c)), (a) -> (b), (a) -> (c)]"),
-                ]
-
-        # test transformation
-        for (expr, strexpr) in cases:
-            self.assertEqual( str(only_bv_implies((expr,))), strexpr )
-            self.assertTrue(Model(expr).solve())
-
     def test_reif_element(self):
         bvs = boolvar(shape=5, name="bvs")
         iv = intvar(1,10, name="iv")

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -4,7 +4,7 @@ from cpmpy import *
 from cpmpy.transformations.decompose_global import decompose_in_tree
 from cpmpy.transformations.get_variables import get_variables
 from cpmpy.transformations.flatten_model import flatten_constraint
-from cpmpy.transformations.reification import only_bv_implies, reify_rewrite
+from cpmpy.transformations.reification import only_implies, reify_rewrite
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl # to reset counters
 
 class TestTransfReif(unittest.TestCase):


### PR DESCRIPTION
2 new transformations, based on work done while adding choco:

canonical_comparison: all num expressions converted in canonical form (variables left side, constant right side), This was done inside linearize before, but as choco also needs it, it is now a seperate transformation, which is also called inside linearize.

only_bv_reifies:  the bool var is sent to the left part and the boolexpr to the right part in reifications. This was done in only_bv_implies, which also converted complete reifications to 2 implications. I splitted the 2 parts, as the first one is needed in Choco, while the second one noe (it supports complete reification). First thought was to put it reify_rewrite(), but pysat doesn't need the additional stuff happening there, while it needs only_bv_implies.

Also, as now only_bv_implies is only assuring that there are no "==" and transforms them to implications, it is renamed to only_implies.