### PR TITLE
optional parameter to ensure get_or_make_var outputs boolean var

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -240,13 +240,16 @@ def flatten_constraint(expr):
                     newlist.append(Comparison(exprname, lexpr, rexpr))
                 continue
 
-            # ensure rhs is a boolvar
-            (rvar, rcons) = get_or_make_boolvar(rexpr)
+
             # Reification (double implication): Boolexpr == Var
             # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
             if exprname == '==' and lexpr.is_bool():
+                # ensure rhs is a boolvar
+                (rvar, rcons) = get_or_make_boolvar(rexpr)
                 (lhs, lcons) = normalized_boolexpr(lexpr)
             else:
+                # ensure rhs is a var
+                (rvar, rcons) = get_or_make_var(rexpr)
                 (lhs, lcons) = normalized_numexpr(lexpr)
 
             newlist.append(Comparison(exprname, lhs, rvar))

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -332,7 +332,7 @@ def get_or_make_var(expr,boolean=False):
         # then compute bounds and return (newintvar, LHS == newintvar)
         (flatexpr, flatcons) = normalized_numexpr(expr)
 
-        lb, ub = flatexpr.get_bounds()
+        lb, ub = get_bounds(flatexpr)
         ivar = _IntVarImpl(lb, ub)
         if boolean:
             bvar = _BoolVarImpl()

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -317,7 +317,7 @@ def get_or_make_var(expr,boolean=False):
     if is_any_list(expr):
         raise Exception(f"Expected single variable, not a list for: {expr}")
 
-    if expr.is_bool():
+    if isbool:
         # normalize expr into a boolexpr LHS, reify LHS == bvar
         (flatexpr, flatcons) = normalized_boolexpr(expr)
 

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -308,7 +308,7 @@ def get_or_make_var(expr,boolean=False):
         Determines whether this is a Boolean or Integer variable and returns
         the equivalent of: (var, normalize(expr) == var)
     """
-    if expr.is_bool():
+    if is_boolexpr(expr):
         boolean = True
     if __is_flat_var(expr) and boolean == expr.is_bool():
         return (expr, [])

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -241,7 +241,7 @@ def flatten_constraint(expr):
                 continue
 
             # ensure rhs is var
-            (rvar, rcons) = get_or_make_var(rexpr)
+            (rvar, rcons) = get_or_make_var(rexpr,boolean=True)
             # Reification (double implication): Boolexpr == Var
             # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
             if exprname == '==' and lexpr.is_bool():
@@ -302,13 +302,15 @@ def __is_flat_var_or_list(arg):
            is_any_list(arg) and all(__is_flat_var_or_list(el) for el in arg)
 
 
-def get_or_make_var(expr):
+def get_or_make_var(expr,boolean=False):
     """
         Must return a variable, and list of flat normal constraints
         Determines whether this is a Boolean or Integer variable and returns
         the equivalent of: (var, normalize(expr) == var)
     """
-    if __is_flat_var(expr):
+    if expr.is_bool():
+        boolean = True
+    if __is_flat_var(expr) and boolean == expr.is_bool():
         return (expr, [])
 
     if is_any_list(expr):
@@ -331,6 +333,9 @@ def get_or_make_var(expr):
 
         lb, ub = flatexpr.get_bounds()
         ivar = _IntVarImpl(lb, ub)
+        if boolean:
+            bvar = _BoolVarImpl()
+            return (bvar,[flatexpr == bvar] + flatcons)
         return (ivar, [flatexpr == ivar]+flatcons)
 
 def get_or_make_var_or_list(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -308,9 +308,10 @@ def get_or_make_var(expr,boolean=False):
         Determines whether this is a Boolean or Integer variable and returns
         the equivalent of: (var, normalize(expr) == var)
     """
-    if is_boolexpr(expr):
+    isbool = is_boolexpr(expr)
+    if isbool:
         boolean = True
-    if __is_flat_var(expr) and boolean == expr.is_bool():
+    if __is_flat_var(expr) and boolean == isbool:
         return (expr, [])
 
     if is_any_list(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -354,7 +354,7 @@ def get_or_make_boolvar(expr):
     """
     isbool = is_boolexpr(expr)
     if __is_flat_var(expr):
-        if isbool:
+        if isbool or is_num(expr):
             return (expr, [])
         else:
             bv = _BoolVarImpl()


### PR DESCRIPTION
This is the most intuitive solution to bug #442 for me, we cannot reify with an integer variable, so ensure it's made into a boolean variable in get or make var. This will also work for more complex numexpressions on the rhs.

Does feel a bit weird to alter get_or_make_var though.. maybe better to introduce a new get_or_make_bool_var in stead?