### PR TITLE
Classmethod in SolverLookup

### DIFF
--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -61,8 +61,8 @@ def param_combinations(all_params, remaining_keys=None, cur_params=None):
                             cur_params=cur_params)
 
 class SolverLookup():
-    @staticmethod
-    def base_solvers():
+    @classmethod
+    def base_solvers(cls):
         """
             Return ordered list of (name, class) of base CPMpy
             solvers
@@ -78,10 +78,10 @@ class SolverLookup():
                 ("exact", CPM_exact),
                ]
 
-    @staticmethod
-    def solvernames():
+    @classmethod
+    def solvernames(cls):
         names = []
-        for (basename, CPM_slv) in SolverLookup.base_solvers():
+        for (basename, CPM_slv) in cls.base_solvers():
             if CPM_slv.supported():
                 names.append(basename)
                 if hasattr(CPM_slv, "solvernames"):
@@ -90,23 +90,23 @@ class SolverLookup():
                         names.append(basename+":"+subn)
         return names
 
-    @staticmethod
-    def get(name=None, model=None):
+    @classmethod
+    def get(cls, name=None, model=None):
         """
             get a specific solver (by name), with 'model' passed to its constructor
 
             This is the preferred way to initialise a solver from its name
         """
-        cls = SolverLookup.lookup(name=name)
+        solver_cls = cls.lookup(name=name)
 
         # check for a 'solver:subsolver' name
         subname = None
         if name is not None and ':' in name:
             _,subname = name.split(':',maxsplit=1)
-        return cls(model, subsolver=subname)
+        return solver_cls(model, subsolver=subname)
 
-    @staticmethod
-    def lookup(name=None):
+    @classmethod
+    def lookup(cls, name=None):
         """
             lookup a solver _class_ by its name
 
@@ -115,7 +115,7 @@ class SolverLookup():
         """
         if name is None:
             # first solver class
-            return SolverLookup.base_solvers()[0][1]
+            return cls.base_solvers()[0][1]
 
         # split name if relevant
         solvername = name
@@ -124,7 +124,7 @@ class SolverLookup():
             solvername,_ = solvername.split(':',maxsplit=1)
 
 
-        for (basename, CPM_slv) in SolverLookup.base_solvers():
+        for (basename, CPM_slv) in cls.base_solvers():
             if basename == solvername:
                 # found the right solver
                 return CPM_slv


### PR DESCRIPTION
I change the static methods to class-methods for the methods in the `SolverLookup` class.
This allows a user to extend the class and add for example a custom solver to the base-solvers, while still using the `SolverLookup.get('my-custom-solver', model)` method.