### PR TITLE
More MiniZinc fixes

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,6 +22,8 @@ jobs:
           pip install z3-solver
           pip install exact
           pip install pysdd
+          snap install minizinc
+          pip install minizinc
       - name: Test with pytest
         run: |
           python -m pytest tests/

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
           pip install z3-solver
           pip install exact
           pip install pysdd
-          snap install minizinc
+          sudo snap install minizinc
           pip install minizinc
       - name: Test with pytest
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
           pip install z3-solver
           pip install exact
           pip install pysdd
-          sudo snap install minizinc
+          sudo snap install minizinc --classic
           pip install minizinc
       - name: Test with pytest
         run: |

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -391,7 +391,7 @@ class CPM_minizinc(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "count", "alldifferent", "alldifferent_except0", "allequal",
                      "inverse", "ite" "xor", "table", "cumulative", "circuit", "gcc"}
-        return decompose_in_tree(cpm_cons, supported)
+        return decompose_in_tree(cpm_cons, supported, supported_reified=supported - {"circuit"})
 
 
     def __add__(self, cpm_expr):

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -574,9 +574,9 @@ class CPM_minizinc(SolverInterface):
             if len(start) == 1:
                 format_str = durstr +" /\\ cumulative([{}],[{}],[{}],{})"
             else:
-                format_str = durstr +" ++ [cumulative({},{},{},{})]"
+                format_str = "forall(" + durstr + " ++ [cumulative({},{},{},{})])"
 
-            return "forall("+format_str.format(args_str[0], args_str[1], args_str[3], args_str[4])+")"
+            return format_str.format(args_str[0], args_str[1], args_str[3], args_str[4])
 
         elif expr.name == 'ite':
             cond, tr, fal = expr.args

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -569,14 +569,14 @@ class CPM_minizinc(SolverInterface):
 
         elif expr.name == "cumulative":
             start, dur, end, _, _ = expr.args
-            self += [s + d == e for s,d,e in zip(start,dur,end)]
-            if len(start) == 1:
-                assert len(start) == 1
-                format_str = "cumulative([{}],[{}],[{}],{})"
-            else:
-                format_str = "cumulative({},{},{},{})"
 
-            return format_str.format(args_str[0], args_str[1], args_str[3], args_str[4])
+            durstr = self._convert_expression([s + d == e for s,d,e in zip(start, dur, end)])
+            if len(start) == 1:
+                format_str = durstr +" /\\ cumulative([{}],[{}],[{}],{})"
+            else:
+                format_str = durstr +" ++ [cumulative({},{},{},{})]"
+
+            return "forall("+format_str.format(args_str[0], args_str[1], args_str[3], args_str[4])+")"
 
         elif expr.name == 'ite':
             cond, tr, fal = expr.args

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -401,6 +401,24 @@ class TestGlobal(unittest.TestCase):
         self.assertTrue(m.solve(solver="ortools"))
         self.assertTrue(m.solve(solver="minizinc"))
 
+    @pytest.mark.skipif(not CPM_minizinc.supported(),
+                        reason="Minizinc not installed")
+    def test_cumulative_nested(self):
+        start = cp.intvar(0, 10, name="start", shape=3)
+        dur = [5,5,5]
+        end = cp.intvar(0, 10, name="end", shape=3)
+        demand = [5,5,9]
+        capacity = 10
+        bv = cp.boolvar()
+
+        cons = cp.Cumulative([start], [dur], [end], [demand], capacity)
+
+        m = cp.Model(bv.implies(cons), start + dur != end)
+
+        self.assertTrue(m.solve(solver="ortools"))
+        self.assertTrue(m.solve(solver="minizinc"))
+
+
 
     def test_cumulative_no_np(self):
         start = cp.intvar(0, 10, 4, "start")
@@ -666,7 +684,7 @@ class TestTypeChecks(unittest.TestCase):
         b = cp.boolvar()
         a = cp.boolvar()
 
-        self.assertTrue(cp.Model([cp.Cumulative([x,y],[x,2],[z,q],1,x)]).solve())
+        self.assertTrue(cp.Model([cp.Cumulative([x,y],[x,2],[z,q],1,x)]).solve(solver="minizinc:com.google.ortools.sat"))
         self.assertRaises(TypeError, cp.Cumulative, [x,y],[x,y],[a,y],1,x)
         self.assertRaises(TypeError, cp.Cumulative, [x,y],[x,y],[x,y],1,x)
         self.assertRaises(TypeError, cp.Cumulative, [x,y],[x,y],[x,y],x,False)


### PR DESCRIPTION
The Cumulative constriant was posted wrongly in nested contexts to Minizinc. (The fix may be failing on older versions of Minizinc, it is fixed in release 2.8.1, see [#754](https://github.com/MiniZinc/libminizinc/issues/754))

Other changes:
- Update set of supported reified constraints in mzn
- Add Minizinc to github actions