### PR TITLE
Pycsp3 parser

### DIFF
--- a/benchmarks/callbackscpmpy.py
+++ b/benchmarks/callbackscpmpy.py
@@ -1,0 +1,444 @@
+import copy
+from functools import reduce
+
+from pycsp3.parser.callbacks import Callbacks
+from pycsp3.classes.auxiliary.conditions import Condition
+from pycsp3.classes.auxiliary.enums import (TypeConditionOperator, TypeArithmeticOperator, TypeUnaryArithmeticOperator, TypeLogicalOperator,
+                                            TypeOrderedOperator, TypeRank, TypeObj)
+from pycsp3.classes.main.variables import Variable
+from pycsp3.classes.nodes import (Node)
+
+from pycsp3.parser.xentries import XVar
+from pycsp3.tools.utilities import _Star
+
+import cpmpy as cp
+
+class CallbacksCPMPy(Callbacks):
+
+    def __init__(self):
+        super().__init__()
+        self.cpm_model = cp.Model()
+        self.cpm_variables = dict()
+
+    def var_integer_range(self, x: Variable, min_value: int, max_value: int):
+        newvar = cp.intvar(min_value, max_value, name=x.id)
+        self.cpm_variables[x] = newvar
+
+    def var_integer(self, x: Variable, values: list[int]):
+        mini = min(values)
+        maxi = max(values)
+        newvar = cp.intvar(mini, maxi, name=x.id)
+        nbvals = maxi - mini + 1
+        self.cpm_variables[x] = newvar
+        if nbvals < len(values):
+            # only do this if there are holes in the domain
+            self.cpm_model += cp.InDomain(newvar, values)
+
+    def load_instance(self, discarded_classes=None):
+        return self.cpm_model, self.cpm_variables
+
+    def ctr_true(self, scope: list[Variable]):
+        return cp.BoolVal(True)
+
+    def ctr_false(self, scope: list[Variable]):
+        assert False, "Problem as a constraint with 0 supports: " + str(scope)
+
+    def ctr_intension(self, scope: list[Variable], tree: Node):
+        cons = self.intentionfromtree(tree)
+        self.cpm_model += cons
+
+    funcmap = {
+        # Arithmetic
+        "neg": (1, lambda x: -x),
+        "abs": (1, lambda x: abs(x)),
+        "add": (0, lambda x: cp.sum(x)),
+        "sub": (2, lambda x, y: x - y),
+        "mul": (0, lambda x: reduce((lambda x, y: x*y),x)),
+        "div": (2, lambda x, y: x // y),
+        "mod": (2, lambda x, y: x % y),
+        "sqr": (1, lambda x: x ** 2),
+        "pow": (2, lambda x, y: x ** y),
+        "min": (0, lambda x: cp.min(x)),
+        "max": (0, lambda x: cp.max(x)),
+        "dist": (2, lambda x, y: abs(x - y)),
+        # Relational
+        "lt": (2, lambda x, y: x < y),
+        "le": (2, lambda x, y: x <= y),
+        "ge": (2, lambda x, y: x >= y),
+        "gt": (2, lambda x, y: x > y),
+        "ne": (2, lambda x, y: x != y),
+        "eq": (0, lambda x: x[0] == x[1] if len(x) == 2 else cp.AllEqual(x)),
+        # Set
+        'in': (2, lambda x, y: cp.InDomain(x, y)),
+        # Logic
+        "not": (1, lambda x: ~x),
+        "and": (0, lambda x: cp.all(x)),
+        "or": (0, lambda x: cp.any(x)),
+        "xor": (0, lambda x: cp.Xor(x)),
+        "iff": (0, lambda x: cp.all(a == b for a, b in zip(x[:-1], x[1:]))),
+        "imp": (2, lambda x, y: x.implies(y)),
+        # control
+        "if": (3, lambda b, x, y: cp.IfThenElse(b, x, y))
+    }
+
+    def intentionfromtree(self, node):
+        if isinstance(node, Node):
+            if node.type.lowercase_name == 'var':
+                return self.cpm_variables[node.cnt]
+            if node.type.lowercase_name == 'int':
+                return node.cnt
+            arity, cpm_op = self.funcmap[node.type.lowercase_name]
+            cpm_args = []
+            for arg in node.cnt:
+                cpm_args.append(self.intentionfromtree(arg))
+            if arity != 0:
+                return cpm_op(*cpm_args)
+            return cpm_op(cpm_args)
+        else:
+            return node
+
+    def ctr_primitive1a(self, x: Variable, op: TypeConditionOperator, k: int):
+        assert op.is_rel()
+        x = self.get_cpm_var(x)
+        arity, cpm_op = self.funcmap[op.name.lower()]
+        if arity == 2:
+            self.cpm_model += cpm_op(x, k)
+        elif arity == 0:
+            self.cpm_model += cpm_op([x, k])
+        else:
+            self._unimplemented(x, op, k)
+
+    def ctr_primitive1b(self, x: Variable, op: TypeConditionOperator, term: list[int] | range):
+        assert op.is_set()
+        x = self.get_cpm_var(x)
+        arity, cpm_op = self.funcmap[op.name.lower()]
+        if isinstance(term, range):
+            term = [x for x in term] #list from range
+        if arity == 2:
+            self.cpm_model += cpm_op(x, term)
+        elif arity == 0:
+            self.cpm_model += cpm_op([x, term])
+        else:
+            self._unimplemented(x, op, term)
+
+
+    def ctr_primitive1c(self, x: Variable, aop: TypeArithmeticOperator, p: int, op: TypeConditionOperator, k: int):
+        assert op.is_rel()
+        self.ctr_primitive3(x, aop, p, op, k) #for cpmpy ints and vars are just interchangeable..
+
+    def ctr_primitive2a(self, x: Variable, aop: TypeUnaryArithmeticOperator, y: Variable):
+        self._unimplemented(x, aop, y)
+
+    def ctr_primitive2b(self, x: Variable, aop: TypeArithmeticOperator, y: Variable, op: TypeConditionOperator, k: int):
+        #(x aop y) rel k
+        self.ctr_primitive3(x, aop, y, op, k) #for cpmpy ints and vars are just interchangeable..
+
+    def ctr_primitive2c(self, x: Variable, aop: TypeArithmeticOperator, p: int, op: TypeConditionOperator, y: Variable):
+        #(x aop p) op y
+        assert op.is_rel()
+        self.ctr_primitive3(x, aop, p, op, y) #for cpmpy ints and vars are just interchangeable..
+
+    def ctr_primitive3(self, x: Variable, aop: TypeArithmeticOperator, y: Variable, op: TypeConditionOperator, z: Variable):
+        # (x aop y) op z
+        assert op.is_rel()
+        arity_op, cpm_op = self.funcmap[(op.name).lower()]
+        arity, cpm_aop = self.funcmap[aop.name.lower()]
+        x = self.get_cpm_var(x)
+        y = self.get_cpm_var(y)
+        z = self.get_cpm_var(z)
+        if arity == 2:
+            if arity_op == 2:
+                self.cpm_model += cpm_op(cpm_aop(x, y), z)
+            else:  # eq is arity 0, because of allequal global
+                self.cpm_model += cpm_op([cpm_aop(x, y), z])
+        elif arity == 0:
+            if arity_op == 2:
+                self.cpm_model += cpm_op(cpm_aop([x, y]), z)
+            else:  # eq is arity 0, because of allequal global
+                self.cpm_model += cpm_op([cpm_aop([x, y]), z])
+
+    def ctr_logic(self, lop: TypeLogicalOperator, scope: list[Variable]):  # lop(scope)
+        self._unimplemented(lop, scope)
+
+    def ctr_logic_reif(self, x: Variable, y: Variable, op: TypeConditionOperator, k: int | Variable):  # x = y <op> k
+        assert op.is_rel()
+        self._unimplemented(x, y, op, k)
+
+    def ctr_logic_eqne(self, x: Variable, op: TypeConditionOperator, lop: TypeLogicalOperator, scope: list[Variable]):  # x = lop(scope) or x != lop(scope)
+        assert op in (TypeConditionOperator.EQ, TypeConditionOperator.NE)
+        self._unimplemented(x, op, lop, scope)
+
+    def ctr_extension_unary(self, x: Variable, values: list[int], positive: bool, flags: set[str]):
+        if positive:
+            #unary table constraint is just an inDomain
+            self.cpm_model += cp.InDomain(self.get_cpm_var(x), values)
+        else:
+            # negative, so not in domain
+            self.cpm_model += ~cp.InDomain(self.get_cpm_var(x), values)
+
+    def ctr_extension(self, scope: list[Variable], tuples: list, positive: bool, flags: set[str]):
+        def strwildcard(x):
+            if isinstance(x,_Star):
+                return '*'
+            return x
+        cpm_vars = self.vars_from_node(scope)
+        exttuples = [tuple([strwildcard(x) for x in tup]) for tup in tuples]
+        self.cpm_model += cp.SmartTable(cpm_vars, exttuples)
+
+
+    def ctr_regular(self, scope: list[Variable], transitions: list, start_state: str, final_states: list[str]):
+        #raise NotImplementedError('no cpmpy equivalent yet')
+        pass
+        #self._unimplemented(scope, transitions, start_state, final_states)
+
+    def ctr_mdd(self, scope: list[Variable], transitions: list):
+        #raise NotImplementedError('no cpmpy equivalent yet')
+        #self._unimplemented(scope, transitions)
+        pass
+
+    def ctr_all_different(self, scope: list[Variable] | list[Node], excepting: None | list[int]):
+        if excepting is None:
+            cpm_exprs = self.exprs_from_node(scope)
+            return cp.AllDifferent(cpm_exprs)
+        else:
+            self._unimplemented(scope, excepting)
+
+    def ctr_all_different_lists(self, lists: list[list[Variable]], excepting: None | list[list[int]]):
+        self._unimplemented(lists, excepting)
+
+    def ctr_all_different_matrix(self, matrix: list[list[Variable]], excepting: None | list[int]):
+        pass
+        #self._unimplemented(matrix, excepting)
+
+    def ctr_all_equal(self, scope: list[Variable] | list[Node], excepting: None | list[int]):
+        self._unimplemented(scope, excepting)
+
+    def ctr_ordered(self, lst: list[Variable], operator: TypeOrderedOperator, lengths: None | list[int] | list[Variable]):
+        #raise NotImplementedError('Increasing global not in cpmpy')
+        pass
+        #self._unimplemented(lst, operator, lengths)
+
+    def ctr_lex_limit(self, lst: list[Variable], limit: list[int], operator: TypeOrderedOperator):  # should soon enter XCSP3-core
+        self._unimplemented(lst, limit, operator)
+
+    def ctr_lex(self, lists: list[list[Variable]], operator: TypeOrderedOperator):
+        pass
+        #self._unimplemented(lists, operator)
+
+    def ctr_lex_matrix(self, matrix: list[list[Variable]], operator: TypeOrderedOperator):
+        pass
+        #self._unimplemented(matrix, operator)
+
+    def ctr_precedence(self, lst: list[Variable], values: None | list[int], covered: bool):
+        self._unimplemented(lst, values, covered)
+
+    def ctr_sum(self, lst: list[Variable] | list[Node], coefficients: None | list[int] | list[Variable], condition: Condition):
+        cpm_vars = []
+        if isinstance(lst[0], XVar):
+            for xvar in lst:
+                cpm_vars.append(self.cpm_variables[xvar])
+        else:
+            cpm_vars = self.exprs_from_node(lst)
+        arity, op = self.funcmap[condition.operator.name.lower()]
+        if hasattr(condition, "variable"):
+            rhs = condition.variable
+        elif hasattr(condition, 'value'):
+            rhs = condition.value
+        elif hasattr(condition, 'max'):
+            #operator = in
+            rhs = [x for x in range(condition.min, condition.max + 1)]
+        else:
+            pass
+        cpm_rhs = self.get_cpm_var(rhs)
+        if coefficients is None:
+            cpsum = cp.sum(cpm_vars)
+        else:
+            cp_coeffs = self.get_cpm_vars(coefficients)
+            cpsum = cp.sum(cp.cpm_array(cpm_vars) * cp_coeffs)
+        if arity == 0:
+            self.cpm_model += op([cpsum, cpm_rhs])
+        else:
+            self.cpm_model += op(cpsum, cpm_rhs)
+
+    def ctr_count(self, lst: list[Variable] | list[Node], values: list[int] | list[Variable], condition: Condition):
+        cpm_vars = self.get_cpm_vars(lst)
+        cpm_vals = self.get_cpm_vars(values)
+        self._unimplemented(lst, values, condition)
+
+    def ctr_atleast(self, lst: list[Variable], value: int, k: int):
+        cpm_vars = self.get_cpm_vars(lst)
+        self.cpm_model += (cp.Count(cpm_vars, value) >= k)
+
+    def ctr_atmost(self, lst: list[Variable], value: int, k: int):
+        cpm_vars = self.get_cpm_vars(lst)
+        self.cpm_model += (cp.Count(cpm_vars, value) <= k)
+
+    def ctr_exactly(self, lst: list[Variable], value: int, k: int | Variable):
+        cpm_vars = self.get_cpm_exprs(lst)
+        self.cpm_model += (cp.Count(cpm_vars, value) == k)
+
+    def ctr_among(self, lst: list[Variable], values: list[int], k: int | Variable):
+        pass
+        #self._unimplemented(lst, values, k)
+
+    def ctr_nvalues(self, lst: list[Variable] | list[Node], excepting: None | list[int], condition: Condition):
+        pass
+        #self._unimplemented(lst, excepting, condition)
+
+    def ctr_not_all_qual(self, lst: list[Variable]):
+        cpm_vars = self.get_cpm_vars(lst)
+        self.cpm_model += ~cp.AllEqual(cpm_vars)
+
+    def ctr_cardinality(self, lst: list[Variable], values: list[int] | list[Variable], occurs: list[int] | list[Variable] | list[range], closed: bool):
+        pass
+        #self._unimplemented(lst, values, occurs, closed)
+
+    def ctr_minimum(self, lst: list[Variable] | list[Node], condition: Condition):
+        cpm_vars = self.get_cpm_vars(lst)
+        arity, op = self.funcmap[condition.operator.name.lower()]
+        cpm_rhs = self.cpm_variables[condition.variable]
+        if arity == 0:
+            self.cpm_model += op([cp.Minimum(cpm_vars), cpm_rhs])
+        else:
+            self.cpm_model += op(cp.Minimum(cpm_vars), cpm_rhs)
+
+    def ctr_maximum(self, lst: list[Variable] | list[Node], condition: Condition):
+        cpm_vars = self.get_cpm_vars(lst)
+        arity, op = self.funcmap[condition.operator.name.lower()]
+        cpm_rhs = self.cpm_variables[condition.variable]
+        if arity == 0:
+            self.cpm_model += op([cp.Maximum(cpm_vars), cpm_rhs])
+        else:
+            self.cpm_model += op(cp.Maximum(cpm_vars), cpm_rhs)
+
+    def ctr_minimum_arg(self, lst: list[Variable] | list[Node], condition: Condition, rank: TypeRank):  # should enter XCSP3-core
+        self._unimplemented(lst, condition, rank)
+
+    def ctr_maximum_arg(self, lst: list[Variable] | list[Node], condition: Condition, rank: TypeRank):  # should enter XCSP3-core
+        self._unimplemented(lst, condition, rank)
+
+    def ctr_element(self, lst: list[Variable] | list[int], i: Variable, condition: Condition):
+        cpm_list = self.get_cpm_vars(lst)
+        arity, op = self.funcmap[condition.operator.name.lower()]
+        if hasattr(condition, 'variable'):
+            cpm_rhs = self.cpm_variables[condition.variable]
+        elif hasattr(condition, 'value'):
+            cpm_rhs = condition.value
+        else:
+            self._unimplemented(lst, condition)
+        cpm_index = self.cpm_variables[i]
+        if arity == 0:
+            self.cpm_model += op([cp.Element(cpm_list,cpm_index), cpm_rhs])
+        else:
+            self.cpm_model += op(cp.Element(cpm_list, cpm_index), cpm_rhs)
+
+    def ctr_element_matrix(self, matrix: list[list[Variable]] | list[list[int]], i: Variable, j: Variable, condition: Condition):
+        pass#self._unimplemented(matrix, i, j, condition)
+
+    def ctr_channel(self, lst1: list[Variable], lst2: None | list[Variable]):
+        if lst2 is None:
+            raise NotImplementedError()
+        cpm_vars1 = self.get_cpm_vars(lst1)
+        cpm_vars2 = self.get_cpm_vars(lst2)
+        # make lists same length, last part is irrelevant if not same length
+        if len(cpm_vars2) > len(cpm_vars1):
+            cpm_vars2 = cpm_vars2[0:len(cpm_vars1)]
+        elif len(cpm_vars1) > len(cpm_vars2):
+            cpm_vars1 = cpm_vars1[0:len(cpm_vars2)]
+        self.cpm_model += cp.Inverse(cpm_vars1, cpm_vars2)
+
+    def ctr_channel_value(self, lst: list[Variable], value: Variable):
+        self._unimplemented(lst, value)
+
+    def ctr_nooverlap(self, origins: list[Variable], lengths: list[int] | list[Variable],
+                      zero_ignored: bool):  # in XCSP3 competitions, no 0 permitted in lengths
+        self._unimplemented(origins, lengths, zero_ignored)
+
+    def ctr_nooverlap_multi(self, origins: list[list[Variable]], lengths: list[list[int]] | list[list[Variable]], zero_ignored: bool):
+        self._unimplemented(origins, lengths, zero_ignored)
+
+    def ctr_nooverlap_mixed(self, xs: list[Variable], ys: list[Variable], lx: list[Variable], ly: list[int], zero_ignored: bool):
+        self._unimplemented(xs, ys, lx, ly, zero_ignored)
+
+    def ctr_cumulative(self, origins: list[Variable], lengths: list[int] | list[Variable], heights: list[int] | list[Variable], condition: Condition):
+        self._unimplemented(origins, lengths, heights, condition)
+
+    def ctr_binpacking(self, lst: list[Variable], sizes: list[int], condition: Condition):
+        self._unimplemented(lst, sizes, condition)
+
+    def ctr_binpacking_limits(self, lst: list[Variable], sizes: list[int], limits: list[int] | list[Variable]):
+        self._unimplemented(lst, sizes, limits)
+
+    def ctr_binpacking_loads(self, lst: list[Variable], sizes: list[int], loads: list[int] | list[Variable]):
+        self._unimplemented(lst, sizes, loads)
+
+    def ctr_binpacking_conditions(self, lst: list[Variable], sizes: list[int], conditions: list[Condition]):  # not in XCSP3-core
+        self._unimplemented(lst, sizes, conditions)
+
+    def ctr_knapsack(self, lst: list[Variable], weights: list[int], wcondition: Condition, profits: list[int], pcondition: Condition):
+        self._unimplemented(lst, weights, wcondition, profits, pcondition)
+
+    def ctr_flow(self, lst: list[Variable], balance: list[int] | list[Variable], arcs: list, capacities: None | list[range]):  # not in XCSP3-core
+        self._unimplemented(lst, balance, arcs, capacities)
+
+    def ctr_flow_weighted(self, lst: list[Variable], balance: list[int] | list[Variable], arcs: list, capacities: None | list[range],
+                          weights: list[int] | list[Variable],
+                          condition: Condition):  # not in XCSP3-core
+        self._unimplemented(lst, balance, arcs, capacities, weights, condition)
+
+    def ctr_instantiation(self, lst: list[Variable], values: list[int]):
+        self.cpm_model += cp.Table(self.get_cpm_vars(lst), [values])
+
+    def ctr_clause(self, pos: list[Variable], neg: list[Variable]):  # not in XCSP3-core
+        self._unimplemented(pos, neg)
+
+    def ctr_circuit(self, lst: list[Variable], size: None | int | Variable):  # size is None in XCSP3 competitions
+        return cp.Circuit(lst)
+
+    # # # # # # # # # #
+    # All methods about objectives to be implemented
+    # # # # # # # # # #
+
+    def obj_minimize(self, term: Variable | Node):
+        self._unimplemented(term)
+
+    def obj_maximize(self, term: Variable | Node):
+        self._unimplemented(term)
+
+    def obj_minimize_special(self, obj_type: TypeObj, terms: list[Variable] | list[Node], coefficients: None | list[int]):
+        self._unimplemented(obj_type, terms, coefficients)
+
+    def obj_maximize_special(self, obj_type: TypeObj, terms: list[Variable] | list[Node], coefficients: None | list[int]):
+        self._unimplemented(obj_type, terms, coefficients)
+
+    def vars_from_node(self, scope):
+        cpm_vars = []
+        for var in scope:
+            cpm_var = self.cpm_variables[var]
+            cpm_vars.append(cpm_var)
+        return cpm_vars
+
+    def exprs_from_node(self, node):
+        cpm_exprs = []
+        for expr in node:
+            cpm_expr = self.intentionfromtree(expr)
+            cpm_exprs.append(cpm_expr)
+        return cpm_exprs
+
+    def get_cpm_var(self, x):
+        if isinstance(x, XVar):
+            return self.cpm_variables[x]
+        else:
+            return x #constants
+
+    def get_cpm_vars(self, list):
+        if isinstance(list[0], (XVar, int)):
+            return [self.get_cpm_var(x) for x in list]
+        else:
+            return self.vars_from_node(list)
+
+    def get_cpm_exprs(self, list):
+        if isinstance(list[0], XVar):
+            return [self.get_cpm_var(x) for x in list]
+        else:
+            return self.exprs_from_node(list)

--- a/benchmarks/run_parser.py
+++ b/benchmarks/run_parser.py
@@ -6,9 +6,9 @@ from callbackscpmpy import CallbacksCPMPy
 
 import glob
 from os.path import join
-problems = glob.glob(join("CSP", 'bugs', '*.xml'))
+problems = glob.glob(join("COP",'bug', '*.xml'))
 print(problems)
-count = 10
+count = 0
 ecount = 0
 print(problems[count])
 for xml in problems[count:]:

--- a/benchmarks/run_parser.py
+++ b/benchmarks/run_parser.py
@@ -6,10 +6,9 @@ from callbackscpmpy import CallbacksCPMPy
 
 import glob
 from os.path import join
-problems = glob.glob(join("CSP", '*.xml'))
-problems += glob.glob(join("..", "MiniCOP", '*.xml'))
+problems = glob.glob(join("CSP", 'bugs', '*.xml'))
 print(problems)
-count = 160
+count = 10
 ecount = 0
 print(problems[count])
 for xml in problems[count:]:

--- a/benchmarks/run_parser.py
+++ b/benchmarks/run_parser.py
@@ -1,0 +1,44 @@
+from pycsp3.parser.xparser import CallbackerXCSP3, ParserXCSP3
+
+from callbackscpmpy import CallbacksCPMPy
+
+
+
+import glob
+from os.path import join
+problems = glob.glob(join("CSP", '*.xml'))
+problems += glob.glob(join("..", "MiniCOP", '*.xml'))
+print(problems)
+count = 160
+ecount = 0
+print(problems[count])
+for xml in problems[count:]:
+    count += 1
+    '''if len(sys.argv) < 2:
+        sys.argv.append(xml)
+    assert len(sys.argv) >= 2'''
+    #we are not using commandline
+    #parser = ParserXCSP3(os.path.join("./", sys.argv[1]))
+    parser = ParserXCSP3(xml)
+    callbacks = CallbacksCPMPy()
+    callbacks.force_exit = True
+    # e.g., callbacks.recognize_unary_primitives = False
+    callbacker = CallbackerXCSP3(parser, callbacks)
+    try:
+        callbacker.load_instance()
+    except NotImplementedError as e:
+        ecount += 1
+        raise e
+    except Exception as e:
+        print(problems[count-1])
+        raise e
+    cb = callbacker.cb
+    #print(cb.cpm_model)
+    #print(cb.cpm_variables)
+    #print('________________________________________________________')
+    print(count, ecount)
+    print('________________________________________________________')
+    print('________________________________________________________')
+
+print('not implemented:', ecount, 'out of', count)
+# obj = build_dynamic_object(sys.argv[2], sys.argv[3])

--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -21,7 +21,7 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Xor, Cumulative, IfThenElse, GlobalCardinalityCount, DirectConstraint, InDomain
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, SmartTable, Xor, Cumulative, IfThenElse, GlobalCardinalityCount, DirectConstraint, InDomain
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .globalfunctions import Maximum, Minimum, Abs, Element, Count, NValue
 from .core import BoolVal

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -102,6 +102,7 @@
         Circuit
         Inverse
         Table
+        SmartTable
         Xor
         Cumulative
         GlobalCardinalityCount
@@ -311,6 +312,27 @@ class Table(GlobalConstraint):
         arrval = [argval(a) for a in arr]
         return arrval in tab
 
+
+class SmartTable(GlobalConstraint):
+    """The values of the variables in 'array' correspond to a row in 'table'
+    """
+    def __init__(self, array, table):
+        array = flatlist(array)
+        if not all(isinstance(x, Expression) for x in array):
+            raise TypeError("the first argument of a Table constraint should only contain variables/expressions")
+        super().__init__("smarttable", [array, table])
+
+    def decompose(self):
+        from .python_builtins import any, all
+        arr, tab = self.args
+        raise NotImplementedError('not yet implemented')
+        return [any(all(ai == ri for ai, ri in zip(arr, row)) for row in tab)], []
+
+    def value(self):
+        arr, tab = self.args
+        arrval = [argval(a) for a in arr]
+        raise NotImplementedError('not yet implemented')
+        return arrval in tab
 
 # syntax of the form 'if b then x == 9 else x == 0' is not supported (no override possible)
 # same semantic as CPLEX IfThenElse constraint

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -325,14 +325,22 @@ class SmartTable(GlobalConstraint):
     def decompose(self):
         from .python_builtins import any, all
         arr, tab = self.args
-        raise NotImplementedError('not yet implemented')
-        return [any(all(ai == ri for ai, ri in zip(arr, row)) for row in tab)], []
+        return [any(all(ai == ri for ai, ri in zip(arr, row) if ri != '*') for row in tab)], []
 
     def value(self):
         arr, tab = self.args
         arrval = [argval(a) for a in arr]
-        raise NotImplementedError('not yet implemented')
-        return arrval in tab
+        for tup in tab:
+            thistup = True
+            for aval, tval in zip(arrval, tup):
+                if tval != '*':
+                    if aval != tval:
+                        thistup = False
+            if thistup:
+                #found tuple that matches
+                return True
+        #didn't find tuple that matches
+        return False
 
 # syntax of the form 'if b then x == 9 else x == 0' is not supported (no override possible)
 # same semantic as CPLEX IfThenElse constraint

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -374,8 +374,8 @@ class InDomain(GlobalConstraint):
     """
 
     def __init__(self, expr, arr):
-        assert not (is_boolexpr(expr) or any(is_boolexpr(a) for a in arr)), \
-            "The expressions in the InDomain constraint should not be boolean"
+        #assert not (is_boolexpr(expr) or any(is_boolexpr(a) for a in arr)), \
+         #   "The expressions in the InDomain constraint should not be boolean"
         super().__init__("InDomain", [expr, arr])
 
     def decompose(self):


### PR DESCRIPTION
using the parser that is available in PyCSP3, this branch contains the interface to cpmpy, so it can be used to parse XCSP3 to cpmpy. (requires pycsp3)