### PR TITLE
Cumulative decomposition fix

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -530,7 +530,7 @@ class Cumulative(GlobalConstraint):
             cons += [start[t] + duration[t] == end[t]]
 
         # demand doesn't exceed capacity
-        lb, ub = min(s.lb for s in start), max(s.ub for s in end)
+        lb, ub = min(get_bounds(start)[0]), max(get_bounds(end)[1])
         for t in range(lb,ub+1):
             demand_at_t = 0
             for job in range(len(start)):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -631,6 +631,20 @@ class TestGlobal(unittest.TestCase):
         # also test decomposition
         self.assertFalse(cp.Model(cons.decompose()).solve()) # capacity was not taken into account and this failed
 
+    def test_cumulative_nested_expressions(self):
+        import numpy as np
+
+        # before merging #435 there was an issue with capacity constraint
+        start = cp.intvar(0, 10, 4, "start")
+        duration = [1, 2, 2, 1]
+        end = start + duration
+        demand = 10 # tasks cannot be scheduled
+        capacity = np.int64(5) # bug only happened with numpy ints
+        cons = cp.Cumulative(start, duration, end, demand, capacity)
+        self.assertFalse(cp.Model(cons).solve()) # this worked fine
+        # also test decomposition
+        self.assertFalse(cp.Model(cons.decompose()).solve()) # capacity was not taken into account and this failed
+
     @pytest.mark.skipif(not CPM_minizinc.supported(),
                         reason="Minizinc not installed")
     def test_cumulative_single_demand(self):


### PR DESCRIPTION
Decomposition of cumulative did not allow nested expressions instead of variables, due to direct access of variables bounds.

Fixed by using get_bounds instead.

Also added a test for that