### PR TITLE
Update Choco interface with native reification

### DIFF
--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -332,17 +332,10 @@ class CPM_choco(SolverInterface):
                      "table", 'negative_table', "InDomain", "cumulative", "circuit", "gcc", "inverse", "nvalue", "increasing",
                      "decreasing","strictly_increasing","strictly_decreasing","lex_lesseq", "lex_less", "among", "precedence"}
                      
-        # choco supports reification of any constraint, but has a bug in increasing and decreasing
-        supported_reified = {"min", "max", "abs", "count", "element", "alldifferent", "alldifferent_except0",
-                             "allequal", "table", 'negative_table', "InDomain", "cumulative", "circuit", "gcc", "inverse", "nvalue",
-                             "lex_lesseq", "lex_less",  "among"}
-
-        # for when choco new release comes, fixing the bug on increasing and decreasing
-        #supported_reified = supported
-        cpm_cons = decompose_in_tree(cpm_cons, supported, supported_reified)
+        cpm_cons = decompose_in_tree(cpm_cons, supported, supported) # choco supports any global also (half-) reified
         cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
         cpm_cons = canonical_comparison(cpm_cons)
-        cpm_cons = reify_rewrite(cpm_cons, supported = supported_reified | {"sum", "wsum"})  # constraints that support reification
+        cpm_cons = reify_rewrite(cpm_cons, supported = supported | {"sum", "wsum"})  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # support >, <, !=
 
         return cpm_cons

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -70,6 +70,15 @@ class CPM_choco(SolverInterface):
         # try to import the package
         try:
             import pychoco as chc
+            # check it's the correct version
+            # CPMPy uses features only available from 0.2.1
+            from importlib.metadata import version as get_version
+            from packaging import version
+            pychoco_version = get_version("pychoco")
+            if version.parse(pychoco_version) < version.parse("0.2.1"):
+                import warnings
+                warnings.warn(f"CPMpy uses features only available from Pychoco version 0.2.1, but you have version {pychoco_version}")
+                return False
             return True
         except ImportError:
             return False

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -389,14 +389,6 @@ class CPM_choco(SolverInterface):
 
             elif cpm_expr.name == "->":
                 cond, subexpr = cpm_expr.args
-                if isinstance(cond, _BoolVarImpl) and isinstance(subexpr, _BoolVarImpl): # bv -> bv
-                    chc_cond, chc_subexpr = self.solver_vars([cond, subexpr])
-                elif isinstance(cond, _BoolVarImpl): # bv -> expr
-                    chc_cond = self.solver_var(cond)
-                    chc_subexpr = self._get_constraint(subexpr).reify()
-                elif isinstance(subexpr, _BoolVarImpl): # expr -> bv
-                    chc_cond = self._get_constraint(cond).reify()
-                    chc_subexpr = self.solver_var(subexpr)
                 if isinstance(cond, _BoolVarImpl) and isinstance(subexpr, _BoolVarImpl):
                     return self.chc_model.or_(self.solver_vars([~cond, subexpr]))
                 elif isinstance(cond, _BoolVarImpl):


### PR DESCRIPTION
Choco released pychoco version 0.2.1, which enables support for reification of (global) constraints natively in the Python API.