### PR TITLE
Increasing and decreasing global constraints

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -5,13 +5,13 @@
     List of submodules
     ==================
     .. autosummary::
+        python_builtins
         :nosignatures:
 
         variables
         core
         globalconstraints
         globalfunctions
-        python_builtins
         utils
 
 
@@ -21,7 +21,8 @@
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
 from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Xor, Cumulative, IfThenElse, GlobalCardinalityCount, DirectConstraint, InDomain
+from .globalconstraints import AllDifferent, AllDifferentExcept0, AllEqual, Circuit, Inverse, Table, Xor, Cumulative, \
+    IfThenElse, GlobalCardinalityCount, DirectConstraint, InDomain, Increasing, Decreasing, IncreasingStrict, DecreasingStrict
 from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
 from .globalfunctions import Maximum, Minimum, Abs, Element, Count, NValue
 from .core import BoolVal

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -537,6 +537,7 @@ class Increasing(GlobalConstraint):
         from .python_builtins import all
         return all(var1.value() <= var2.value() for var1, var2 in all_pairs(self.args))
 
+
 class Decreasing(GlobalConstraint):
     """
         The "Decreasing" constraint, the expressions will have decreasing (not strictly) values
@@ -556,6 +557,49 @@ class Decreasing(GlobalConstraint):
     def value(self):
         from .python_builtins import all
         return all(var1.value() >= var2.value() for var1, var2 in all_pairs(self.args))
+
+
+class IncreasingStrict(GlobalConstraint):
+    """
+        The "IncreasingStrict" constraint, the expressions will have increasing (strictly) values
+    """
+
+    def __init__(self, *args):
+        super().__init__("increasing_strict", flatlist(args))
+
+    def decompose(self):
+        """
+        Returns two lists of constraints:
+            1) the decomposition of the IncreasingStrict constraint
+            2) empty list of defining constraints
+        """
+        return [var1 < var2 for var1, var2 in all_pairs(self.args)], []
+
+    def value(self):
+        from .python_builtins import all
+        return all(var1.value() < var2.value() for var1, var2 in all_pairs(self.args))
+
+
+class DecreasingStrict(GlobalConstraint):
+    """
+        The "DecreasingStrict" constraint, the expressions will have decreasing (strictly) values
+    """
+
+    def __init__(self, *args):
+        super().__init__("decreasing_strict", flatlist(args))
+
+    def decompose(self):
+        """
+        Returns two lists of constraints:
+            1) the decomposition of the DecreasingStrict constraint
+            2) empty list of defining constraints
+        """
+        return [var1 > var2 for var1, var2 in all_pairs(self.args)], []
+
+    def value(self):
+        from .python_builtins import all
+        return all(var1.value() > var2.value() for var1, var2 in all_pairs(self.args))
+
 
 class DirectConstraint(Expression):
     """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -531,11 +531,13 @@ class Increasing(GlobalConstraint):
             1) the decomposition of the Increasing constraint
             2) empty list of defining constraints
         """
-        return [var1 <= var2 for var1, var2 in all_pairs(self.args)], []
+        args = self.args
+        return [(args[i] <= args[i+1]) for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
-        return all(var1.value() <= var2.value() for var1, var2 in all_pairs(self.args))
+        args = self.args
+        return all((args[i] <= args[i+1]) for i in range(len(args)-1))
 
 
 class Decreasing(GlobalConstraint):
@@ -552,11 +554,13 @@ class Decreasing(GlobalConstraint):
             1) the decomposition of the Decreasing constraint
             2) empty list of defining constraints
         """
-        return [var1 >= var2 for var1, var2 in all_pairs(self.args)], []
+        args = self.args
+        return [(args[i] >= args[i+1]) for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
-        return all(var1.value() >= var2.value() for var1, var2 in all_pairs(self.args))
+        args = self.args
+        return all((args[i] >= args[i+1]) for i in range(len(args)-1))
 
 
 class IncreasingStrict(GlobalConstraint):
@@ -573,11 +577,13 @@ class IncreasingStrict(GlobalConstraint):
             1) the decomposition of the IncreasingStrict constraint
             2) empty list of defining constraints
         """
-        return [var1 < var2 for var1, var2 in all_pairs(self.args)], []
+        args = self.args
+        return [(args[i] < args[i+1]) for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
-        return all(var1.value() < var2.value() for var1, var2 in all_pairs(self.args))
+        args = self.args
+        return all((args[i] < args[i+1]) for i in range(len(args)-1))
 
 
 class DecreasingStrict(GlobalConstraint):
@@ -594,11 +600,13 @@ class DecreasingStrict(GlobalConstraint):
             1) the decomposition of the DecreasingStrict constraint
             2) empty list of defining constraints
         """
-        return [var1 > var2 for var1, var2 in all_pairs(self.args)], []
+        args = self.args
+        return [(args[i] > args[i+1]) for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
-        return all(var1.value() > var2.value() for var1, var2 in all_pairs(self.args))
+        args = self.args
+        return all((args[i] > args[i+1]) for i in range(len(args)-1))
 
 
 class DirectConstraint(Expression):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -532,12 +532,12 @@ class Increasing(GlobalConstraint):
             2) empty list of defining constraints
         """
         args = self.args
-        return [(args[i] <= args[i+1]) for i in range(len(args)-1)], []
+        return [args[i] <= args[i+1] for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
         args = self.args
-        return all((args[i] <= args[i+1]) for i in range(len(args)-1))
+        return all(args[i].value() <= args[i+1].value() for i in range(len(args)-1))
 
 
 class Decreasing(GlobalConstraint):
@@ -555,12 +555,12 @@ class Decreasing(GlobalConstraint):
             2) empty list of defining constraints
         """
         args = self.args
-        return [(args[i] >= args[i+1]) for i in range(len(args)-1)], []
+        return [args[i] >= args[i+1] for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
         args = self.args
-        return all((args[i] >= args[i+1]) for i in range(len(args)-1))
+        return all(args[i].value() >= args[i+1].value() for i in range(len(args)-1))
 
 
 class IncreasingStrict(GlobalConstraint):
@@ -578,12 +578,12 @@ class IncreasingStrict(GlobalConstraint):
             2) empty list of defining constraints
         """
         args = self.args
-        return [(args[i] < args[i+1]) for i in range(len(args)-1)], []
+        return [args[i] < args[i+1] for i in range(len(args)-1)], []
 
     def value(self):
         from .python_builtins import all
         args = self.args
-        return all((args[i] < args[i+1]) for i in range(len(args)-1))
+        return all((args[i].value() < args[i+1].value()) for i in range(len(args)-1))
 
 
 class DecreasingStrict(GlobalConstraint):
@@ -606,7 +606,7 @@ class DecreasingStrict(GlobalConstraint):
     def value(self):
         from .python_builtins import all
         args = self.args
-        return all((args[i] > args[i+1]) for i in range(len(args)-1))
+        return all((args[i].value() > args[i+1].value()) for i in range(len(args)-1))
 
 
 class DirectConstraint(Expression):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -517,6 +517,46 @@ class GlobalCardinalityCount(GlobalConstraint):
         return all(decomposed).value()
 
 
+class Increasing(GlobalConstraint):
+    """
+        The "Increasing" constraint, the expressions will have increasing (not strictly) values
+    """
+
+    def __init__(self, *args):
+        super().__init__("increasing", flatlist(args))
+
+    def decompose(self):
+        """
+        Returns two lists of constraints:
+            1) the decomposition of the Increasing constraint
+            2) empty list of defining constraints
+        """
+        return [var1 <= var2 for var1, var2 in all_pairs(self.args)], []
+
+    def value(self):
+        from .python_builtins import all
+        return all(var1.value() <= var2.value() for var1, var2 in all_pairs(self.args))
+
+class Decreasing(GlobalConstraint):
+    """
+        The "Decreasing" constraint, the expressions will have decreasing (not strictly) values
+    """
+
+    def __init__(self, *args):
+        super().__init__("decreasing", flatlist(args))
+
+    def decompose(self):
+        """
+        Returns two lists of constraints:
+            1) the decomposition of the Decreasing constraint
+            2) empty list of defining constraints
+        """
+        return [var1 >= var2 for var1, var2 in all_pairs(self.args)], []
+
+    def value(self):
+        from .python_builtins import all
+        return all(var1.value() >= var2.value() for var1, var2 in all_pairs(self.args))
+
 class DirectConstraint(Expression):
     """
         A DirectConstraint will directly call a function of the underlying solver when added to a CPMpy solver

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -104,7 +104,14 @@
         Table
         Xor
         Cumulative
+        IfThenElse
         GlobalCardinalityCount
+        DirectConstraint
+        InDomain
+        Increasing
+        Decreasing
+        IncreasingStrict
+        DecreasingStrict
 
 """
 import copy

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -308,8 +308,11 @@ class CPM_choco(SolverInterface):
 
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "count", "element", "alldifferent", "alldifferent_except0", "allequal",
-                     "table", "InDomain", "cumulative", "circuit", "gcc", "inverse", "nvalue"}
-        supported_reified = supported # choco supports reification of any constraint
+                     "table", "InDomain", "cumulative", "circuit", "gcc", "inverse", "nvalue", "increasing",
+                     "decreasing","increasing_strict","decreasing_strict"}
+        # choco supports reification of any constraint, but has a bug in increasing and decreasing
+        supported_reified = {"min", "max", "abs", "count", "element", "alldifferent", "alldifferent_except0",
+                             "allequal", "table", "InDomain", "cumulative", "circuit", "gcc", "inverse", "nvalue"}
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = canonical_comparison(cpm_cons)
@@ -485,7 +488,7 @@ class CPM_choco(SolverInterface):
         elif isinstance(cpm_expr, GlobalConstraint):
 
             # many globals require all variables as arguments
-            if cpm_expr.name in {"alldifferent", "alldifferent_except0", "allequal", "circuit", "inverse"}:
+            if cpm_expr.name in {"alldifferent", "alldifferent_except0", "allequal", "circuit", "inverse","increasing","decreasing","increasing_strict","decreasing_strict"}:
                 chc_args = self._to_vars(cpm_expr.args)
                 if cpm_expr.name == 'alldifferent':
                     return self.chc_model.all_different(chc_args)
@@ -497,6 +500,14 @@ class CPM_choco(SolverInterface):
                     return self.chc_model.circuit(chc_args)
                 elif cpm_expr.name == "inverse":
                     return self.chc_model.inverse_channeling(*chc_args)
+                elif cpm_expr.name == "increasing":
+                    return self.chc_model.increasing(chc_args,0)
+                elif cpm_expr.name == "decreasing":
+                    return self.chc_model.decreasing(chc_args,0)
+                elif cpm_expr.name == "increasing_strict":
+                    return self.chc_model.increasing(chc_args,1)
+                elif cpm_expr.name == "decreasing_strict":
+                    return self.chc_model.decreasing(chc_args,1)
 
             # but not all
             elif cpm_expr.name == 'table':

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -313,6 +313,8 @@ class CPM_choco(SolverInterface):
         # choco supports reification of any constraint, but has a bug in increasing and decreasing
         supported_reified = {"min", "max", "abs", "count", "element", "alldifferent", "alldifferent_except0",
                              "allequal", "table", "InDomain", "cumulative", "circuit", "gcc", "inverse", "nvalue"}
+        # for when choco new release comes, fixing the bug on increasing and decreasing
+        #supported_reified = supported
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = canonical_comparison(cpm_cons)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -14,8 +14,8 @@ SOLVERNAMES = [name for name, solver in SolverLookup.base_solvers() if solver.su
 EXCLUDE_GLOBAL = {"ortools": {},
                   "gurobi": {},
                   "minizinc": {"circuit"},
-                  "pysat": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative"},
-                  "pysdd": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative",'xor'},
+                  "pysat": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative","increasing","decreasing"},
+                  "pysdd": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative","xor","increasing","decreasing"},
                   "exact": {},
                   "choco": {}
                   }
@@ -152,7 +152,7 @@ def global_constraints(solver):
         -  AllDifferent, AllEqual, Circuit,  Minimum, Maximum, Element,
            Xor, Cumulative, NValue, Count
     """
-    global_cons = [AllDifferent, AllEqual, Minimum, Maximum, NValue]
+    global_cons = [AllDifferent, AllEqual, Minimum, Maximum, NValue, Increasing, Decreasing]
     for global_type in global_cons:
         cons = global_type(NUM_ARGS)
         if solver not in EXCLUDE_GLOBAL or cons.name not in EXCLUDE_GLOBAL[solver]:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -14,8 +14,8 @@ SOLVERNAMES = [name for name, solver in SolverLookup.base_solvers() if solver.su
 EXCLUDE_GLOBAL = {"ortools": {},
                   "gurobi": {},
                   "minizinc": {"circuit"},
-                  "pysat": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative","increasing","decreasing"},
-                  "pysdd": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative","xor","increasing","decreasing"},
+                  "pysat": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative","increasing","decreasing","increasing_strict","decreasing_strict"},
+                  "pysdd": {"circuit", "element","min","max","count", "nvalue", "allequal","alldifferent","cumulative","xor","increasing","decreasing","increasing_strict","decreasing_strict"},
                   "exact": {},
                   "choco": {}
                   }
@@ -152,7 +152,7 @@ def global_constraints(solver):
         -  AllDifferent, AllEqual, Circuit,  Minimum, Maximum, Element,
            Xor, Cumulative, NValue, Count
     """
-    global_cons = [AllDifferent, AllEqual, Minimum, Maximum, NValue, Increasing, Decreasing]
+    global_cons = [AllDifferent, AllEqual, Minimum, Maximum, NValue, Increasing, Decreasing, IncreasingStrict, DecreasingStrict]
     for global_type in global_cons:
         cons = global_type(NUM_ARGS)
         if solver not in EXCLUDE_GLOBAL or cons.name not in EXCLUDE_GLOBAL[solver]:


### PR DESCRIPTION
Increasing and decreasing (+ strict cases seperately) global constraints.

Implemented decomposition with all pairs (not only consecutive ones), should I change it to consequtive ones as it has the same effect with less constraints?

+ For choco, it normally supports all globals reified, but it has a bug at increasing and decreasing propagation in negative context. They fixed it, but until the next release the bug is there.

So, I had to remove the beautiul supported_reified = supported, and put the list of the rest constraints.