### PR TITLE
Safening of partial functions

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -613,6 +613,8 @@ class Operator(Expression):
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
             if lb2 <= 0 <= ub2:
+                if lb2 == ub2:
+                    raise ZeroDivisionError("Domain of {} only contains 0".format(self.args[1]))
                 # x mod y is always smaller than y. Make sure to not exclude 0 from domain.
                 return min(lb2 + 1, 0), max(ub2 - 1, 0)
             elif ub2 < 0:

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -596,8 +596,18 @@ class Operator(Expression):
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
             if lb2 <= 0 <= ub2:
-                raise ZeroDivisionError("division by domain containing 0 is not supported")
-            bounds = [lb1 // lb2, lb1 // ub2, ub1 // lb2, ub1 // ub2]
+                if lb2 == ub2:
+                    raise ZeroDivisionError(f"Domain of {self.args[1]} only contains 0")
+                if lb2 == 0:
+                    lb2 = 1
+                if ub2 == 0:
+                    ub2 = -1
+                bounds = [
+                    lb1 // lb2, lb1 // -1, lb1 // 1, lb1 // ub2,
+                    ub1 // lb2, ub1 // -1, ub1 // 1, ub1 // ub2
+                ]
+            else:
+                bounds = [lb1 // lb2, lb1 // ub2, ub1 // lb2, ub1 // ub2]
             lowerbound, upperbound = min(bounds), max(bounds)
         elif self.name == 'mod':
             lb1, ub1 = get_bounds(self.args[0])

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -613,7 +613,8 @@ class Operator(Expression):
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
             if lb2 <= 0 <= ub2:
-                raise ZeroDivisionError("% by domain containing 0 is not supported")
+                # x mod y is always smaller than y. Make sure to not exclude 0 from domain.
+                return min(lb2 + 1, 0), max(ub2 - 1, 0)
             elif ub2 < 0:
                 return lb2 + 1, 0
             elif lb2 > 0:

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -340,8 +340,8 @@ class CPM_choco(SolverInterface):
 
         # for when choco new release comes, fixing the bug on increasing and decreasing
         #supported_reified = supported
-        cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
         cpm_cons = no_partial_functions(cpm_cons)
+        cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = canonical_comparison(cpm_cons)
         cpm_cons = reify_rewrite(cpm_cons, supported = supported_reified | {"sum", "wsum"})  # constraints that support reification

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -45,7 +45,7 @@ from ..transformations.flatten_model import flatten_constraint, flatten_objectiv
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.linearize import canonical_comparison
 from ..transformations.reification import only_bv_reifies, reify_rewrite
-from ..transformations.safening import safen
+from ..transformations.safening import no_partial_functions
 from ..exceptions import ChocoBoundsException, ChocoTypeException, NotSupportedError
 
 
@@ -341,7 +341,7 @@ class CPM_choco(SolverInterface):
         # for when choco new release comes, fixing the bug on increasing and decreasing
         #supported_reified = supported
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
-        cpm_cons = safen(cpm_cons)
+        cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = canonical_comparison(cpm_cons)
         cpm_cons = reify_rewrite(cpm_cons, supported = supported_reified | {"sum", "wsum"})  # constraints that support reification

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -45,6 +45,7 @@ from ..transformations.flatten_model import flatten_constraint, flatten_objectiv
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.linearize import canonical_comparison
 from ..transformations.reification import only_bv_reifies, reify_rewrite
+from ..transformations.safening import safen
 from ..exceptions import ChocoBoundsException, ChocoTypeException, NotSupportedError
 
 
@@ -340,6 +341,7 @@ class CPM_choco(SolverInterface):
         # for when choco new release comes, fixing the bug on increasing and decreasing
         #supported_reified = supported
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
+        cpm_cons = safen(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = canonical_comparison(cpm_cons)
         cpm_cons = reify_rewrite(cpm_cons, supported = supported_reified | {"sum", "wsum"})  # constraints that support reification

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -42,7 +42,7 @@ from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.linearize import linearize_constraint, only_positive_bv
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.normalize import toplevel_list
-from ..transformations.safening import safen
+from ..transformations.safening import no_partial_functions
 from ..expressions.globalconstraints import DirectConstraint
 from ..exceptions import NotSupportedError
 from ..expressions.utils import flatlist, argvals
@@ -426,7 +426,7 @@ class CPM_exact(SolverInterface):
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = decompose_in_tree(cpm_cons, supported=frozenset({'alldifferent'})) # Alldiff has a specialzed MIP decomp
-        cpm_cons = safen(cpm_cons)
+        cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]))  # supports >, <, !=

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -42,6 +42,7 @@ from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.linearize import linearize_constraint, only_positive_bv
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.normalize import toplevel_list
+from ..transformations.safening import safen
 from ..expressions.globalconstraints import DirectConstraint
 from ..exceptions import NotSupportedError
 from ..expressions.utils import flatlist, argvals
@@ -425,6 +426,7 @@ class CPM_exact(SolverInterface):
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = decompose_in_tree(cpm_cons, supported=frozenset({'alldifferent'})) # Alldiff has a specialzed MIP decomp
+        cpm_cons = safen(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]))  # supports >, <, !=

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -425,8 +425,8 @@ class CPM_exact(SolverInterface):
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
         cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = decompose_in_tree(cpm_cons, supported=frozenset({'alldifferent'})) # Alldiff has a specialzed MIP decomp
         cpm_cons = no_partial_functions(cpm_cons)
+        cpm_cons = decompose_in_tree(cpm_cons, supported=frozenset({'alldifferent'})) # Alldiff has a specialzed MIP decomp
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]))  # supports >, <, !=

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -27,7 +27,7 @@ from ..expressions.utils import is_num, is_any_list, argval, argvals
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
-from ..transformations.safening import safen
+from ..transformations.safening import no_partial_functions
 
 from ..transformations.normalize import toplevel_list
 
@@ -343,7 +343,7 @@ class CPM_gcs(SolverInterface):
             'circuit', 
             'xor'}
         cpm_cons = decompose_in_tree(cpm_cons, supported)
-        cpm_cons = safen(cpm_cons)
+        cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
 
         # NB: GCS supports full reification for linear equality and linear inequaltiy constraints

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -27,6 +27,7 @@ from ..expressions.utils import is_num, is_any_list, argval, argvals
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
+from ..transformations.safening import safen
 
 from ..transformations.normalize import toplevel_list
 
@@ -342,6 +343,7 @@ class CPM_gcs(SolverInterface):
             'circuit', 
             'xor'}
         cpm_cons = decompose_in_tree(cpm_cons, supported)
+        cpm_cons = safen(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
 
         # NB: GCS supports full reification for linear equality and linear inequaltiy constraints

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -342,8 +342,8 @@ class CPM_gcs(SolverInterface):
             'inverse', 
             'circuit', 
             'xor'}
-        cpm_cons = decompose_in_tree(cpm_cons, supported)
         cpm_cons = no_partial_functions(cpm_cons)
+        cpm_cons = decompose_in_tree(cpm_cons, supported)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
 
         # NB: GCS supports full reification for linear equality and linear inequaltiy constraints

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -32,6 +32,7 @@
 """
 
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
+from ..exceptions import NotSupportedError
 from ..expressions.core import *
 from ..expressions.utils import argvals
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
@@ -351,7 +352,8 @@ class CPM_gurobi(SolverInterface):
                     self.grb_model.addConstr(a * b == grbrhs)
 
                 elif lhs.name == 'div':
-                    assert is_num(lhs.args[1]), "Gurobi only supports division by constants"
+                    if not is_num(lhs.args[1]):
+                        raise NotSupportedError(f"Gurobi only supports division by constants, but got {lhs.args[1]}")
                     a, b = self.solver_vars(lhs.args)
                     self.grb_model.addLConstr(a / b, GRB.EQUAL, grbrhs)
 

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -286,9 +286,9 @@ class CPM_gurobi(SolverInterface):
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
         cpm_cons = toplevel_list(cpm_expr)
+        cpm_cons = no_partial_functions(cpm_cons)
         supported = {"min", "max", "abs", "alldifferent"} # alldiff has a specialized MIP decomp in linearize
         cpm_cons = decompose_in_tree(cpm_cons, supported)
-        cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -43,6 +43,7 @@ from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, only_positive_bv
 from ..transformations.normalize import toplevel_list
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
+from ..transformations.safening import safen
 
 try:
     import gurobipy as gp
@@ -287,6 +288,7 @@ class CPM_gurobi(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "alldifferent"} # alldiff has a specialized MIP decomp in linearize
         cpm_cons = decompose_in_tree(cpm_cons, supported)
+        cpm_cons = safen(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -43,7 +43,7 @@ from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, only_positive_bv
 from ..transformations.normalize import toplevel_list
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
-from ..transformations.safening import safen
+from ..transformations.safening import no_partial_functions
 
 try:
     import gurobipy as gp
@@ -288,7 +288,7 @@ class CPM_gurobi(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "alldifferent"} # alldiff has a specialized MIP decomp in linearize
         cpm_cons = decompose_in_tree(cpm_cons, supported)
-        cpm_cons = safen(cpm_cons)
+        cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -48,7 +48,7 @@ from ..transformations.flatten_model import flatten_constraint, flatten_objectiv
 from ..transformations.normalize import toplevel_list
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.safening import safen
+from ..transformations.safening import no_partial_functions
 
 
 class CPM_ortools(SolverInterface):
@@ -349,7 +349,7 @@ class CPM_ortools(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "negative_table", "cumulative", "circuit", "inverse", "no_overlap"}
         cpm_cons = decompose_in_tree(cpm_cons, supported)
-        cpm_cons = safen(cpm_cons) # after decompose, assumes total decomposition for partial functions
+        cpm_cons = no_partial_functions(cpm_cons) # after decompose, assumes total decomposition for partial functions
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -348,7 +348,7 @@ class CPM_ortools(SolverInterface):
         """
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "negative_table", "cumulative", "circuit", "inverse", "no_overlap"}
-        cpm_cons = no_partial_functions(cpm_cons) # after decompose, assumes total decomposition for partial functions
+        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel=frozenset({"div", "mod"})) # before decompose, assumes total decomposition for partial functions
         cpm_cons = decompose_in_tree(cpm_cons, supported)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -348,8 +348,8 @@ class CPM_ortools(SolverInterface):
         """
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "negative_table", "cumulative", "circuit", "inverse", "no_overlap"}
-        cpm_cons = decompose_in_tree(cpm_cons, supported)
         cpm_cons = no_partial_functions(cpm_cons) # after decompose, assumes total decomposition for partial functions
+        cpm_cons = decompose_in_tree(cpm_cons, supported)
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -48,6 +48,8 @@ from ..transformations.flatten_model import flatten_constraint, flatten_objectiv
 from ..transformations.normalize import toplevel_list
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.comparison import only_numexpr_equality
+from ..transformations.safening import safen
+
 
 class CPM_ortools(SolverInterface):
     """
@@ -347,6 +349,7 @@ class CPM_ortools(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "negative_table", "cumulative", "circuit", "inverse", "no_overlap"}
         cpm_cons = decompose_in_tree(cpm_cons, supported)
+        cpm_cons = safen(cpm_cons) # after decompose, assumes total decomposition for partial functions
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -40,6 +40,7 @@ from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, _Int
 from ..expressions.utils import is_num, is_any_list, is_bool, is_int, is_boolexpr, eval_comparison
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.normalize import toplevel_list, simplify_boolean
+from ..transformations.safening import safen
 
 
 class CPM_z3(SolverInterface):
@@ -272,6 +273,7 @@ class CPM_z3(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"alldifferent", "xor", "ite"}  # z3 accepts these reified too
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported)
+        cpm_cons = safen(cpm_cons)
         return cpm_cons
 
     def __add__(self, cpm_expr):

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -367,7 +367,7 @@ class CPM_z3(SolverInterface):
                 elif cpm_con.name == "mul":
                     return lhs * rhs
                 elif cpm_con.name == "div":
-                    return lhs / rhs
+                    return z3.ToReal(lhs) / z3.ToReal(rhs)
                 elif cpm_con.name == "pow":
                     return lhs ** rhs
                 elif cpm_con.name == "mod":

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -271,7 +271,7 @@ class CPM_z3(SolverInterface):
         """
 
         cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
+        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel={"div", "mod"})
         supported = {"alldifferent", "xor", "ite"}  # z3 accepts these reified too
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported)
         return cpm_cons

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -271,9 +271,9 @@ class CPM_z3(SolverInterface):
         """
 
         cpm_cons = toplevel_list(cpm_expr)
+        cpm_cons = no_partial_functions(cpm_cons)
         supported = {"alldifferent", "xor", "ite"}  # z3 accepts these reified too
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported)
-        cpm_cons = no_partial_functions(cpm_cons)
         return cpm_cons
 
     def __add__(self, cpm_expr):

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -40,7 +40,7 @@ from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, _Int
 from ..expressions.utils import is_num, is_any_list, is_bool, is_int, is_boolexpr, eval_comparison
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.normalize import toplevel_list, simplify_boolean
-from ..transformations.safening import safen
+from ..transformations.safening import no_partial_functions
 
 
 class CPM_z3(SolverInterface):
@@ -273,7 +273,7 @@ class CPM_z3(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"alldifferent", "xor", "ite"}  # z3 accepts these reified too
         cpm_cons = decompose_in_tree(cpm_cons, supported, supported)
-        cpm_cons = safen(cpm_cons)
+        cpm_cons = no_partial_functions(cpm_cons)
         return cpm_cons
 
     def __add__(self, cpm_expr):

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -161,22 +161,8 @@ def reify_rewrite(constraints, supported=frozenset()):
                 #   at the very least, (iv1 == iv2) == bv has to be supported
                 if isinstance(lhs, _NumVarImpl) or lhs.name in supported:
                     newcons.append(cpm_expr)
-                elif isinstance(lhs, Element) and (lhs.args[1].lb < 0 or lhs.args[1].ub >= len(lhs.args[0])):
-                    # special case: (Element(arr,idx) <OP> RHS) == BV (or -> in some way)
-                    # if the domain of 'idx' is larger than the range of 'arr', then
-                    # this is allowed and BV should be false if it takes a value there
-                    # so we can not use Element (which would restruct the domain of idx)
-                    # and have to work with an element-wise decomposition instead
-                    reifexpr = copy.copy(cpm_expr)
-                    decomp = all(lhs.decompose_comparison(op, rhs)[0])  # decomp() returns list
-                    #print(decomp)
-                    if decomp is False:
-                        # TODO uh... special case, can't insert a constant here with the current transformations...
-                        # use IV < IV.lb which will be false...
-                        decomp = (lhs.args[1] < lhs.args[1].lb)
-                    reifexpr.args[boolexpr_index] = decomp
-                    newcons += flatten_constraint(reifexpr)
-                else:  # other cases (assuming LHS is a total function):
+                else:  # other cases, LHS is a total function
+                    #     introduce aux var and bring function to toplevel
                     #     (AUX,c) = get_or_make_var(LHS)
                     #     return c+[Comp(OP,AUX,RHS) == BV] or +[Comp(OP,AUX,RHS) -> BV] or +[Comp(OP,AUX,RHS) <- BV]
                     (auxvar, cons) = get_or_make_var(lhs)

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from ..expressions.variables import _NumVarImpl, boolvar, intvar, NDVarArray
+from ..expressions.variables import _NumVarImpl, boolvar, intvar, NDVarArray, cpm_array
 from ..expressions.core import Operator, BoolVal
 from ..expressions.utils import get_bounds, is_num
 from ..expressions.globalfunctions import GlobalFunction, Element
@@ -26,8 +26,8 @@ def no_partial_functions(lst_of_expr, _toplevel=None, nbc=None):
             new_lst.append(no_partial_functions(cpm_expr, _toplevel, nbc))
 
         elif isinstance(cpm_expr, NDVarArray):
-            safened = no_partial_functions(cpm_expr.tolist(), _toplevel, nbc)
-            new_lst.append(safened)
+            safened = no_partial_functions(cpm_expr, _toplevel, nbc)
+            new_lst.append(cpm_array(safened))
 
 
         elif isinstance(cpm_expr, Operator) and cpm_expr.name == "div":

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from ..expressions.variables import _NumVarImpl, boolvar, intvar, NDVarArray, cpm_array
-from ..expressions.core import Operator, BoolVal
+from ..expressions.core import Expression, Operator, BoolVal
 from ..expressions.utils import get_bounds, is_num
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.globalconstraints import DirectConstraint
@@ -52,8 +52,8 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None):
         toplevel_call = True
         _toplevel = []
     else:
-        assert isinstance(_toplevel, list), f"_toplevel argument must be of type list but got {type(_toplevel)}"
         toplevel_call = False
+        assert isinstance(_toplevel, list), f"_toplevel argument must be of type list but got {type(_toplevel)}"
 
     new_lst = []
     for cpm_expr in lst_of_expr:
@@ -64,66 +64,65 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None):
         elif isinstance(cpm_expr, (list,tuple)):
             new_lst.append(no_partial_functions(cpm_expr, _toplevel, _nbc))
 
-        elif isinstance(cpm_expr, NDVarArray):
-            safened = no_partial_functions(cpm_expr, _toplevel, _nbc)
-            new_lst.append(cpm_array(safened))
+        elif isinstance(cpm_expr, NDVarArray):  # TODO efficiency: and cpm_expr.has_subexpr()
+            # efficiency: flatten into single iterator, then reshape to n-dimensional again
+            new_cpm_expr = cpm_array(no_partial_functions(cpm_expr.flat, _toplevel, _nbc)).reshape(cpm_expr.shape)
+            new_lst.append(new_cpm_expr)
 
-
-        elif isinstance(cpm_expr, Operator) and (cpm_expr.name == "div" or cpm_expr.name == "mod"):
-            safe_args = no_partial_functions(cpm_expr.args, _toplevel, _nbc=_nbc)
-            x, y = safe_args
-            lb, ub = get_bounds(y)
-            expr = Operator(cpm_expr.name, [x,y])
-
-            if lb <= 0 <= ub:
-                assert lb != 0 or ub != 0, "domain of divisor contains only 0" # TODO, I guess we can fix this by making nbc = False?
-
-                if lb == 0:
-                    is_safe, safe_expr, extra_cons = _safen_range(expr, (1, ub), 1)
-                elif ub == 0:
-                    is_safe, safe_expr, extra_cons = _safen_range(expr, (lb, -1), 1)
-                else: # proper hole
-                    is_safe, safe_expr, extra_cons = _safen_hole(expr, 0, 1)
-
-                _nbc.append(is_safe)
-                new_lst.append(safe_expr)
-                _toplevel += extra_cons
-
-            else: # already safe
-                new_lst.append(expr)
-
-
-        elif isinstance(cpm_expr, GlobalFunction) and cpm_expr.name == "element":
-            safe_args = no_partial_functions(cpm_expr.args, _toplevel, _nbc=_nbc)
-            arr, idx = safe_args
-            lb, ub = get_bounds(idx)
-            expr = Element(arr,idx)
-
-            if lb < 0 or ub >= len(arr): # index can be out of bounds
-                is_safe, safe_expr, extra_cons = _safen_range(expr, (0, len(arr)-1), 1)
-                _nbc.append(is_safe)
-                new_lst.append(safe_expr)
-                _toplevel += extra_cons
-            else:
-                new_lst.append(expr)
-
-
-        elif isinstance(cpm_expr, DirectConstraint): # do nothing
+        elif isinstance(cpm_expr, DirectConstraint):  # do not recurse into args
             new_lst.append(cpm_expr)
 
-        elif cpm_expr.is_bool(): # reached Boolean (sub)expression
-            new_exprs = []
-            safe_args = no_partial_functions(cpm_expr.args, _toplevel, _nbc=new_exprs)
-            cpm_expr = copy(cpm_expr)
-            cpm_expr.args = safe_args
-            new_lst.append(cpm_expr & cpm_all(new_exprs))
+        else:
+            assert isinstance(cpm_expr, Expression), f"each `cpm_expr` should be an Expression at this point, not {type(cpm_expr)}"
+            args = cpm_expr.args
 
-        else: # numerical subexpression or toplevel, just recurse
-            safe_args = no_partial_functions(cpm_expr.args, _toplevel, _nbc=_nbc)
-            cpm_expr = copy(cpm_expr)
-            cpm_expr.args = safe_args
+            if cpm_expr.is_bool():  # a Boolean context, create a new _nbc
+                _nbc = []
+
+            # recurse over the arguments of the expression
+            # TODO efficiency: if cpm_expr.has_subexpr()
+            new_args = no_partial_functions(args, _toplevel, _nbc=_nbc)
+            if any((a1 is not a2) for a1,a2 in zip(new_args,args)):  # efficiency (hopefully): only copy if an arg changed
+                cpm_expr = copy(cpm_expr)
+                cpm_expr.args = new_args
+                args = new_args
+
+            if cpm_expr.is_bool() and len(_nbc) != 0:
+                # a Boolean context, conjoin my Boolean expression with _nbc
+                # in `b <-> (Arr[idx] == 5)`, this would trigger for cpm_expr (Arr[idx] == 5)
+                cpm_expr = cpm_all(_nbc) & cpm_expr
+
+            elif isinstance(cpm_expr, GlobalFunction) and cpm_expr.name == "element":
+                arr, idx = args
+                lb, ub = get_bounds(idx)
+
+                if lb < 0 or ub >= len(arr): # index can be out of bounds
+                    guard, output_expr, extra_cons = _safen_range(cpm_expr, safe_range=(0, len(arr)-1), idx_to_safen=1)
+
+                    _nbc.append(guard)  # guard must be added to nearest Boolean context
+                    _toplevel += extra_cons  # any additional constraint that must be true
+                    cpm_expr = output_expr  # replace partial function by this (total) new output expression
+
+            elif cpm_expr.name == "div" or cpm_expr.name == "mod":
+                idx_to_safen = 1
+                lb, ub = get_bounds(args[idx_to_safen])
+
+                if lb <= 0 <= ub:
+                    assert lb != 0 or ub != 0, "domain of divisor contains only 0" # TODO, I guess we can fix this by making nbc = False?
+
+                    if lb == 0:
+                        guard, output_expr, extra_cons = _safen_range(cpm_expr, safe_range=(1, ub), idx_to_safen=idx_to_safen)
+                    elif ub == 0:
+                        guard, output_expr, extra_cons = _safen_range(cpm_expr, safe_range=(lb, -1), idx_to_safen=idx_to_safen)
+                    else:  # proper hole
+                        guard, output_expr, extra_cons = _safen_hole(cpm_expr, exclude=0, idx_to_safen=idx_to_safen)
+
+                    _nbc.append(guard)  # guard must be added to nearest Boolean context
+                    _toplevel += extra_cons  # any additional constraint that must be true
+                    cpm_expr = output_expr  # replace partial function by this (total) new output expression
+
+            # add the (potentially new) cpm_expr to the list
             new_lst.append(cpm_expr)
-
 
     if toplevel_call is True:
         return new_lst + _toplevel
@@ -146,53 +145,57 @@ def _safen_range(cpm_expr, safe_range, idx_to_safen):
 
     """
     lb, ub = safe_range
-    safe_expr = copy(cpm_expr)
-    unsafe_arg = safe_expr.args[idx_to_safen]
     is_safe, safe_arg = boolvar(), intvar(lb, ub)
-    safe_expr.args = [safe_arg if i == idx_to_safen else a for i,a in enumerate(cpm_expr.args)]
+
+    unsafe_arg = cpm_expr.args[idx_to_safen]
+    safe_expr = copy(cpm_expr)
+    safe_expr.args = [safe_arg if i == idx_to_safen else a for i,a in enumerate(safe_expr.args)]
 
     toplevel = [((unsafe_arg >= lb) & (unsafe_arg <= ub)).implies(is_safe),
                  (is_safe == (safe_arg == unsafe_arg)),
-                # avoid new solutions in aux vars (is this dangerous?)
+                 # avoid additional solutions when new var is unconstrained (should always work because newly defined?)
                  (~is_safe).implies(safe_arg == lb)]
 
     return is_safe, safe_expr, toplevel
+
 
 def _safen_hole(cpm_expr, exclude, idx_to_safen):
     """
         Safen expression where a single value of an argument can cause undefinedness.
         Examples include `div` where 0 has to be removed from the denominator
 
-
         Constructs an expression for each interval of safe values, and
-            introduces a new `result` variable (essentially does flattening)
+            introduces a new `output_expr` variable
 
         :param cpm_expr: The numerical expression to safen
         :param exclude: The domain value to exclude
         :param idx_to_safen: The index of unsafe argument in the expression
     """
-    result = intvar(*get_bounds(cpm_expr))
-
     unsafe_arg = cpm_expr.args[idx_to_safen]
-    lb, ub = get_bounds(unsafe_arg)
-    # introduce safe arguments
-    safe_lower, safe_upper = intvar(lb, exclude-1), intvar(exclude+1, ub)
-    lower_expr, upper_expr = copy(cpm_expr), copy(cpm_expr)
-    lower_expr.args = [safe_lower if i == idx_to_safen else a for i,a in enumerate(cpm_expr.args)]
-    upper_expr.args = [safe_upper if i == idx_to_safen else a for i,a in enumerate(cpm_expr.args)]
+    unsafe_lb, unsafe_ub = get_bounds(unsafe_arg)
+
+    # output when arg in [unsafe_lb..exclude-1]
+    safe_arg_lower = intvar(unsafe_lb, exclude-1)
+    output_expr_lower = copy(cpm_expr)
+    output_expr_lower.args = [safe_arg_lower if i == idx_to_safen else a for i,a in enumerate(cpm_expr.args)]
+    # output when arg in [exclude+1..unsafe_ub]
+    safe_arg_upper = intvar(exclude+1, unsafe_ub)
+    output_expr_upper = copy(cpm_expr)
+    output_expr_upper.args = [safe_arg_upper if i == idx_to_safen else a for i, a in enumerate(cpm_expr.args)]
 
     is_safe = boolvar()
+    output_expr = intvar(*get_bounds(cpm_expr))
 
     toplevel  =[
-        (unsafe_arg < exclude).implies(lower_expr == result),
-        (unsafe_arg > exclude).implies(upper_expr == result),
-        is_safe == ((unsafe_arg == safe_lower) | (unsafe_arg == safe_upper)),
-        # avoid new solutions in aux vars (is this dangerous?)
-        (unsafe_arg >= exclude).implies(safe_lower == exclude-1),
-        (unsafe_arg <= exclude).implies(safe_upper == exclude+1),
-        (~is_safe).implies(result == result.lb)
+        (unsafe_arg < exclude).implies(output_expr_lower == output_expr),
+        (unsafe_arg > exclude).implies(output_expr_upper == output_expr),
+        is_safe == ((unsafe_arg == safe_arg_lower) | (unsafe_arg == safe_arg_upper)),
+        # avoid additional solutions when new vars are unconstrained (should always work because newly defined?)
+        (unsafe_arg >= exclude).implies(safe_arg_lower == exclude-1),
+        (unsafe_arg <= exclude).implies(safe_arg_upper == exclude+1),
+        (~is_safe).implies(output_expr == output_expr.lb)
     ]
 
-    return is_safe, result, toplevel
+    return is_safe, output_expr, toplevel
 
 

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -135,9 +135,11 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
                 lb, ub = get_bounds(args[idx_to_safen])
 
                 if lb <= 0 <= ub:
-                    assert lb != 0 or ub != 0, "domain of divisor contains only 0" # TODO, I guess we can fix this by making nbc = False?
-
-                    if lb == 0:
+                    if lb == ub == 0:
+                        guard = BoolVal(False)  # domain of divisor contains only 0
+                        output_expr = boolvar()  # arbitrary, but we need something? #todo can we delete the whole thing where the partial occurs at the level of nbc, and only keep the false?
+                        extra_cons = []
+                    elif lb == 0:
                         guard, output_expr, extra_cons = _safen_range(cpm_expr, safe_range=(1, ub), idx_to_safen=idx_to_safen)
                     elif ub == 0:
                         guard, output_expr, extra_cons = _safen_range(cpm_expr, safe_range=(lb, -1), idx_to_safen=idx_to_safen)

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -88,9 +88,6 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
 
         else:
             assert isinstance(cpm_expr, Expression), f"each `cpm_expr` should be an Expression at this point, not {type(cpm_expr)}"
-            if (not cpm_expr.has_subexpr()) and (not cpm_expr.name == 'div') and (not cpm_expr.name == 'mod'):
-                new_lst.append(cpm_expr)
-                continue
             args = cpm_expr.args
 
             if cpm_expr.is_bool() and toplevel_call is False:  # a Boolean context, create a new _nbc

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -61,7 +61,7 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None):
         if is_num(cpm_expr) or isinstance(cpm_expr, _NumVarImpl):
             new_lst.append(cpm_expr)
 
-        elif isinstance(cpm_expr, list):
+        elif isinstance(cpm_expr, (list,tuple)):
             new_lst.append(no_partial_functions(cpm_expr, _toplevel, _nbc))
 
         elif isinstance(cpm_expr, NDVarArray):

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -1,0 +1,109 @@
+from copy import copy
+
+from ..expressions.variables import _NumVarImpl, boolvar, intvar, NDVarArray
+from ..expressions.core import Operator, BoolVal
+from ..expressions.utils import get_bounds, is_num
+from ..expressions.globalfunctions import GlobalFunction, Element
+from ..expressions.globalconstraints import DirectConstraint
+from ..expressions.python_builtins import all as cpm_all
+
+def safen(lst_of_expr, _toplevel=None, nbc=None):
+
+    if _toplevel is None:
+        toplevel_call = True
+        _toplevel = []
+    else:
+        assert isinstance(_toplevel, list), f"_toplevel argument must be of type list but got {type(_toplevel)}"
+        toplevel_call = False
+
+    new_lst = []
+    for cpm_expr in lst_of_expr:
+
+        if is_num(cpm_expr) or isinstance(cpm_expr, _NumVarImpl):
+            new_lst.append(cpm_expr)
+
+        elif isinstance(cpm_expr, list):
+            new_lst.append(safen(cpm_expr, _toplevel, nbc))
+
+        elif isinstance(cpm_expr, NDVarArray):
+            safened = safen(cpm_expr.tolist(), _toplevel, nbc)
+            new_lst.append(safened)
+
+
+        elif isinstance(cpm_expr, Operator) and cpm_expr.name == "div":
+            safe_args = safen(cpm_expr.args, _toplevel, nbc=nbc)
+            x, y = safe_args
+            lb, ub = get_bounds(y)
+
+            if lb <= 0 <= ub:
+                assert lb != 0 or ub != 0, "domain of divisor contains only 0" # TODO, I guess we can fix this by making nbc = False?
+
+                is_safe = boolvar()
+                nbc.append(is_safe)
+                _toplevel += [(y != 0).implies(is_safe)]
+                # case-by case analysis on exact domain of divisor
+                if lb < 0 < ub: # proper hole... need to split up into two and do some flattening
+                    y_neg, y_pos = intvar(lb, -1), intvar(1,ub)
+                    new_rhs = intvar(*get_bounds(cpm_expr))
+                    _toplevel += [is_safe == ((y == y_neg) | (y == y_pos))]
+                    _toplevel += [(y < 0).implies((x // y_neg) == new_rhs),
+                                  (y > 0).implies((x // y_pos) == new_rhs),
+                                  # avoid new solutions in aux vars (is this dangerous?)
+                                  (y >= 0).implies(y_neg == -1),
+                                  (y <= 0).implies(y_pos == 1),
+                                  (~is_safe).implies(new_rhs == new_rhs.lb)
+                                  ]
+                    new_lst.append(new_rhs)
+                else: # just a range, exclude 0 from domain
+                    assert lb == 0 or ub == 0, "domain of divisor should contain a 0, otherwise it's safe..."
+                    if lb == 0:
+                        safe_y = intvar(1,ub)
+                    elif ub == 0:
+                        safe_y = intvar(lb, -1)
+                    _toplevel += [is_safe == (y == safe_y)]
+                    _toplevel += [(~is_safe).implies(safe_y == safe_y.lb)] # avoid new solutions in aux vars (is this dangerous?)
+                    new_lst.append(x // safe_y)
+
+            else: # already safe
+                new_lst.append(x // y)
+
+
+        elif isinstance(cpm_expr, GlobalFunction) and cpm_expr.name == "element":
+            safe_args = safen(cpm_expr.args, _toplevel, nbc=nbc)
+            arr, idx = safe_args
+            lb, ub = get_bounds(idx)
+            if lb < 0 or ub >= len(arr): # index can be out of bounds
+                is_safe, safe_idx = boolvar(), intvar(0,len(arr)-1)
+                _toplevel += [((idx >= 0) & (idx < len(arr))).implies(is_safe)]
+                _toplevel += [(is_safe == (safe_idx == idx))]
+                _toplevel += [(~is_safe).implies(safe_idx == 0)] # avoid new solutions in aux vars (is this dangerous?)
+                nbc.append(is_safe)
+                new_lst.append(Element(arr, safe_idx))
+
+            else:
+                new_lst.append(Element(arr, idx))
+
+
+        elif isinstance(cpm_expr, DirectConstraint): # do nothing
+            new_lst.append(cpm_expr)
+
+        elif cpm_expr.is_bool(): # reached Boolean (sub)expression
+            new_exprs = []
+            safe_args = safen(cpm_expr.args, _toplevel,  nbc=new_exprs)
+            cpm_expr = copy(cpm_expr)
+            cpm_expr.args = safe_args
+            new_lst.append(cpm_expr & cpm_all(new_exprs))
+
+        else: # numerical subexpression or toplevel, just recurse
+            safe_args = safen(cpm_expr.args, _toplevel, nbc=nbc)
+            cpm_expr = copy(cpm_expr)
+            cpm_expr.args = safe_args
+            new_lst.append(cpm_expr)
+
+
+    if toplevel_call is True:
+        return new_lst + _toplevel
+    else:
+        return new_lst
+
+

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -17,7 +17,7 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None):
             - Element 'Arr[idx]': undefined when idx is not in the range of Arr
 
         A toplevel constraint must always be true, so constraint solvers simply propagate the 'unsafe'
-        value(s) away. However CPMpy allows arbitrary nesting and reification of constraints, so an
+        value(s) away. However, CPMpy allows arbitrary nesting and reification of constraints, so an
         expression like `b <-> (Arr[idx] == 5)` is allowed, even when variable `idx` goes outside the bounds of `Arr`.
         Should idx be restricted to be in-bounds? and what value should 'b' take if it is out-of-bounds?
 
@@ -38,7 +38,7 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None):
         and a new 'safe' argument variable which is used in the expression. The `is_defined` flag serves two
         purposes: it represents whether the original argument has a safe value; and if it is true the new
         argument must equal the original argument so the two are coupled again. If `is_defined` is false, the new
-        argument remains decoupled (can take any value, as will the expression's output).
+        argument remains decoupled (can take any value, as will the function's output).
 
         WARNING! Under the relational semantics, `b <-> ~(partial==5)` and `b <-> (partial!=5) mean
         different things! The second is `b <-> (is_defined & (total!=5))` the first is

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -60,6 +60,7 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
     """
 
     if _toplevel is None:
+        assert _nbc is None, f"_nbc is an internal argument, should not be filled by caller but got {_nbc}"
         toplevel_call = True
         _toplevel = []
         _nbc = _toplevel # at the toplevel of the contraint model, the neirest Boolean context is just toplevel

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -99,7 +99,7 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
             new_args = no_partial_functions(args, _toplevel, _nbc, safen_toplevel=safen_toplevel)
             if any((a1 is not a2) for a1,a2 in zip(new_args,args)):  # efficiency (hopefully): only copy if an arg changed
                 cpm_expr = copy(cpm_expr)
-                cpm_expr.args = new_args
+                cpm_expr.update_args(new_args)
                 args = new_args
 
             if cpm_expr.is_bool() and len(_nbc) != 0 and toplevel_call is False:
@@ -176,7 +176,7 @@ def _safen_range(partial_expr, safe_range, idx_to_safen):
     new_arg = intvar(safe_lb, safe_ub)  # values for which the partial function is defined
 
     total_expr = copy(partial_expr)  # the new total function, with the new arg
-    total_expr.args = [new_arg if i == idx_to_safen else a for i,a in enumerate(partial_expr.args)]
+    total_expr.update_args([new_arg if i == idx_to_safen else a for i,a in enumerate(partial_expr.args)])
 
     is_defined = boolvar()
     toplevel = [is_defined == ((safe_lb <= orig_arg) & (orig_arg <= safe_ub)),
@@ -206,11 +206,11 @@ def _safen_hole(cpm_expr, exclude, idx_to_safen):
     # expr when arg in [orig_lb..exclude-1]
     new_arg_lower = intvar(orig_lb, exclude-1)
     total_expr_lower = copy(cpm_expr)
-    total_expr_lower.args = [new_arg_lower if i == idx_to_safen else a for i,a in enumerate(cpm_expr.args)]
+    total_expr_lower.update_args([new_arg_lower if i == idx_to_safen else a for i,a in enumerate(cpm_expr.args)])
     # expr when arg in [exclude+1..orig_ub]
     new_arg_upper = intvar(exclude+1, orig_ub)
     total_expr_upper = copy(cpm_expr)
-    total_expr_upper.args = [new_arg_upper if i == idx_to_safen else a for i, a in enumerate(cpm_expr.args)]
+    total_expr_upper.update_args([new_arg_upper if i == idx_to_safen else a for i, a in enumerate(cpm_expr.args)])
 
     is_defined = boolvar()
     is_defined_lower = boolvar()

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -88,6 +88,9 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
 
         else:
             assert isinstance(cpm_expr, Expression), f"each `cpm_expr` should be an Expression at this point, not {type(cpm_expr)}"
+            if (not cpm_expr.has_subexpr()) and (not cpm_expr.name == 'div') and (not cpm_expr.name == 'mod'):
+                new_lst.append(cpm_expr)
+                continue
             args = cpm_expr.args
 
             if cpm_expr.is_bool() and toplevel_call is False:  # a Boolean context, create a new _nbc

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -136,9 +136,9 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
 
                 if lb <= 0 <= ub:
                     if lb == ub == 0:
-                        guard = BoolVal(False)  # domain of divisor contains only 0
-                        output_expr = boolvar()  # arbitrary, but we need something? #todo can we delete the whole thing where the partial occurs at the level of nbc, and only keep the false?
-                        extra_cons = []
+                        # (unlikely) edge case, neirest Boolean context should propagate to False.
+                        # introduce dummy numerical integer expression
+                        guard, output_expr, extra_cons = BoolVal(False), intvar(0,1), []
                     elif lb == 0:
                         guard, output_expr, extra_cons = _safen_range(cpm_expr, safe_range=(1, ub), idx_to_safen=idx_to_safen)
                     elif ub == 0:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -76,7 +76,7 @@ def numexprs(solver):
     for name, arity in names:
         if name == "wsum":
             operator_args = [list(range(len(NUM_ARGS))), NUM_ARGS]
-        elif name == "div" or name == "pow":
+        elif name == "pow":
             operator_args = [NN_VAR,2]
         elif name == "mod":
             operator_args = [NN_VAR,POS_VAR]

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -78,6 +78,8 @@ def numexprs(solver):
             operator_args = [list(range(len(NUM_ARGS))), NUM_ARGS]
         elif name == "pow":
             operator_args = [NN_VAR,2]
+        elif name == "div" and solver == "gurobi": # supports only division by constants
+            operator_args = [NN_VAR,2]
         elif name == "mod":
             operator_args = [NN_VAR,POS_VAR]
         elif arity != 0:

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -121,7 +121,7 @@ class TestTransLinearize(unittest.TestCase):
         arr = cp.intvar(0,3, shape=3, name="x")
         idx = cp.intvar(-1, 4, name="i")
 
-        expr = (a / arr[idx]) == 0
+        expr = (a * arr[idx]) == 0
 
         safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model([safe_expr, idx == 4]).solve())

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -116,7 +116,15 @@ class TestTransLinearize(unittest.TestCase):
         solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
         self.assertEqual(solcount, 10*(4**3)*6)
 
+    def test_nested_partial_functions2(self):
+        a = cp.intvar(1, 10)
+        arr = cp.intvar(0,3, shape=3, name="x")
+        idx = cp.intvar(-1, 4, name="i")
 
+        expr = (a / arr[idx]) == 0
+
+        safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
+        self.assertTrue(cp.Model([safe_expr, idx == 4]).solve())
     # def test_division_by_constant_zero(self):
     #     a = cp.intvar(1, 10)
     #     expr = (a / cp.intvar(0,0)) == 2

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -2,7 +2,7 @@ import unittest
 
 import cpmpy as cp
 from cpmpy.transformations.normalize import toplevel_list
-from cpmpy.transformations.safening import safen
+from cpmpy.transformations.safening import no_partial_functions
 from cpmpy.expressions.utils import argval
 
 
@@ -13,11 +13,11 @@ class TestTransLinearize(unittest.TestCase):
         b = cp.intvar(0, 10, name="b")
         expr = (a // b) == 3
 
-        safe_expr = safen([expr])
+        safe_expr = no_partial_functions([expr])
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
-        safened = safen([expr | ~expr])
+        safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 110)
 
@@ -26,11 +26,11 @@ class TestTransLinearize(unittest.TestCase):
         b = cp.intvar(-1, 10, name="b")
         expr = (a // b) == 3
 
-        safe_expr = safen([expr])
+        safe_expr = no_partial_functions([expr])
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
-        safened = safen([expr | ~expr])
+        safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 120)
 
@@ -40,11 +40,11 @@ class TestTransLinearize(unittest.TestCase):
         idx = cp.intvar(-1, 4, name="i")
         expr = arr[idx] == 2
 
-        safe_expr = safen([expr])
+        safe_expr = no_partial_functions([expr])
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
-        safened = safen([expr | ~expr])
+        safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 162)
     
@@ -56,11 +56,11 @@ class TestTransLinearize(unittest.TestCase):
 
         expr = (a / b + arr[idx]) == 2
 
-        safe_expr = safen([expr])
+        safe_expr = no_partial_functions([expr])
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
-        safened = safen([expr | ~expr])
+        safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 15*162)
 
@@ -71,11 +71,11 @@ class TestTransLinearize(unittest.TestCase):
 
         expr = (a / arr[idx]) == 2
 
-        safe_expr = safen([expr])
+        safe_expr = no_partial_functions([expr])
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
-        safened = safen([expr | ~expr])
+        safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 10*(4**3)*6)
 

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -121,7 +121,7 @@ class TestTransLinearize(unittest.TestCase):
         arr = cp.intvar(0,3, shape=3, name="x")
         idx = cp.intvar(-1, 4, name="i")
 
-        expr = (a * arr[idx]) == 0
+        expr = ~((a * arr[idx]) == 0)
 
         safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model([safe_expr, idx == 4]).solve())

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -29,7 +29,6 @@ class TestTransLinearize(unittest.TestCase):
         solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
         self.assertEqual(solcount, 110)
 
-
     def test_division_by_zero_proper_hole(self):
         a = cp.intvar(1, 10, name="a")
         b = cp.intvar(-1, 10, name="b")
@@ -50,6 +49,16 @@ class TestTransLinearize(unittest.TestCase):
         solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
         self.assertEqual(solcount, 120)
 
+    def test_division_by_constant_zero(self):
+        a = cp.intvar(1, 10, name="a")
+        b = cp.intvar(0, 0, name="b")
+        expr = (a // b) <= 3
+
+        safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
+        self.assertFalse(cp.Model(safe_expr).solve())
+
+        safened = no_partial_functions([~expr])
+        self.assertEqual(str(safened[0]), "not([boolval(False)])")
 
     def test_element_out_of_bounds(self):
         arr = cp.intvar(1,3, shape=3, name="x")
@@ -125,10 +134,3 @@ class TestTransLinearize(unittest.TestCase):
 
         safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model([safe_expr, idx == 4]).solve())
-    # def test_division_by_constant_zero(self):
-    #     a = cp.intvar(1, 10)
-    #     expr = (a / cp.intvar(0,0)) == 2
-    #     safened = safen([expr | ~expr])
-    #     solcount = cp.Model(safened).solveAll()
-    #     self.assertEqual(solcount, 10)
-    

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -21,10 +21,19 @@ class TestTransLinearize(unittest.TestCase):
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 110)
 
+        # check with reification
+        bv = cp.boolvar(name="bv")
+        reif_expr = bv == expr
+        def check():
+            self.assertTrue(reif_expr.value())
+        solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
+        self.assertEqual(solcount, 110)
+
+
     def test_division_by_zero_proper_hole(self):
         a = cp.intvar(1, 10, name="a")
         b = cp.intvar(-1, 10, name="b")
-        expr = (a // b) == 3
+        expr = (a // b) <= 3
 
         safe_expr = no_partial_functions([expr])
         self.assertTrue(cp.Model(safe_expr).solve())
@@ -32,6 +41,13 @@ class TestTransLinearize(unittest.TestCase):
 
         safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 120)
+
+        bv = cp.boolvar(name="bv")
+        reif_expr = bv == expr
+        def check():
+            self.assertTrue(reif_expr.value())
+        solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
         self.assertEqual(solcount, 120)
 
 
@@ -46,6 +62,13 @@ class TestTransLinearize(unittest.TestCase):
 
         safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 162)
+
+        bv = cp.boolvar(name="bv")
+        reif_expr = bv == expr
+        def check():
+            self.assertTrue(reif_expr.value())
+        solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
         self.assertEqual(solcount, 162)
     
     def test_multiple_partial_functions(self):
@@ -64,6 +87,13 @@ class TestTransLinearize(unittest.TestCase):
         solcount = cp.Model(safened).solveAll()
         self.assertEqual(solcount, 15*162)
 
+        bv = cp.boolvar(name="bv")
+        reif_expr = bv == expr
+        def check():
+            self.assertTrue(reif_expr.value())
+        solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
+        self.assertEqual(solcount, 15*162)
+
     def test_nested_partial_functions(self):
         a = cp.intvar(1, 10)
         arr = cp.intvar(0,3, shape=3, name="x")
@@ -77,6 +107,13 @@ class TestTransLinearize(unittest.TestCase):
 
         safened = no_partial_functions([expr | ~expr])
         solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 10*(4**3)*6)
+
+        bv = cp.boolvar(name="bv")
+        reif_expr = bv == expr
+        def check():
+            self.assertTrue(reif_expr.value())
+        solcount = cp.Model(no_partial_functions([reif_expr])).solveAll(display=check)
         self.assertEqual(solcount, 10*(4**3)*6)
 
 

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -13,7 +13,7 @@ class TestTransLinearize(unittest.TestCase):
         b = cp.intvar(0, 10, name="b")
         expr = (a // b) == 3
 
-        safe_expr = no_partial_functions([expr])
+        safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
@@ -35,7 +35,7 @@ class TestTransLinearize(unittest.TestCase):
         b = cp.intvar(-1, 10, name="b")
         expr = (a // b) <= 3
 
-        safe_expr = no_partial_functions([expr])
+        safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
@@ -79,7 +79,7 @@ class TestTransLinearize(unittest.TestCase):
 
         expr = (a / b + arr[idx]) == 2
 
-        safe_expr = no_partial_functions([expr])
+        safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 
@@ -101,7 +101,7 @@ class TestTransLinearize(unittest.TestCase):
 
         expr = (a / arr[idx]) == 2
 
-        safe_expr = no_partial_functions([expr])
+        safe_expr = no_partial_functions([expr], safen_toplevel={"div"})
         self.assertTrue(cp.Model(safe_expr).solve())
         self.assertTrue(argval(safe_expr))
 

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -1,0 +1,89 @@
+import unittest
+
+import cpmpy as cp
+from cpmpy.transformations.normalize import toplevel_list
+from cpmpy.transformations.safening import safen
+from cpmpy.expressions.utils import argval
+
+
+class TestTransLinearize(unittest.TestCase):
+
+    def test_division_by_zero(self):
+        a = cp.intvar(1, 10, name="a")
+        b = cp.intvar(0, 10, name="b")
+        expr = (a // b) == 3
+
+        safe_expr = safen([expr])
+        self.assertTrue(cp.Model(safe_expr).solve())
+        self.assertTrue(argval(safe_expr))
+
+        safened = safen([expr | ~expr])
+        solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 110)
+
+    def test_division_by_zero_proper_hole(self):
+        a = cp.intvar(1, 10, name="a")
+        b = cp.intvar(-1, 10, name="b")
+        expr = (a // b) == 3
+
+        safe_expr = safen([expr])
+        self.assertTrue(cp.Model(safe_expr).solve())
+        self.assertTrue(argval(safe_expr))
+
+        safened = safen([expr | ~expr])
+        solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 120)
+
+
+    def test_element_out_of_bounds(self):
+        arr = cp.intvar(1,3, shape=3, name="x")
+        idx = cp.intvar(-1, 4, name="i")
+        expr = arr[idx] == 2
+
+        safe_expr = safen([expr])
+        self.assertTrue(cp.Model(safe_expr).solve())
+        self.assertTrue(argval(safe_expr))
+
+        safened = safen([expr | ~expr])
+        solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 162)
+    
+    def test_multiple_partial_functions(self):
+        a = cp.intvar(1, 5)
+        b = cp.intvar(0, 2)
+        arr = cp.intvar(1, 3, shape=3, name="x")
+        idx = cp.intvar(-1, 4, name="i")
+
+        expr = (a / b + arr[idx]) == 2
+
+        safe_expr = safen([expr])
+        self.assertTrue(cp.Model(safe_expr).solve())
+        self.assertTrue(argval(safe_expr))
+
+        safened = safen([expr | ~expr])
+        solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 15*162)
+
+    def test_nested_partial_functions(self):
+        a = cp.intvar(1, 10)
+        arr = cp.intvar(0,3, shape=3, name="x")
+        idx = cp.intvar(-1, 4, name="i")
+
+        expr = (a / arr[idx]) == 2
+
+        safe_expr = safen([expr])
+        self.assertTrue(cp.Model(safe_expr).solve())
+        self.assertTrue(argval(safe_expr))
+
+        safened = safen([expr | ~expr])
+        solcount = cp.Model(safened).solveAll()
+        self.assertEqual(solcount, 10*(4**3)*6)
+
+
+    # def test_division_by_constant_zero(self):
+    #     a = cp.intvar(1, 10)
+    #     expr = (a / cp.intvar(0,0)) == 2
+    #     safened = safen([expr | ~expr])
+    #     solcount = cp.Model(safened).solveAll()
+    #     self.assertEqual(solcount, 10)
+    


### PR DESCRIPTION
Started on a `safening` transformation for partial functions.
Largely based on 
> Frisch, Alan M., and Peter J. Stuckey. "The proper treatment of undefinedness in constraint languages." International Conference on Principles and Practice of Constraint Programming. Berlin, Heidelberg: Springer Berlin Heidelberg, 2009.

but some trickery was required for `div` as we do not allow domains with a hole in it.


For now, this is quite dumb: no care is taken to the context of an expression, nor whether it is top-level.

For example, `arr[x] == 2` will be safened and thus introduce a bunch of extra variables/constraints.
I think it's reasonable to leave this expression "unsafe" and just let the solver to its thing with it (TODO).

BUT, in the case of division it's more tricky, as the actual API of e.g., OR-Tools does not accept `0` in the denominator's domain.
So for that one, we actually do need safening at toplevel... (hence I did it this way for now)
A solution to this is to also introduce a `supported` list for this transformation but it feels quite hacky...

This PR only includes safening for `div` and `Element`, but the same can be implemented for `mod` I believe.

