### PR TITLE
Testing incrementality

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -709,8 +709,23 @@ class TestSolvers(unittest.TestCase):
         m = cp.Model([x + y == 2, wsum == 9])
         self.assertTrue(m.solve(solver="minizinc"))
 
-
     def test_incremental(self):
+
+        x,y,z = cp.boolvar(shape=3, name="x")
+        for solver, cls in cp.SolverLookup.base_solvers():
+            if cls.supported() is False:
+                continue
+            s = cp.SolverLookup.get(solver)
+            s += [x]
+            s += [y | z]
+            self.assertTrue(s.solve())
+            self.assertTrue(x.value(), (y | z).value())
+            s += ~y | ~z
+            self.assertTrue(s.solve())
+            self.assertTrue(x.value())
+            self.assertEqual(y.value() + z.value(), 1)
+
+    def test_incremental_objective(self):
 
         x = cp.intvar(0,10,shape=3)
         for solver, cls in cp.SolverLookup.base_solvers():
@@ -737,6 +752,7 @@ class TestSolvers(unittest.TestCase):
             s.maximize(cp.sum(x))
             self.assertTrue(s.solve())
             self.assertEqual(s.objective_value(), 25)
+
 
 
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -713,7 +713,7 @@ class TestSolvers(unittest.TestCase):
     def test_incremental(self):
 
         x = cp.intvar(0,10,shape=3)
-        for solver in cp.Solverlookup.base_solvers():
+        for solver, cls in cp.SolverLookup.base_solvers():
             if solver == "choco":
                 """
                 Choco does not support first optimizing and then adding a constraint.
@@ -721,6 +721,8 @@ class TestSolvers(unittest.TestCase):
                 which removes feasible solutions.
                 No straightforward way to resolve this for now.
                 """
+                continue
+            if cls.supported() is False:
                 continue
             s = cp.SolverLookup.get(solver)
             try:

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -11,7 +11,8 @@ from cpmpy.solvers.exact import CPM_exact
 from cpmpy.solvers.choco import CPM_choco
 
 
-from cpmpy.exceptions import MinizincNameException
+from cpmpy.exceptions import MinizincNameException, NotSupportedError
+
 
 class TestSolvers(unittest.TestCase):
     def test_installed_solvers(self):
@@ -707,3 +708,35 @@ class TestSolvers(unittest.TestCase):
 
         m = cp.Model([x + y == 2, wsum == 9])
         self.assertTrue(m.solve(solver="minizinc"))
+
+
+    def test_incremental(self):
+
+        x = cp.intvar(0,10,shape=3)
+        for solver in cp.Solverlookup.base_solvers():
+            if solver == "choco":
+                """
+                Choco does not support first optimizing and then adding a constraint.
+                During optimization, additional constraints get added to the solver,
+                which removes feasible solutions.
+                No straightforward way to resolve this for now.
+                """
+                continue
+            s = cp.SolverLookup.get(solver)
+            try:
+                s.minimize(cp.sum(x))
+            except (NotSupportedError, NotImplementedError): # solver does not support optimization
+                continue
+            self.assertTrue(s.solve())
+            self.assertEqual(s.objective_value(), 0)
+            s += x[0] == 5
+            self.assertTrue(s.solve())
+            self.assertEqual(s.objective_value(), 5)
+            s.maximize(cp.sum(x))
+            self.assertTrue(s.solve())
+            self.assertEqual(s.objective_value(), 25)
+
+
+
+
+


### PR DESCRIPTION
Added some tricky cases for incremental solving.
Especially the use of an objective function proved to be tricky, as some solvers add the cuts during optimization as hard constraints to the solver, and let it run until it reports UNSAT internally.

Currently, there is no straightforward way to get around this restriction in Choco... Incremental solving without objective does work as expected.