### PR TITLE
Minizinc print

### DIFF
--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -697,3 +697,19 @@ class CPM_minizinc(SolverInterface):
             finally:
                 asyncio.events.set_event_loop(None)
                 loop.close()
+
+    def minizinc_string(self) -> list[str]:
+        """
+            Returns the model as represented in the Minizinc language.
+        """
+        return "".join(self._pre_solve()[1]._code_fragments)
+
+    def flatzinc_string(self, **kwargs) -> list[str]:
+        """
+            Returns the model as represented in the Flatzinc language.
+        """
+        with self._pre_solve()[1].flat(**kwargs) as (fzn, ozn, statistics):
+            with open(fzn.name) as f:
+                f.seek(0)
+                contents = f.readlines()
+        return "".join(contents)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -698,13 +698,13 @@ class CPM_minizinc(SolverInterface):
                 asyncio.events.set_event_loop(None)
                 loop.close()
 
-    def minizinc_string(self) -> list[str]:
+    def minizinc_string(self) -> str:
         """
             Returns the model as represented in the Minizinc language.
         """
         return "".join(self._pre_solve()[1]._code_fragments)
 
-    def flatzinc_string(self, **kwargs) -> list[str]:
+    def flatzinc_string(self, **kwargs) -> str:
         """
             Returns the model as represented in the Flatzinc language.
         """


### PR DESCRIPTION
When working on the XCSP3 competition, I needed to access the Minizinc and Flatzinc models to debug our decompositions. @IgnaceBleukx explained to me how I should access the underlying native solve and how to print the models. It is not that straight forward, especially for flatzinc due to the `_TemporaryFileWrapper` that the minizinc library returns. I thought it might be useful to add the retrieval of these "minizinc model strings" as a build-in method of the minizinc solver object.