### PR TITLE
Utility functions for NDVarArrays

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -555,6 +555,40 @@ class NDVarArray(np.ndarray, Expression):
 
         return np.apply_along_axis(cpm_all, axis=axis, arr=self)
 
+    def alldifferent(self, axis=None):
+        from .globalconstraints import AllDifferent
+        return np.apply_along_axis(lambda arr : AllDifferent(arr), axis=axis, arr=self)
+
+    def alldifferent_except0(self, axis=None):
+        from .globalconstraints import AllDifferentExcept0
+        return np.apply_along_axis(lambda arr: AllDifferentExcept0(arr), axis=axis, arr=self)
+
+    def allequal(self, axis=None):
+        from .globalconstraints import AllEqual
+        return np.apply_along_axis(lambda arr: AllEqual(arr), axis=axis, arr=self)
+
+    def circuit(self, axis=None):
+        from .globalconstraints import Circuit
+        return np.apply_along_axis(lambda arr: Circuit(arr), axis=axis, arr=self)
+
+    def increasing(self, axis=None):
+        from .globalconstraints import Increasing
+        return np.apply_along_axis(lambda arr: Increasing(arr), axis=axis, arr=self)
+
+    def increasing_strict(self, axis=None):
+        from .globalconstraints import IncreasingStrict
+        return np.apply_along_axis(lambda arr: IncreasingStrict(arr), axis=axis, arr=self)
+
+    def decreasing(self, axis=None):
+        from .globalconstraints import Decreasing
+        return np.apply_along_axis(lambda arr: Decreasing(arr), axis=axis, arr=self)
+
+    def decreasing_strict(self, axis=None):
+        from .globalconstraints import DecreasingStrict
+        return np.apply_along_axis(lambda arr: DecreasingStrict(arr), axis=axis, arr=self)
+
+
+
     def get_bounds(self):
         lbs, ubs = zip(*[get_bounds(e) for e in self])
         return cpm_array(lbs), cpm_array(ubs)

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -487,7 +487,7 @@ class NDVarArray(np.ndarray, Expression):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:  # simple case where we want the maximum over the whole array
+        if axis is None:  # simple case where we want the product over the whole array
             return reduce(lambda a, b: a * b, self.flatten())
 
         # TODO: is there a better way? This does pairwise multiplication still
@@ -514,7 +514,7 @@ class NDVarArray(np.ndarray, Expression):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the maximum over the whole array
+        if axis is None:    # simple case where we want the minimum over the whole array
             return cpm_min(self)
 
         return cpm_array(np.apply_along_axis(cpm_min, axis=axis, arr=self))
@@ -523,7 +523,7 @@ class NDVarArray(np.ndarray, Expression):
         """
             overwrite np.any(NDVarArray)
         """
-        from .python_builtins import max as cpm_any
+        from .python_builtins import any as cpm_any
 
         if any(not is_boolexpr(x) for x in self.flat):
             raise TypeError("Cannot call .any() in an array not consisting only of bools")
@@ -531,7 +531,7 @@ class NDVarArray(np.ndarray, Expression):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the maximum over the whole array
+        if axis is None:    # simple case where we want a disjunction over the whole array
             return cpm_any(self)
 
         return cpm_array(np.apply_along_axis(cpm_any, axis=axis, arr=self))
@@ -542,7 +542,7 @@ class NDVarArray(np.ndarray, Expression):
             overwrite np.any(NDVarArray)
         """
 
-        from .python_builtins import max as cpm_all
+        from .python_builtins import all as cpm_all
 
         if any(not is_boolexpr(x) for x in self.flat):
             raise TypeError("Cannot call .any() in an array not consisting only of bools")
@@ -550,7 +550,7 @@ class NDVarArray(np.ndarray, Expression):
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:  # simple case where we want the maximum over the whole array
+        if axis is None:  # simple case where we want a conjunction over the whole array
             return cpm_all(self)
 
         return cpm_array(np.apply_along_axis(cpm_all, axis=axis, arr=self))

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -488,9 +488,9 @@ class NDVarArray(np.ndarray, Expression):
             raise NotImplementedError()
 
         if axis is None:  # simple case where we want the maximum over the whole array
-            return Operator("mul", self)
+            return reduce(lambda a, b: a * b, self.flatten())
 
-        # TODO: is there a better way? This does pairwise multiplication
+        # TODO: is there a better way? This does pairwise multiplication still
         return np.multiply.reduce(self, axis=axis)
 
     def max(self, axis=None, out=None):

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -569,40 +569,6 @@ class NDVarArray(np.ndarray, Expression):
 
         return cpm_array(np.apply_along_axis(cpm_all, axis=axis, arr=self))
 
-    def alldifferent(self, axis=None):
-        from .globalconstraints import AllDifferent
-        return cpm_array(np.apply_along_axis(lambda arr : AllDifferent(arr), axis=axis, arr=self))
-
-    def alldifferent_except0(self, axis=None):
-        from .globalconstraints import AllDifferentExcept0
-        return cpm_array(np.apply_along_axis(lambda arr: AllDifferentExcept0(arr), axis=axis, arr=self))
-
-    def allequal(self, axis=None):
-        from .globalconstraints import AllEqual
-        return cpm_array(np.apply_along_axis(lambda arr: AllEqual(arr), axis=axis, arr=self))
-
-    def circuit(self, axis=None):
-        from .globalconstraints import Circuit
-        return cpm_array(np.apply_along_axis(lambda arr: Circuit(arr), axis=axis, arr=self))
-
-    def increasing(self, axis=None):
-        from .globalconstraints import Increasing
-        return cpm_array(np.apply_along_axis(lambda arr: Increasing(arr), axis=axis, arr=self))
-
-    def increasing_strict(self, axis=None):
-        from .globalconstraints import IncreasingStrict
-        return cpm_array(np.apply_along_axis(lambda arr: IncreasingStrict(arr), axis=axis, arr=self))
-
-    def decreasing(self, axis=None):
-        from .globalconstraints import Decreasing
-        return cpm_array(np.apply_along_axis(lambda arr: Decreasing(arr), axis=axis, arr=self))
-
-    def decreasing_strict(self, axis=None):
-        from .globalconstraints import DecreasingStrict
-        return cpm_array(np.apply_along_axis(lambda arr: DecreasingStrict(arr), axis=axis, arr=self))
-
-
-
     def get_bounds(self):
         lbs, ubs = zip(*[get_bounds(e) for e in self])
         return cpm_array(lbs), cpm_array(ubs)

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -468,132 +468,92 @@ class NDVarArray(np.ndarray, Expression):
         """
             overwrite np.sum(NDVarArray) as people might use it
         """
+        from .python_builtins import sum as cpm_sum
+
         if out is not None:
             raise NotImplementedError()
 
         if axis is None:    # simple case where we want the sum over the whole array
-            arr = self.flatten()
-            return Operator("sum", arr)
+            return cpm_sum(self)
 
-        arr = self.__axis(axis=axis)
-
-        out = []
-        for i in range(0, arr.shape[0]):
-            out.append(Operator("sum", arr[i, ...]))
-
-        # return the NDVarArray that contains the sum constraints
-        return out
+        return np.apply_along_axis(cpm_sum, axis=axis, arr=self)
 
 
     def prod(self, axis=None, out=None):
         """
             overwrite np.prod(NDVarArray) as people might use it
         """
+
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the product over the whole array
-            arr = self.flatten()
-            return reduce(lambda a, b: a * b, arr)
+        if axis is None:  # simple case where we want the maximum over the whole array
+            return Operator("mul", self)
 
-        arr = self.__axis(axis=axis)
-
-        out = []
-        for i in range(0, arr.shape[0]):
-            out.append(reduce(lambda a, b: a * b, arr[i, ...]))
-
-        # return the NDVarArray that contains the sum constraints
-        return out
+        # TODO: is there a better way? This does pairwise multiplication
+        return np.multiply.reduce(self, axis=axis)
 
     def max(self, axis=None, out=None):
         """
             overwrite np.max(NDVarArray) as people might use it
         """
-        from .globalfunctions import Maximum
+        from .python_builtins import max as cpm_max
         if out is not None:
             raise NotImplementedError()
 
         if axis is None:    # simple case where we want the maximum over the whole array
-            arr = self.flatten()
-            return Maximum(arr)
+            return cpm_max(self)
 
-        arr = self.__axis(axis=axis)
-
-        out = []
-        for i in range(0, arr.shape[0]):
-            out.append(Maximum(arr[i, ...]))
-
-        # return the NDVarArray that contains the Maximum global constraints
-        return out
+        return np.apply_along_axis(cpm_max, axis=axis, arr=self)
 
     def min(self, axis=None, out=None):
         """
             overwrite np.min(NDVarArray) as people might use it
         """
-        from .globalfunctions import Minimum
+        from .python_builtins import min as cpm_min
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the Minimum over the whole array
-            arr = self.flatten()
-            return Minimum(arr)
+        if axis is None:    # simple case where we want the maximum over the whole array
+            return cpm_min(self)
 
-        arr = self.__axis(axis=axis)
-
-        out = []
-        for i in range(0, arr.shape[0]):
-            out.append(Minimum(arr[i, ...]))
-
-        # return the NDVarArray that contains the Minimum global constraints
-        return out
+        return np.apply_along_axis(cpm_min, axis=axis, arr=self)
 
     def any(self, axis=None, out=None):
         """
             overwrite np.any(NDVarArray)
         """
-        from .python_builtins import any
+        from .python_builtins import max as cpm_any
 
-        if any(not is_boolexpr(x) for x in self.flatten()):
+        if any(not is_boolexpr(x) for x in self.flat):
             raise TypeError("Cannot call .any() in an array not consisting only of bools")
 
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the .any() over the whole array
-            arr = self.flatten()
-            return any(arr)
+        if axis is None:    # simple case where we want the maximum over the whole array
+            return cpm_any(self)
 
-        arr = self.__axis(axis=axis)
+        return np.apply_along_axis(cpm_any, axis=axis, arr=self)
 
-        out = []
-        for i in range(0, arr.shape[0]):
-            out.append(any(arr[i, ...]))
-
-        # return the NDVarArray that contains the any() constraints
-        return out
 
     def all(self, axis=None, out=None):
         """
             overwrite np.any(NDVarArray)
         """
 
-        from .python_builtins import all
+        from .python_builtins import max as cpm_all
+
+        if any(not is_boolexpr(x) for x in self.flat):
+            raise TypeError("Cannot call .any() in an array not consisting only of bools")
+
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the .all() over the whole array
-            arr = self.flatten()
-            return all(arr)
+        if axis is None:  # simple case where we want the maximum over the whole array
+            return cpm_all(self)
 
-        arr = self.__axis(axis=axis)
-
-        out = []
-        for i in range(0, arr.shape[0]):
-            out.append(all(arr[i, ...]))
-
-        # return the NDVarArray that contains the all() constraints
-        return out
-
+        return np.apply_along_axis(cpm_all, axis=axis, arr=self)
 
     def get_bounds(self):
         lbs, ubs = zip(*[get_bounds(e) for e in self])

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -476,7 +476,7 @@ class NDVarArray(np.ndarray, Expression):
         if axis is None:    # simple case where we want the sum over the whole array
             return cpm_sum(self)
 
-        return np.apply_along_axis(cpm_sum, axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(cpm_sum, axis=axis, arr=self))
 
 
     def prod(self, axis=None, out=None):
@@ -491,7 +491,7 @@ class NDVarArray(np.ndarray, Expression):
             return reduce(lambda a, b: a * b, self.flatten())
 
         # TODO: is there a better way? This does pairwise multiplication still
-        return np.multiply.reduce(self, axis=axis)
+        return cpm_array(np.multiply.reduce(self, axis=axis))
 
     def max(self, axis=None, out=None):
         """
@@ -504,7 +504,7 @@ class NDVarArray(np.ndarray, Expression):
         if axis is None:    # simple case where we want the maximum over the whole array
             return cpm_max(self)
 
-        return np.apply_along_axis(cpm_max, axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(cpm_max, axis=axis, arr=self))
 
     def min(self, axis=None, out=None):
         """
@@ -517,7 +517,7 @@ class NDVarArray(np.ndarray, Expression):
         if axis is None:    # simple case where we want the maximum over the whole array
             return cpm_min(self)
 
-        return np.apply_along_axis(cpm_min, axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(cpm_min, axis=axis, arr=self))
 
     def any(self, axis=None, out=None):
         """
@@ -534,7 +534,7 @@ class NDVarArray(np.ndarray, Expression):
         if axis is None:    # simple case where we want the maximum over the whole array
             return cpm_any(self)
 
-        return np.apply_along_axis(cpm_any, axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(cpm_any, axis=axis, arr=self))
 
 
     def all(self, axis=None, out=None):
@@ -553,39 +553,39 @@ class NDVarArray(np.ndarray, Expression):
         if axis is None:  # simple case where we want the maximum over the whole array
             return cpm_all(self)
 
-        return np.apply_along_axis(cpm_all, axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(cpm_all, axis=axis, arr=self))
 
     def alldifferent(self, axis=None):
         from .globalconstraints import AllDifferent
-        return np.apply_along_axis(lambda arr : AllDifferent(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr : AllDifferent(arr), axis=axis, arr=self))
 
     def alldifferent_except0(self, axis=None):
         from .globalconstraints import AllDifferentExcept0
-        return np.apply_along_axis(lambda arr: AllDifferentExcept0(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: AllDifferentExcept0(arr), axis=axis, arr=self))
 
     def allequal(self, axis=None):
         from .globalconstraints import AllEqual
-        return np.apply_along_axis(lambda arr: AllEqual(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: AllEqual(arr), axis=axis, arr=self))
 
     def circuit(self, axis=None):
         from .globalconstraints import Circuit
-        return np.apply_along_axis(lambda arr: Circuit(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: Circuit(arr), axis=axis, arr=self))
 
     def increasing(self, axis=None):
         from .globalconstraints import Increasing
-        return np.apply_along_axis(lambda arr: Increasing(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: Increasing(arr), axis=axis, arr=self))
 
     def increasing_strict(self, axis=None):
         from .globalconstraints import IncreasingStrict
-        return np.apply_along_axis(lambda arr: IncreasingStrict(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: IncreasingStrict(arr), axis=axis, arr=self))
 
     def decreasing(self, axis=None):
         from .globalconstraints import Decreasing
-        return np.apply_along_axis(lambda arr: Decreasing(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: Decreasing(arr), axis=axis, arr=self))
 
     def decreasing_strict(self, axis=None):
         from .globalconstraints import DecreasingStrict
-        return np.apply_along_axis(lambda arr: DecreasingStrict(arr), axis=axis, arr=self)
+        return cpm_array(np.apply_along_axis(lambda arr: DecreasingStrict(arr), axis=axis, arr=self))
 
 
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -312,9 +312,22 @@ class TestArrayExpressions(unittest.TestCase):
         res = np.array([all(x[i, ...].value()) for i in range(len(y))])
         self.assertTrue(all(y.value() == res))
 
+
+    def test_multidim(self):
+
+        functions = ["all", "any", "max", "min", "sum", "prod"]
+        bv = cp.boolvar(shape=(5,4,3,2)) # high dimensional tensor
+        arr = np.zeros(shape=bv.shape) # numpy "ground truth"
+
+        for axis in range(len(bv.shape)):
+            for func in functions:
+                cpm_res = getattr(bv, func)(axis=axis)
+                np_res = getattr(arr, func)(axis=axis)
+                self.assertEqual(cpm_res.shape, np_res.shape)
+
         
 def inclusive_range(lb,ub):
-        return range(lb,ub+1)
+    return range(lb,ub+1)
 
 class TestBounds(unittest.TestCase):
     def test_bounds_mul_sub_sum(self):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -326,9 +326,11 @@ class TestArrayExpressions(unittest.TestCase):
             np_res = arr.sum(axis=axis)
             for func in functions:
                 cpm_res = getattr(bv, func)(axis=axis)
+                self.assertIsInstance(cpm_res, NDVarArray)
                 self.assertEqual(cpm_res.shape, np_res.shape)
             for cons in constraints:
-                cpm_res = getattr(iv, func)(axis=axis)
+                cpm_res = getattr(iv, cons)(axis=axis)
+                self.assertIsInstance(cpm_res, NDVarArray)
                 self.assertEqual(cpm_res.shape, np_res.shape)
 
         

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -316,13 +316,19 @@ class TestArrayExpressions(unittest.TestCase):
     def test_multidim(self):
 
         functions = ["all", "any", "max", "min", "sum", "prod"]
+        constraints = ["alldifferent", "alldifferent_except0", "allequal", "circuit",
+                       "increasing", "increasing_strict", "decreasing", "decreasing_strict"]
         bv = cp.boolvar(shape=(5,4,3,2)) # high dimensional tensor
+        iv = cp.intvar(0,10,shape=(5,4,3,2))
         arr = np.zeros(shape=bv.shape) # numpy "ground truth"
 
         for axis in range(len(bv.shape)):
+            np_res = arr.sum(axis=axis)
             for func in functions:
                 cpm_res = getattr(bv, func)(axis=axis)
-                np_res = getattr(arr, func)(axis=axis)
+                self.assertEqual(cpm_res.shape, np_res.shape)
+            for cons in constraints:
+                cpm_res = getattr(iv, func)(axis=axis)
                 self.assertEqual(cpm_res.shape, np_res.shape)
 
         

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -316,10 +316,7 @@ class TestArrayExpressions(unittest.TestCase):
     def test_multidim(self):
 
         functions = ["all", "any", "max", "min", "sum", "prod"]
-        constraints = ["alldifferent", "alldifferent_except0", "allequal", "circuit",
-                       "increasing", "increasing_strict", "decreasing", "decreasing_strict"]
         bv = cp.boolvar(shape=(5,4,3,2)) # high dimensional tensor
-        iv = cp.intvar(0,10,shape=(5,4,3,2))
         arr = np.zeros(shape=bv.shape) # numpy "ground truth"
 
         for axis in range(len(bv.shape)):
@@ -328,11 +325,6 @@ class TestArrayExpressions(unittest.TestCase):
                 cpm_res = getattr(bv, func)(axis=axis)
                 self.assertIsInstance(cpm_res, NDVarArray)
                 self.assertEqual(cpm_res.shape, np_res.shape)
-            for cons in constraints:
-                cpm_res = getattr(iv, cons)(axis=axis)
-                self.assertIsInstance(cpm_res, NDVarArray)
-                self.assertEqual(cpm_res.shape, np_res.shape)
-
         
 def inclusive_range(lb,ub):
     return range(lb,ub+1)
@@ -539,8 +531,26 @@ class TestBounds(unittest.TestCase):
         self.assertEqual(str(cons), "either a or b should be true, but not both -- (a) or (b)")
 
 
+class TestBuildIns(unittest.TestCase):
 
+    def setUp(self):
+        self.x = cp.intvar(0,10,shape=3)
 
+    def test_sum(self):
+        gt = Operator("sum", list(self.x))
+
+        self.assertEqual(str(gt), str(cp.sum(self.x)))
+        self.assertEqual(str(gt), str(cp.sum(list(self.x))))
+        self.assertEqual(str(gt), str(cp.sum(v for v in self.x)))
+        self.assertEqual(str(gt), str(cp.sum(self.x[0], self.x[1], self.x[2])))
+
+    def test_max(self):
+        gt = Maximum(self.x)
+
+        self.assertEqual(str(gt), str(cp.max(self.x)))
+        self.assertEqual(str(gt), str(cp.max(list(self.x))))
+        self.assertEqual(str(gt), str(cp.max(v for v in self.x)))
+        self.assertEqual(str(gt), str(cp.max(self.x[0], self.x[1], self.x[2])))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was an issue with our overriding of numpy-functionality for NDVarArrays with higher dimensions.
E.g., the following happened:
```python
bvs = cp.boolvar(shape=(3,3,2))
res = bvs.any(axis=2)
```
Now `res` was a single clause with 18 elements, while doing the same with a numpy array results a 3x3 matrix, which is correct. This PR fixes that.

[Feature] Also added the option to create common global constraints directly from the array.
E.g., a user can now do `puzzle.alldifferent(axis=1)` to post the alldifferent constraints over the columns of a Sudoku.