### PR TITLE
Reals in objective function

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -542,7 +542,7 @@ class Operator(Expression):
         if any(a is None for a in arg_vals): return None
         # non-boolean
         elif self.name == "sum": return sum(arg_vals)
-        elif self.name == "wsum": return int(sum(arg_vals[0]*np.array(arg_vals[1])))
+        elif self.name == "wsum": return np.dot(arg_vals[0], arg_vals[1]).item()
         elif self.name == "mul": return arg_vals[0] * arg_vals[1]
         elif self.name == "sub": return arg_vals[0] - arg_vals[1]
         elif self.name == "mod": return arg_vals[0] % arg_vals[1]

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -542,7 +542,11 @@ class Operator(Expression):
         if any(a is None for a in arg_vals): return None
         # non-boolean
         elif self.name == "sum": return sum(arg_vals)
-        elif self.name == "wsum": return np.dot(arg_vals[0], arg_vals[1]).item()
+        elif self.name == "wsum": 
+            val = np.dot(arg_vals[0], arg_vals[1]).item()
+            if round(val) == val: # it is an integer
+                return int(val)
+            return val # can be a float
         elif self.name == "mul": return arg_vals[0] * arg_vals[1]
         elif self.name == "sub": return arg_vals[0] - arg_vals[1]
         elif self.name == "mod": return arg_vals[0] % arg_vals[1]

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -181,10 +181,10 @@ class CPM_gurobi(SolverInterface):
             # set _objective_value
             if self.has_objective():
                 grb_obj_val = grb_objective.getValue()
-                if grb_obj_val != int(grb_obj_val):
-                    self.objective_value_ =  grb_obj_val # can happen with DirectVar using floats
-                else:
+                if round(grb_obj_val) == grb_obj_val: # it is an integer?:
                     self.objective_value_ = int(grb_obj_val)
+                else: #  can happen with DirectVar or when using floats as coefficients
+                    self.objective_value_ =  float(grb_obj_val)
 
         return has_sol
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -321,14 +321,14 @@ class CPM_ortools(SolverInterface):
         # sum or weighted sum
         if isinstance(cpm_expr, Operator):
             if cpm_expr.name == 'sum':
-                return sum(self.solver_vars(cpm_expr.args))  # OR-Tools supports this
+                return ort.LinearExpr.sum(self.solver_vars(cpm_expr.args))
             elif cpm_expr.name == "sub":
                 a,b = self.solver_vars(cpm_expr.args)
                 return a - b
             elif cpm_expr.name == 'wsum':
                 w = cpm_expr.args[0]
                 x = self.solver_vars(cpm_expr.args[1])
-                return sum(wi*xi for wi,xi in zip(w,x))  # XXX is there a more direct way?
+                return ort.LinearExpr.weighted_sum(x,w)
 
         raise NotImplementedError("ORTools: Not a known supported numexpr {}".format(cpm_expr))
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -218,9 +218,10 @@ class CPM_ortools(SolverInterface):
             # translate objective
             if self.has_objective():
                 ort_obj_val = self.ort_solver.ObjectiveValue()
-                assert int(ort_obj_val) == ort_obj_val, "Objective value should be integer, please report on github"
-                self.objective_value_ = int(ort_obj_val) # ensure it is an integer
-
+                if round(ort_obj_val) == ort_obj_val: # it is an integer?
+                    self.objective_value_ = int(ort_obj_val)  # ensure it is an integer
+                else: # can happen when using floats as coeff in objective
+                    self.objective_value_ = float(ort_obj_val)
         return has_sol
 
     def solveAll(self, display=None, time_limit=None, solution_limit=None, call_from_model=False, **kwargs):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -536,7 +536,6 @@ class TestBounds(unittest.TestCase):
         x = cp.intvar(1,10,shape=(3,3), name="x")
         self.assertTrue(cp.Model(cp.sum(x) >= 10).solve())
         self.assertIsNotNone(x.value())
-        print(x.value())
         # test all types of expressions
         self.assertEqual(int, type(x[0,0].value())) # just the var
         for v in x[0]:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -544,6 +544,7 @@ class TestBounds(unittest.TestCase):
         self.assertEqual(int, type(cp.sum(x[0]).value()))
         self.assertEqual(int, type(cp.sum(x).value()))
         self.assertEqual(int, type(cp.sum([1,2,3] * x[0]).value()))
+        self.assertEqual(float, type(cp.sum([0.1,0.2,0.3] * x[0]).value()))
         self.assertEqual(int, type(cp.sum(np.array([1, 2, 3]) * x[0]).value()))
         a,b = x[0,[0,1]]
         self.assertEqual(int, type((-a).value()))

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -302,6 +302,18 @@ class TestSolvers(unittest.TestCase):
 
         self.assertTrue(model.solve(solver="ortools")) # this is a bug in ortools version 9.5, upgrade to version >=9.6 using pip install --upgrade ortools
 
+    def test_ortools_real_coeff(self):
+
+        m = cp.Model()
+        # this works in OR-Tools
+        x,y,z = cp.boolvar(shape=3, name=tuple("xyz"))
+        m.maximize(0.3 * x + 0.5 * y + 0.6 * z)
+        assert m.solve()
+        assert m.objective_value() == 1.4
+        # this does not
+        m += 0.7 * x + 0.8 * y >= 1
+        self.assertRaises(TypeError, m.solve)
+
     @pytest.mark.skipif(not CPM_pysat.supported(),
                         reason="PySAT not installed")
     def test_pysat(self):


### PR DESCRIPTION
It seems #517 was merged a little too eager.
In newer versions of OR-Tools, you can actually use a real coefficient in the objective function, which was prohibited by my earlier fix.

Updated tests accordingly and made some small changes to Gurobi to make things more streamlined