### PR TITLE
Extension to tools: MARCO and SMUS

### DIFF
--- a/cpmpy/tools/explain/__init__.py
+++ b/cpmpy/tools/explain/__init__.py
@@ -1,3 +1,4 @@
 from .mus import *
 from .mss import *
 from .mcs import *
+from .marco import *

--- a/cpmpy/tools/explain/marco.py
+++ b/cpmpy/tools/explain/marco.py
@@ -1,0 +1,55 @@
+"""
+ Re-implementation of MUS-enumeration using MARCO.
+"""
+
+import cpmpy as cp
+from cpmpy.tools import make_assump_model
+
+
+
+def marco(soft, hard=[], solver="ortools", map_solver="ortools"):
+    """
+        Enumerates all MUSes in the unsatisfiable problem
+        Iteratively generates a subset of constraints (the seed) and checks whether it is SAT.
+        When the seed is SAT, it is grown to an MSS to derive an MCS.
+        This MCS is then added to the Map solver as a set to hit
+        In case the seed is UNSAT, the seed is shrunk to a real MUS and returned.
+        The Map-solver is instructed to not generated any superset of this MUS as next seeds
+
+        Based on:
+            Liffiton, Mark H., et al. "Fast, flexible MUS enumeration." Constraints 21 (2016): 223-250.
+    """
+
+    model, soft, assump = make_assump_model(soft, hard)
+    dmap = dict(zip(assump, soft))
+    s = cp.SolverLookup.get(solver, model)
+
+    map_solver = cp.SolverLookup.get(map_solver)
+    map_solver += cp.any(assump)
+    map_solver.solution_hint(assump, [1]*len(assump)) # we want large subsets, more likely to be a MUS
+
+    while map_solver.solve():
+
+        seed = [a for a in assump if a.value()]
+
+        if s.solve(assumptions=seed) is True: # SAT subset, find corr subsets
+            sat_subset = seed
+            new_mcs = [a for a, c in zip(assump, soft) if a.value() is False and c.value() is False]
+            map_solver += cp.any(new_mcs)
+            sat_subset += new_mcs
+            while s.solve(assumptions=sat_subset) is True:
+                new_mcs = [a for a, c in zip(assump, soft) if a.value() is False and c.value() is False]
+                sat_subset += new_mcs  # extend sat subset with new MCS
+                map_solver += cp.any(new_mcs)
+
+        else: # UNSAT, shrink to MUS, re-use MUSX
+            core = s.get_core()
+            mus = []
+            for i in range(len(core)):
+                subassump = mus + core[i + 1:]  # all but the 'i'th constraint
+                if s.solve(assumptions=subassump):
+                    mus.append(core[i])
+
+            yield [dmap[a] for a in mus]
+            # block in map solver
+            map_solver += ~cp.all(mus)

--- a/cpmpy/tools/explain/marco.py
+++ b/cpmpy/tools/explain/marco.py
@@ -29,6 +29,9 @@ def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True
     map_solver = cp.SolverLookup.get(map_solver)
     map_solver += cp.any(assump)
     map_solver.solution_hint(assump, [1]*len(assump)) # we want large subsets, more likely to be a MUS
+    hint = [1] *len(assump)
+    map_solver.solution_hint(assump, hint) # we want large subsets, more likely to be a MUS
+
 
     while map_solver.solve():
 
@@ -50,7 +53,7 @@ def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True
                 # find more MCSes, disjoint from this one, similar to "optimal_mus" in mus.py
                 # can only be done when MCSes do not have to be returned as there is no guarantee
                 # the MCSes encountered during enumeration are "new" MCSes
-                sat_subset = [a for a,c in zip(assump, soft) if not (a.value() or c.value())]
+                sat_subset = [a for a,c in zip(assump, soft) if not (a.value() or c.value())] # start from corr_subset
                 map_solver += cp.any(sat_subset)
                 while s.solve(assumptions=sat_subset) is True:
                     mss = [a for a, c in zip(assump, soft) if a.value() or c.value()]
@@ -74,3 +77,5 @@ def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True
 
             # block in map solver
             map_solver += ~cp.all(core)
+        # ensure solution hint is still active
+        map_solver.solution_hint(assump, hint)

--- a/cpmpy/tools/explain/marco.py
+++ b/cpmpy/tools/explain/marco.py
@@ -28,10 +28,10 @@ def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True
 
     map_solver = cp.SolverLookup.get(map_solver)
     map_solver += cp.any(assump)
-    map_solver.solution_hint(assump, [1]*len(assump)) # we want large subsets, more likely to be a MUS
     hint = [1] *len(assump)
     map_solver.solution_hint(assump, hint) # we want large subsets, more likely to be a MUS
 
+    deletion_order = {a : -len(get_variables(dmap[a])) for a in assump} # avoid recomputing
 
     while map_solver.solve():
 
@@ -63,7 +63,7 @@ def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True
 
         else: # UNSAT, shrink to MUS, re-use MUSX
             core = set(s.get_core())
-            for c in sorted(core, key=lambda a : len(get_variables(dmap[a]))):
+            for c in sorted(core, key=deletion_order.get):
                 if c not in core: # already removed
                     continue
                 core.remove(c)

--- a/cpmpy/tools/explain/marco.py
+++ b/cpmpy/tools/explain/marco.py
@@ -3,7 +3,7 @@
 """
 
 import cpmpy as cp
-from cpmpy.tools import make_assump_model
+from .utils import make_assump_model
 
 
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -266,55 +266,5 @@ def optimal_mus_naive(soft, hard=[], weights=1, solver="ortools", hs_solver="ort
     return hitting_set
 
 
-## MUS enumeration (should this be in a separate file?)
-def marco(soft, hard=[], solver="ortools", map_solver="ortools"):
-    """
-        Enumerates all MUSes in the unsatisfiable problem
-        Iteratively generates a subset of constraints (the seed) and checks whether it is SAT.
-        When the seed is SAT, it is grown to an MSS to derive an MCS.
-        This MCS is then added to the Map solver as a set to hit
-        In case the seed is UNSAT, the seed is shrunk to a real MUS and returned.
-        The Map-solver is instructed to not generated any superset of this MUS as next seeds
-
-        Based on:
-            Liffiton, Mark H., et al. "Fast, flexible MUS enumeration." Constraints 21 (2016): 223-250.
-    """
-
-    model, soft, assump = make_assump_model(soft, hard)
-    dmap = dict(zip(assump, soft))
-    s = cp.SolverLookup.get(solver, model)
-
-    map_solver = cp.SolverLookup.get(map_solver)
-    map_solver += cp.any(assump)
-    map_solver.solution_hint(assump, [1]*len(assump)) # we want large subsets, more likely to be a MUS
-
-    while map_solver.solve():
-
-        seed = [a for a in assump if a.value()]
-
-        if s.solve(assumptions=seed) is True: # SAT subset, find corr subsets
-            sat_subset = seed
-            new_mcs = [a for a, c in zip(assump, soft) if a.value() is False and c.value() is False]
-            map_solver += cp.any(new_mcs)
-            sat_subset += new_mcs
-            while s.solve(assumptions=sat_subset) is True:
-                new_mcs = [a for a, c in zip(assump, soft) if a.value() is False and c.value() is False]
-                sat_subset += new_mcs  # extend sat subset with new MCS
-                map_solver += cp.any(new_mcs)
-
-        else: # UNSAT, shrink to MUS, re-use MUSX
-            core = s.get_core()
-            mus = []
-            for i in range(len(core)):
-                subassump = mus + core[i + 1:]  # all but the 'i'th constraint
-                if s.solve(assumptions=subassump):
-                    mus.append(core[i])
-
-            yield [dmap[a] for a in mus]
-            # block in map solver
-            map_solver += ~cp.all(mus)
-
-
-
 
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -10,7 +10,6 @@ import cpmpy as cp
 from cpmpy.transformations.get_variables import get_variables
 from cpmpy.transformations.normalize import toplevel_list
 
-from .mss import mss_grow_naive
 from .utils import make_assump_model
 from ...expressions.utils import is_num
 
@@ -151,6 +150,8 @@ def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortool
         # else, the hitting set is SAT, now try to extend it without extra solve calls.
         # Check which other assumptions/constraints are satisfied (using c.value())
         # complement of grown subset is a correction subset
+        # Assumptions encode indicator constraints a -> c, find all false assumptions
+        #   that really have to be false given the current solution.
         new_corr_subset = [a for a,c in zip(assump, soft) if a.value() is False and c.value() is False]
         hs_solver += cp.sum(new_corr_subset) >= 1
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -4,7 +4,6 @@
     - Deletion-based MUS
     - QuickXplain
     - Optimal MUS
-    - MUS enumeration with MARCO
 """
 import numpy as np
 import cpmpy as cp

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -131,7 +131,7 @@ def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortool
 
 
     model, soft, assump = make_assump_model(soft, hard)
-    dmap = dict(zip(assump, soft))
+    dmap = dict(zip(assump, soft)) # map assumption variables to constraints
 
     s = cp.SolverLookup.get(solver, model)
     if hasattr(s, "solution_hint"): # algo is constructive, so favor large subsets

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -118,10 +118,8 @@ def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortool
         Assumption-based implementation for solvers that support s.solve(assumptions=...)
         More naive version available as `optimal_mus_naive` to use with other solvers.
 
-        CPMpy implementation loosely based on the "SMUS" algorithm from
-            Ignatiev, Alexey, et al. "Smallest MUS extraction with minimal hitting set dualization."
-            International Conference on Principles and Practice of Constraint Programming. Cham: Springer International Publishing, 2015.
-        and OCUS from:
+        CPMpy implementation loosely based on the "OCUS" algorithm from:
+
             Gamba, Emilio, Bart Bogaerts, and Tias Guns. "Efficiently explaining CSPs with unsatisfiable subset optimization."
             Journal of Artificial Intelligence Research 78 (2023): 709-746.
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -1,12 +1,10 @@
 """
     Re-impementation of MUS-computation techniques in CPMPy
 
-Loosely based on PySat's MUSX:
-https://github.com/pysathq/pysat/blob/master/examples/musx.py
-
     - Deletion-based MUS
     - QuickXplain
     - Optimal MUS
+    - MUS enumeration with MARCO
 """
 import numpy as np
 import cpmpy as cp
@@ -262,3 +260,57 @@ def optimal_mus_naive(soft, hard=[], weights=1, solver="ortools", hs_solver="ort
         hs_solver += cp.sum(mcs) >= 1
 
     return hitting_set
+
+
+## MUS enumeration (should this be in a separate file?)
+def marco(soft, hard=[], solver="ortools", map_solver="ortools"):
+    """
+        Enumerates all MUSes in the unsatisfiable problem
+        Iteratively generates a subset of constraints (the seed) and checks whether it is SAT.
+        When the seed is SAT, it is grown to an MSS to derive an MCS.
+        This MCS is then added to the Map solver as a set to hit
+        In case the seed is UNSAT, the seed is shrunk to a real MUS and returned.
+        The Map-solver is instructed to not generated any superset of this MUS as next seeds
+
+        Based on:
+            Liffiton, Mark H., et al. "Fast, flexible MUS enumeration." Constraints 21 (2016): 223-250.
+    """
+
+    model, soft, assump = make_assump_model(soft, hard)
+    dmap = dict(zip(assump, soft))
+    s = cp.SolverLookup.get(solver, model)
+
+    map_solver = cp.SolverLookup.get(map_solver)
+    map_solver += cp.any(assump)
+    map_solver.solution_hint(assump, [1]*len(assump)) # we want large subsets, more likely to be a MUS
+
+    while map_solver.solve():
+
+        seed = [a for a in assump if a.value()]
+
+        if s.solve(assumptions=seed) is True: # SAT subset, find corr subsets
+            sat_subset = seed
+            new_mcs = [a for a, c in zip(assump, soft) if a.value() is False and c.value() is False]
+            map_solver += cp.any(new_mcs)
+            sat_subset += new_mcs
+            while s.solve(assumptions=sat_subset) is True:
+                new_mcs = [a for a, c in zip(assump, soft) if a.value() is False and c.value() is False]
+                sat_subset += new_mcs  # extend sat subset with new MCS
+                map_solver += cp.any(new_mcs)
+
+        else: # UNSAT, shrink to MUS, re-use MUSX
+            core = s.get_core()
+            mus = []
+            for i in range(len(core)):
+                subassump = mus + core[i + 1:]  # all but the 'i'th constraint
+                if s.solve(assumptions=subassump):
+                    mus.append(core[i])
+
+            yield [dmap[a] for a in mus]
+            # block in map solver
+            map_solver += ~cp.all(mus)
+
+
+
+
+

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -134,7 +134,10 @@ def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortool
     dmap = dict(zip(assump, soft))
 
     s = cp.SolverLookup.get(solver, model)
-    # s.solution_hint(assump, [1]*len(assump)) # causes weirdness in OR-Tools: https://github.com/google/or-tools/issues/4324
+    if hasattr(s, "solution_hint"): # algo is constructive, so favor large subsets
+        if solver != "ortools": # causes weidness in OR-Tools: https://github.com/google/or-tools/issues/4324
+            s.solution_hint(assump, [1]*len(assump))
+
     assert s.solve(assumptions=assump) is False
 
     # initialize hitting set solver
@@ -157,7 +160,8 @@ def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortool
 
     return [dmap[a] for a in hitting_set]
 
-
+def smus(soft, hard=[], solver="ortools", hs_solver="ortools"):
+    return optimal_mus(soft, hard=hard, weights=None, solver=solver, hs_solver=hs_solver)
 
 
 ## Naive, non-assumption based versions of MUS-algos above

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -110,9 +110,10 @@ def quickxplain(soft, hard=[], solver="ortools"):
     return [dmap[a] for a in core]
 
 
-def optimal_mus(soft, hard=[], weights=1, solver="ortools", hs_solver="ortools"):
+def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortools"):
     """
         Find an optimal MUS according to a linear objective function.
+        By not providing a weightvector, this function will return the smallest mus.
         Works by iteratively generating correction subsets and computing optimal hitting sets to those enumerated sets.
         For better performance of the algorithm, use an incemental solver to compute the hitting sets such as Gurobi.
 
@@ -137,7 +138,7 @@ def optimal_mus(soft, hard=[], weights=1, solver="ortools", hs_solver="ortools")
     assert s.solve(assumptions=assump) is False
 
     # initialize hitting set solver
-    if is_num(weights):
+    if weights is None:
         weights = np.ones(len(assump), dtype=int)
     hs_solver = cp.SolverLookup.get(hs_solver)
     hs_solver.minimize(cp.sum(assump * np.array(weights)))

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -54,7 +54,7 @@ def mus(soft, hard=[], solver="ortools"):
         if s.solve(assumptions=list(core)) is True:
             core.add(c)
         else: # UNSAT, use new solver core (clause set refinement)
-            core = s.get_core()
+            core = set(s.get_core())
 
     return [dmap[avar] for avar in core]
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -120,9 +120,13 @@ def optimal_mus(soft, hard=[], weights=1, solver="ortools", hs_solver="ortools")
         Assumption-based implementation for solvers that support s.solve(assumptions=...)
         More naive version available as `optimal_mus_naive` to use with other solvers.
 
-        CPMpy implementation of the "SMUS" algorithm from
+        CPMpy implementation loosely based on the "SMUS" algorithm from
             Ignatiev, Alexey, et al. "Smallest MUS extraction with minimal hitting set dualization."
             International Conference on Principles and Practice of Constraint Programming. Cham: Springer International Publishing, 2015.
+        and OCUS from:
+            Gamba, Emilio, Bart Bogaerts, and Tias Guns. "Efficiently explaining CSPs with unsatisfiable subset optimization."
+            Journal of Artificial Intelligence Research 78 (2023): 709-746.
+
     """
 
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -159,10 +159,10 @@ def optimal_mus(soft, hard=[], weights=None, solver="ortools", hs_solver="ortool
         hs_solver += cp.sum(new_corr_subset) >= 1
 
         # greedily search for other corr subsets disjoint to this one
-        sat_subset = list(hitting_set) + new_corr_subset
+        sat_subset = list(new_corr_subset)
         while s.solve(assumptions=sat_subset) is True:
             new_corr_subset = [a for a,c in zip(assump, soft) if a.value() is False and c.value() is False]
-            sat_subset += new_corr_subset # extend sat subset with new corr subset, guarenteed to be disjoint
+            sat_subset += new_corr_subset # extend sat subset with new corr subset, guaranteed to be disjoint
             hs_solver += cp.sum(new_corr_subset) >= 1 # add new corr subset to hitting set solver
 
     return [dmap[a] for a in hitting_set]

--- a/cpmpy/tools/explain/utils.py
+++ b/cpmpy/tools/explain/utils.py
@@ -1,4 +1,5 @@
 import cpmpy as cp
+from cpmpy.expressions.core import Expression
 from cpmpy.transformations.normalize import toplevel_list
 
 def make_assump_model(soft, hard=[], name=None):
@@ -14,6 +15,8 @@ def make_assump_model(soft, hard=[], name=None):
     assump = cp.boolvar(shape=(len(soft2),), name=name)
 
     # hard + implied soft constraints
+    if isinstance(hard, Expression):
+        hard = [hard]
     model = cp.Model(hard + [assump.implies(soft2)])  # each assumption variable implies a candidate
 
     return model, soft2, assump

--- a/cpmpy/tools/explain/utils.py
+++ b/cpmpy/tools/explain/utils.py
@@ -15,8 +15,7 @@ def make_assump_model(soft, hard=[], name=None):
     assump = cp.boolvar(shape=(len(soft2),), name=name)
 
     # hard + implied soft constraints
-    if isinstance(hard, Expression):
-        hard = [hard]
+    hard = toplevel_list(hard)
     model = cp.Model(hard + [assump.implies(soft2)])  # each assumption variable implies a candidate
 
     return model, soft2, assump

--- a/cpmpy/tools/explain/utils.py
+++ b/cpmpy/tools/explain/utils.py
@@ -17,7 +17,6 @@
 """
 
 import cpmpy as cp
-from cpmpy.expressions.core import Expression
 from cpmpy.transformations.normalize import toplevel_list
 
 def make_assump_model(soft, hard=[], name=None):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -146,14 +146,23 @@ class MARCOMUSTests(MusTests):
     def test_php(self):
         x = cp.boolvar(shape=(5,3), name="x")
         model = cp.Model()
-        model += cp.cpm_array(x.sum(axis=0)) >= 1
-        model += cp.cpm_array(x.sum(axis=1)) <= 1
+        model += cp.cpm_array(x.sum(axis=1)) >= 1
+        model += cp.cpm_array(x.sum(axis=0)) <= 1
 
+        subsets = list(marco(soft=model.constraints))
+        musses = [ss for kind, ss in subsets if kind == "MUS"]
+        mcses = [ss for kind, ss in subsets if kind == "MCS"]
+        self.assertEqual(len(musses), 5)
+        self.assertEqual(len(mcses), 13)
+
+        # also works when only enumerating MUSes?
         musses = list(marco(soft=model.constraints, return_mcs=False))
         self.assertEqual(len(musses), 5)
-
+        # or only MCSes?
         mcses = list(marco(soft=model.constraints, return_mus=False))
         self.assertEqual(len(mcses), 13) # any combination of 3 pigeon constraints + 3 mcses with the hole constraints
+
+
 
 
 class MSSTests(unittest.TestCase):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -2,8 +2,8 @@ import unittest
 from unittest import TestCase
 
 import cpmpy as cp
-from cpmpy.tools import mss_opt
-from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, mss, mcs
+from cpmpy.tools import mss_opt, marco
+from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, optimal_mus, optimal_mus_naive, mss, mcs
 
 
 class MusTests(TestCase):
@@ -37,7 +37,7 @@ class MusTests(TestCase):
         hard = [~bv]
         soft = [bv]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard) # crashes
+        mus_cons = self.mus_func(soft=soft, hard=hard, solver="ortools") # crashes
         self.assertEqual(set(mus_cons), set(soft))
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         self.assertEqual(set(mus_naive_cons), set(soft))
@@ -112,6 +112,45 @@ class QuickXplainTests(MusTests):
         self.assertSetEqual(set(subset), {a, b, c})
         subset2 = self.naive_func([d, c, b, a], hard)
         self.assertSetEqual(set(subset2), {b, d})
+
+class OptimalMUSTests(MusTests):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mus_func = optimal_mus
+        self.mus_func_naive = optimal_mus_naive
+
+    def test_weighted(self):
+        a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
+
+        mus1 = [b, d]
+        mus2 = [a, b, c]
+
+        hard = [~cp.all(mus1), ~cp.all(mus2)]
+        subset = self.mus_func([a, b, c, d], hard, weights = [1,1,2,4])
+        self.assertSetEqual(set(subset), {a, b, c})
+        subset2 = self.mus_func([a,b,c,d], hard, weights= [2,3,4,2])
+        self.assertSetEqual(set(subset2), {b, d})
+        subset3 = self.mus_func([a,b,c,d], hard)
+        self.assertEqual(set(subset3), {b,d})
+
+        subset = self.mus_func_naive([a, b, c, d], hard, weights=[1, 1, 2, 4])
+        self.assertSetEqual(set(subset), {a, b, c})
+        subset2 = self.mus_func_naive([a, b, c, d], hard, weights=[2, 3, 4, 2])
+        self.assertSetEqual(set(subset2), {b, d})
+        subset3 = self.mus_func_naive([a, b, c, d], hard)
+        self.assertEqual(set(subset3), {b, d})
+
+class MARCOMUSTests(MusTests):
+
+    def test_php(self):
+        x = cp.boolvar(shape=(5,3), name="x")
+        model = cp.Model()
+        model += cp.cpm_array(x.sum(axis=0)) >= 1
+        model += cp.cpm_array(x.sum(axis=1)) <= 1
+
+        musses = list(marco(soft=model.constraints))
+        self.assertEqual(len(musses), 5)
 
 
 class MSSTests(unittest.TestCase):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -149,8 +149,11 @@ class MARCOMUSTests(MusTests):
         model += cp.cpm_array(x.sum(axis=0)) >= 1
         model += cp.cpm_array(x.sum(axis=1)) <= 1
 
-        musses = list(marco(soft=model.constraints))
+        musses = list(marco(soft=model.constraints, return_mcs=False))
         self.assertEqual(len(musses), 5)
+
+        mcses = list(marco(soft=model.constraints, return_mus=False))
+        self.assertEqual(len(mcses), 13) # any combination of 3 pigeon constraints + 3 mcses with the hole constraints
 
 
 class MSSTests(unittest.TestCase):


### PR DESCRIPTION
I added the SMUS algorithm (with optional weights resulting in OUS) and the MARCO algorithm to tools.
A few questions:
- For now I made the "Grow" in the naive version of OUS an optional argument (which uses mss_grow_naive by default), is this smt we want?
- Do we need a naive version of MARCO as well?
- Does MARCO need to live in it's own file? For now its in tools/explain/mus