### PR TITLE
Better naive grow

### DIFF
--- a/cpmpy/tools/explain/mss.py
+++ b/cpmpy/tools/explain/mss.py
@@ -82,13 +82,15 @@ def mss_grow_naive(soft, hard=[], solver="ortools"):
 
     to_check = list(soft)
     sat_subset = []
+    solver = cp.SolverLookup.get(solver, cp.Model(hard))
 
     while len(to_check):
         c = to_check.pop()
-        if cp.Model(sat_subset + [c] + hard).solve(solver=solver) is True:
-            sat_subset += [c]
+        solver += c
+        if solver.solve() is True:
+            sat_subset.append(c)
         else:
-            # UNSAT, cannot add to sat subset
-            pass
+            # UNSAT, cannot add to sat subset, reset solver to just sat subset
+            solver = cp.SolverLookup.get(solver, cp.Model(hard + sat_subset))
 
     return sat_subset

--- a/cpmpy/tools/explain/mss.py
+++ b/cpmpy/tools/explain/mss.py
@@ -40,6 +40,10 @@ def mss_grow(soft, hard=[], solver="ortools"):
         Computes a subset-maximal set of constraints by greedily adding contraints.
         Relies on solving under assumptions, so using an incremental solver is adviced
         No guarantees on optimality, but can be faster in some cases
+
+        Exploits the solution found to add more constraints at once, cfr:
+        Mencía, Carlos, and Joao Marques-Silva. "Efficient relaxations of over-constrained CSPs."
+        2014 IEEE 26th International Conference on Tools with Artificial Intelligence. IEEE, 2014.
     """
 
     (m, soft, assump) = make_assump_model(soft, hard=hard)
@@ -53,11 +57,12 @@ def mss_grow(soft, hard=[], solver="ortools"):
     else:
         sat_subset = []
 
-    to_check = list(set(assump) - set(sat_subset))
+    to_check = set(assump) - set(sat_subset)
     while len(to_check):
         a = to_check.pop()
         if s.solve(assumptions=sat_subset + [a]) is True:
-            sat_subset.append(a)
+            sat_subset = [a for a, c in zip(assump, soft) if a.value() or c.value()]
+            to_check -= set(sat_subset)
         else:
             # UNSAT, cannot add
             pass

--- a/cpmpy/tools/explain/mss.py
+++ b/cpmpy/tools/explain/mss.py
@@ -87,15 +87,17 @@ def mss_grow_naive(soft, hard=[], solver="ortools"):
 
     to_check = list(soft)
     sat_subset = []
-    solver = cp.SolverLookup.get(solver, cp.Model(hard))
+    s = cp.SolverLookup.get(solver)
+    s += hard
 
     while len(to_check):
         c = to_check.pop()
-        solver += c
-        if solver.solve() is True:
+        s += c
+        if s.solve() is True:
             sat_subset.append(c)
         else:
             # UNSAT, cannot add to sat subset, reset solver to just sat subset
-            solver = cp.SolverLookup.get(solver, cp.Model(hard + sat_subset))
+            s = cp.SolverLookup.get(solver)
+            s += hard
 
     return sat_subset


### PR DESCRIPTION
Small change to `mcs_naive` to support _some_ incrementality.

If the solver at hand (e.g, Gurobi) does not support assumption variables, but is incremental, this addition will keep the state of the solver as long the result is SAT. 
Solver is reset to scratch at each failure (before it was reset at each solve call)