### PR TITLE
no distributivity in flatten_model.py

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -158,18 +158,6 @@ def flatten_constraint(expr):
                     # there could be nested implications
                     newlist.extend(flatten_constraint(Operator('or', newargs)))
                     continue
-                else:
-                    # check if disjunction contains conjunctions, and if so split out
-                    newexprs = None
-                    for i,a in enumerate(expr.args):
-                        if isinstance(a, Operator) and a.name == 'and':
-                            # can avoid aux var creation by splitting over the and
-                            newexprs = [Operator("or", expr.args[:i]+[e]+expr.args[i+1:]) for e in a.args]
-                            break
-                    if newexprs is not None:
-                        newlist.extend(flatten_constraint(newexprs))
-                        continue
-
             elif expr.name == '->':
                 # some rewrite rules that avoid creating auxiliary variables
                 # 1) if rhs is 'and', split into individual implications a0->and([a11..a1n]) :: a0->a11,...,a0->a1n

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -158,6 +158,9 @@ def flatten_constraint(expr):
                     # there could be nested implications
                     newlist.extend(flatten_constraint(Operator('or', newargs)))
                     continue
+                # conjunctions in disjunctions could be split out by applying distributivity,
+                # but this would explode the number of constraints in favour of having less auxiliary variables.
+                # Testing has proven that this is not worth it.
             elif expr.name == '->':
                 # some rewrite rules that avoid creating auxiliary variables
                 # 1) if rhs is 'and', split into individual implications a0->and([a11..a1n]) :: a0->a11,...,a0->a1n


### PR DESCRIPTION
After extensive testing on the distributivity rule for conjunctions in disjunctions I came to the following conclusion:

- In almost all of our used benchmarks this does not have any impact.
- It seems only to be positive in very small instances where the effect is therefor minimal. I tried to construct cases where it gives big benefit but I was unable to do so.
- It is very easy to construct cases where it is orders of magnitude worse than not applying distributivity, making simple problems infeasible.

Since there aren't really any cases where it is worth to do, I would just remove this code in stead of looking for a heuristic of when to apply it.
