### PR TITLE
Changes to Cumulative constraint

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -417,28 +417,24 @@ class Cumulative(GlobalConstraint):
     """
     def __init__(self, start, duration, end, demand, capacity):
         assert is_any_list(start), "start should be a list"
-        start = flatlist(start)
         assert is_any_list(duration), "duration should be a list"
-        duration = flatlist(duration)
-        for d in duration:
-            if get_bounds(d)[0]<0:
-                raise TypeError("durations should be non-negative")
         assert is_any_list(end), "end should be a list"
+
+        start = flatlist(start)
+        duration = flatlist(duration)
         end = flatlist(end)
-        assert len(start) == len(duration) == len(end), "Lists should be equal length"
+        assert len(start) == len(duration) == len(end), "Start, duration and end should have equal length"
+        n_jobs = len(start)
+
+        for lb in get_bounds(duration)[0]:
+            if lb < 0:
+                raise TypeError("Durations should be non-negative")
 
         if is_any_list(demand):
             demand = flatlist(demand)
-            assert len(demand) == len(start), "Shape of demand should match start, duration and end"
-            for d in demand:
-                if is_boolexpr(d):
-                    raise TypeError("demands must be non-boolean: {}".format(d))
-        else:
-            if is_boolexpr(demand):
-                raise TypeError("demand must be non-boolean: {}".format(demand))
-        flatargs = flatlist([start, duration, end, demand, capacity])
-        if any(is_boolexpr(arg) for arg in flatargs):
-            raise TypeError("All input lists should contain only arithmetic arguments for Cumulative constraints: {}".format(flatargs))
+            assert len(demand) == n_jobs, "Demand should be supplied for each task or be single constant"
+        else: # constant demand
+            demand = [demand] * n_jobs
 
         super(Cumulative, self).__init__("cumulative", [start, duration, end, demand, capacity])
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -464,7 +464,8 @@ class Cumulative(GlobalConstraint):
                     demand_at_t += demand * ((start[job] <= t) & (t < end[job]))
                 else:
                     demand_at_t += demand[job] * ((start[job] <= t) & (t < end[job]))
-            cons += [capacity >= demand_at_t]
+
+            cons += [demand_at_t <= capacity]
 
         return cons, []
 

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -570,7 +570,13 @@ class CPM_minizinc(SolverInterface):
         elif expr.name == "cumulative":
             start, dur, end, _, _ = expr.args
             self += [s + d == e for s,d,e in zip(start,dur,end)]
-            return "cumulative({},{},{},{})".format(args_str[0], args_str[1], args_str[3], args_str[4])
+            if not isinstance(args_str[0], list):
+                assert len(start) == 1
+                format_str = "cumulative([{}],[{}],[{}],{})"
+            else:
+                format_str = "cumulative({},{},{},{})"
+
+            return format_str.format(args_str[0], args_str[1], args_str[3], args_str[4])
 
         elif expr.name == 'ite':
             cond, tr, fal = expr.args

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -570,7 +570,7 @@ class CPM_minizinc(SolverInterface):
         elif expr.name == "cumulative":
             start, dur, end, _, _ = expr.args
             self += [s + d == e for s,d,e in zip(start,dur,end)]
-            if not isinstance(args_str[0], list):
+            if len(start) == 1:
                 assert len(start) == 1
                 format_str = "cumulative([{}],[{}],[{}],{})"
             else:

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -466,8 +466,6 @@ class CPM_ortools(SolverInterface):
                 return self.ort_model.AddAllowedAssignments(array, table)
             elif cpm_expr.name == "cumulative":
                 start, dur, end, demand, cap = self.solver_vars(cpm_expr.args)
-                if is_num(demand):
-                    demand = [demand] * len(start)
                 intervals = [self.ort_model.NewIntervalVar(s,d,e,f"interval_{s}-{d}-{e}") for s,d,e in zip(start,dur,end)]
                 return self.ort_model.AddCumulative(intervals, demand, cap)
             elif cpm_expr.name == "circuit":


### PR DESCRIPTION
- Restructured __init__ for readability
- When demand is numeric, it is automatically converted to a list of equal demands (no solver actually support constant demand so better to convert it here than in each solver interface separately)
- Fixed bug in the decomposition