### PR TITLE
get_bounds() for arrays

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -570,7 +570,7 @@ class Operator(Expression):
             bounds = [lb1 * lb2, lb1 * ub2, ub1 * lb2, ub1 * ub2]
             lowerbound, upperbound = min(bounds), max(bounds)
         elif self.name == 'sum':
-            lbs, ubs = zip(*[get_bounds(x) for x in self.args])
+            lbs, ubs = get_bounds(self.args)
             lowerbound, upperbound = sum(lbs), sum(ubs)
         elif self.name == 'wsum':
             weights, vars = self.args

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -163,9 +163,15 @@ def get_bounds(expr):
     returns appropriately rounded integers
     """
 
+    # import here to avoid circular import
     from cpmpy.expressions.core import Expression
+    from cpmpy.expressions.variables import cpm_array
+
     if isinstance(expr, Expression):
         return expr.get_bounds()
+    elif is_any_list(expr):
+        lbs, ubs = zip(*[get_bounds(e) for e in expr])
+        return list(lbs), list(ubs) # return list as NDVarArray is covered above
     else:
         assert is_num(expr), f"All Expressions should have a get_bounds function, `{expr}`"
         if is_bool(expr):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -53,7 +53,7 @@ from functools import reduce
 
 import numpy as np
 from .core import Expression, Operator
-from .utils import is_num, is_int, flatlist, is_boolexpr, is_true_cst, is_false_cst
+from .utils import is_num, is_int, flatlist, is_boolexpr, is_true_cst, is_false_cst, get_bounds
 
 
 def BoolVar(shape=1, name=None):
@@ -593,6 +593,11 @@ class NDVarArray(np.ndarray, Expression):
 
         # return the NDVarArray that contains the all() constraints
         return out
+
+
+    def get_bounds(self):
+        lbs, ubs = zip(*[get_bounds(e) for e in self])
+        return cpm_array(lbs), cpm_array(ubs)
 
     # VECTORIZED master function (delegate)
     def _vectorized(self, other, attr):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -6,6 +6,7 @@ from cpmpy.exceptions import IncompleteFunctionError
 from cpmpy.expressions import *
 from cpmpy.expressions.variables import NDVarArray
 from cpmpy.expressions.core import Operator, Expression
+from cpmpy.expressions.utils import get_bounds
 
 class TestComparison(unittest.TestCase):
     def test_comps(self):
@@ -443,6 +444,27 @@ class TestBounds(unittest.TestCase):
         if cp.SolverLookup.lookup("z3").supported():
             self.assertTrue(m.solve(solver="z3"))
             self.assertTrue(cons.value())
+
+
+    def test_list(self):
+
+        # cpm_array
+        iv = cp.intvar(0,10,shape=3)
+        lbs, ubs = iv.get_bounds()
+        self.assertListEqual([0,0,0], lbs.tolist())
+        self.assertListEqual([10,10,10], ubs.tolist())
+        # list
+        iv = [cp.intvar(0,10) for _ in range(3)]
+        lbs, ubs = get_bounds(iv)
+        self.assertListEqual([0, 0, 0], lbs)
+        self.assertListEqual([10, 10, 10], ubs)
+        # nested list
+        exprs = [intvar(0,1), [intvar(2,3), intvar(4,5)], [intvar(5,6)]]
+        lbs, ubs = get_bounds(exprs)
+        self.assertListEqual([0,[2,4],[5]], lbs)
+        self.assertListEqual([1,[3,5],[6]], ubs)
+
+
 
     def test_not_operator(self):
         p = boolvar()


### PR DESCRIPTION
Added the get_bounds() functionality for NDVarArrays and (nested) lists in general.
Returns two arguments with arg0 being a list of lowerbounds for each of the elements and the second return argument being the upperbounds.