### PR TITLE
allow kwargs in Model.solve()

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -136,7 +136,7 @@ class Model(object):
         self.objective(expr, minimize=False)
 
     # solver: name of supported solver or any SolverInterface object
-    def solve(self, solver=None, time_limit=None):
+    def solve(self, solver=None, time_limit=None, **kwargs):
         """ Send the model to a solver and get the result
 
         :param solver: name of a solver to use. Run SolverLookup.solvernames() to find out the valid solver names on your system. (default: None = first available solver)
@@ -156,7 +156,7 @@ class Model(object):
             s = SolverLookup.get(solver, self)
 
         # call solver
-        ret = s.solve(time_limit=time_limit)
+        ret = s.solve(time_limit=time_limit, **kwargs)
         # store CPMpy status (s object has no further use)
         self.cpm_status = s.status()
         return ret


### PR DESCRIPTION
found when quickly wanting to tests gcs' `verify=True` argument.