### PR TITLE
use floor and ceil to ensure int bounds

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -335,7 +335,7 @@ def get_or_make_var(expr):
         (flatexpr, flatcons) = normalized_numexpr(expr)
 
         lb, ub = flatexpr.get_bounds()
-        ivar = _IntVarImpl(lb, ub)
+        ivar = _IntVarImpl(math.floor(lb), math.ceil(ub))
         return (ivar, [flatexpr == ivar]+flatcons)
 
 def get_or_make_var_or_list(expr):


### PR DESCRIPTION
Bound calculations are not guaranteed to give integers, so convert before making an intvar