### PR TITLE
Clear values when UNSAT

### DIFF
--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -152,6 +152,10 @@ class CPM_template(SolverInterface):
             if self.has_objective():
                 self.objective_value_ = self.TPL_solver.ObjectiveValue()
 
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
+
         return has_sol
 
 

--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -404,6 +404,10 @@ class CPM_template(SolverInterface):
             callback = display
 
         self.solve(time_limit, callback=callback, enumerate_all_solutions=True, **kwargs)
+        # clear user vars if no solution found
+        if self.TPL_solver.SolutionCount() == 0:
+            for var in self.user_vars:
+                var.clear()
         return self.TPL_solver.SolutionCount()
 
         # B. Example code if solver does not support callbacks
@@ -422,5 +426,10 @@ class CPM_template(SolverInterface):
                     print([v.value() for v in display])
                 else:
                     display()  # callback
+
+        # clear user vars if no solution found
+        if solution_count == 0:
+            for var in self.user_vars:
+                var.clear()
 
         return solution_count

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -175,6 +175,9 @@ class CPM_choco(SolverInterface):
             # translate objective
             if self.has_objective():
                 self.objective_value_ = sol.get_int_val(self.solver_var(self.obj))
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
 
         return has_sol
 

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -215,6 +215,11 @@ class CPM_choco(SolverInterface):
         self.cpm_status = SolverStatus(self.name)
         self.cpm_status.runtime = end - start
 
+        # if no solutions, clear values of variables
+        if len(sols) == 0:
+            for var in self.user_vars:
+                var.clear()
+
         # display if needed
         if display is not None:
             for sol in sols:

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -177,7 +177,7 @@ class CPM_choco(SolverInterface):
                 self.objective_value_ = sol.get_int_val(self.solver_var(self.obj))
         else: # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
         return has_sol
 
@@ -218,7 +218,7 @@ class CPM_choco(SolverInterface):
         # if no solutions, clear values of variables
         if len(sols) == 0:
             for var in self.user_vars:
-                var.clear()
+                var._value = None
 
         # display if needed
         if display is not None:

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -183,6 +183,7 @@ class CPM_exact(SolverInterface):
         self.cpm_status = SolverStatus(self.name)
         self.cpm_status.runtime = end - start
 
+        self.objective_value_ = None
         # translate exit status
         if my_status == "UNSAT": # found unsatisfiability
             if self.has_objective() and self.xct_solver.hasSolution():

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -127,7 +127,7 @@ class CPM_exact(SolverInterface):
         if not self.xct_solver.hasSolution():
             self.objective_value_ = None
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
             return
 
         # fill in variable values

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -127,7 +127,7 @@ class CPM_exact(SolverInterface):
         if not self.xct_solver.hasSolution():
             self.objective_value_ = None
             for cpm_var in self.user_vars:
-                cpm_var._value = None
+                cpm_var.clear()
             return
 
         # fill in variable values
@@ -205,7 +205,6 @@ class CPM_exact(SolverInterface):
                 self.objective_value_ = obj_val
             else: # maximize, so actually negative value
                 self.objective_value_ = -obj_val
-
         
         # True/False depending on self.cpm_status
         return self._solve_return(self.cpm_status)

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -172,7 +172,11 @@ class CPM_gcs(SolverInterface):
             # translate objective, for optimisation problems only
             if self.has_objective():
                 self.objective_value_ = self.gcs.get_solution_value(self.solver_var(self.objective_var))
-        
+
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
+
         # Verify proof, if requested
         if verify:
             self.verify(name=self.proof_name, location=proof_location, time_limit=verify_time_limit,

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -175,7 +175,7 @@ class CPM_gcs(SolverInterface):
 
         else: # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
         # Verify proof, if requested
         if verify:
@@ -264,7 +264,7 @@ class CPM_gcs(SolverInterface):
         # clear user vars if no solution found
         if self._solve_return(self.cpm_status, self.objective_value_) is False:
             for var in self.user_vars:
-                var.clear()
+                var._value = None
 
         # Verify proof, if requested
         if verify:

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -261,6 +261,11 @@ class CPM_gcs(SolverInterface):
         self.cpm_status = SolverStatus(self.name)
         self.cpm_status.runtime = gcs_stats["solve_time"]
 
+        # clear user vars if no solution found
+        if self._solve_return(self.cpm_status, self.objective_value_) is False:
+            for var in self.user_vars:
+                var.clear()
+
         # Verify proof, if requested
         if verify:
             self.verify(name=self.proof_name, location=proof_location, time_limit=verify_time_limit, 

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -188,7 +188,7 @@ class CPM_gurobi(SolverInterface):
 
         else: # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                var._value = None
 
         return has_sol
 
@@ -461,7 +461,7 @@ class CPM_gurobi(SolverInterface):
         if solution_count == 0:
             self.objective_value_ = None
             for var in self.user_vars:
-                var.clear()
+                var._value = None
 
         for i in range(solution_count):
             # Specify which solution to query

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -457,6 +457,12 @@ class CPM_gurobi(SolverInterface):
         solution_count = self.grb_model.SolCount
         opt_sol_count = 0
 
+        # clear user vars if no solution found
+        if solution_count == 0:
+            self.objective_value_ = None
+            for var in self.user_vars:
+                var.clear()
+
         for i in range(solution_count):
             # Specify which solution to query
             self.grb_model.setParam("SolutionNumber", i)

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -186,6 +186,10 @@ class CPM_gurobi(SolverInterface):
                 else:
                     self.objective_value_ = int(grb_obj_val)
 
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
+
         return has_sol
 
 

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -282,7 +282,7 @@ class CPM_minizinc(SolverInterface):
 
         else: # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
         return has_sol
 
@@ -378,7 +378,7 @@ class CPM_minizinc(SolverInterface):
             # clear user vars if no solution found
             self.objective_value_ = None
             for var in self.user_vars:
-                var.clear()
+                var._value = None
 
         # status handling
         self._post_solve(mzn_result)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -374,6 +374,12 @@ class CPM_minizinc(SolverInterface):
             # add nogood on the user variables
             self += any([v != v.value() for v in self.user_vars])
 
+        if solution_count == 0:
+            # clear user vars if no solution found
+            self.objective_value_ = None
+            for var in self.user_vars:
+                var.clear()
+
         # status handling
         self._post_solve(mzn_result)
 

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -279,7 +279,11 @@ class CPM_minizinc(SolverInterface):
 
             # translate objective, for optimisation problems only (otherwise None)
             self.objective_value_ = self.mzn_result.objective
-        
+
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
+
         return has_sol
 
     def _post_solve(self, mzn_result):

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -221,6 +221,10 @@ class CPM_ortools(SolverInterface):
                 assert int(ort_obj_val) == ort_obj_val, "Objective value should be integer, please report on github"
                 self.objective_value_ = int(ort_obj_val) # ensure it is an integer
 
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
+
         return has_sol
 
     def solveAll(self, display=None, time_limit=None, solution_limit=None, call_from_model=False, **kwargs):

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -223,7 +223,7 @@ class CPM_ortools(SolverInterface):
 
         else: # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
         return has_sol
 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -208,6 +208,11 @@ class CPM_pysat(SolverInterface):
                 else: # not specified, dummy val
                     cpm_var._value = True
 
+        else: # clear values of variables
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
+
+
         return has_sol
 
 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -210,7 +210,7 @@ class CPM_pysat(SolverInterface):
 
         else: # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
 
         return has_sol

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -124,6 +124,8 @@ class CPM_pysdd(SolverInterface):
             self.cpm_status.exitstatus = ExitStatus.FEASIBLE
         else:
             self.cpm_status.exitstatus = ExitStatus.UNSATISFIABLE
+            for cpm_var in self.user_vars:
+                cpm_var.clear()
 
         # get solution values (of user specified variables only)
         if has_sol and self.pysdd_root is not None:

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -164,6 +164,9 @@ class CPM_pysdd(SolverInterface):
             raise NotImplementedError("PySDD.solveAll(), solution_limit not (yet?) supported")
 
         if self.pysdd_root is None:
+            # clear user vars if no solution found
+            for var in self.user_vars:
+                var.clear()
             return 0
 
         sddmodels = [x for x in self.pysdd_root.models()]

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -125,7 +125,7 @@ class CPM_pysdd(SolverInterface):
         else:
             self.cpm_status.exitstatus = ExitStatus.UNSATISFIABLE
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
         # get solution values (of user specified variables only)
         if has_sol and self.pysdd_root is not None:
@@ -166,7 +166,7 @@ class CPM_pysdd(SolverInterface):
         if self.pysdd_root is None:
             # clear user vars if no solution found
             for var in self.user_vars:
-                var.clear()
+                var._value = None
             return 0
 
         sddmodels = [x for x in self.pysdd_root.models()]

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -190,9 +190,9 @@ class CPM_z3(SolverInterface):
                 obj = self.z3_solver.objectives()[0]
                 self.objective_value_ = sol.evaluate(obj).as_long()
 
-        else:
+        else:  # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var._value = None # XXX, maybe all solvers should do this...
+                cpm_var.clear()
 
         return has_sol
 

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -192,7 +192,7 @@ class CPM_z3(SolverInterface):
 
         else:  # clear values of variables
             for cpm_var in self.user_vars:
-                cpm_var.clear()
+                cpm_var._value = None
 
         return has_sol
 

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -67,7 +67,7 @@ Since the arrays of decision variables are based on numpy, you can do **vectoriz
 
 See [the API documentation on variables](./api/expressions/variables.rst) for more detailed information.
 
-Note that decision variables are not tied to a model. You can use the same variable in different models; its value() will be the one of the last succesful solve call.
+Note that decision variables are not tied to a model. You can use the same variable in different models; its value() will be the one of the last solve call. Hence, when the last solve call was unsatisfiable, it's value will again be `None`.
 
 ## Creating a model
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -753,6 +753,21 @@ class TestSolvers(unittest.TestCase):
             self.assertTrue(s.solve())
             self.assertEqual(s.objective_value(), 25)
 
+    def test_value_cleared(self):
+
+        x,y,z = cp.boolvar(shape=3)
+        sat_model = cp.Model(cp.any([x,y,z]))
+        unsat_model = cp.Model([x | y | z, ~x, ~y,~z])
+
+        for name, cls in cp.SolverLookup.base_solvers():
+            if cls.supported() is False: # solver not supported
+                continue
+            self.assertTrue(sat_model.solve(solver=name))
+            for v in (x,y,z):
+                self.assertIsNotNone(v.value())
+            self.assertFalse(unsat_model.solve(solver=name))
+            for v in (x,y,z):
+                self.assertIsNone(v.value())
 
 
 


### PR DESCRIPTION
There was some inconcistency regarding what to do when the solver found UNSAT.
Z3 already cleared the values of all known variables, which I think made sense.

Extended this behaviour to all other solvers too and updated documentation