### PR TITLE
Remove broadcast in min/max when forwarding to builtins

### DIFF
--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -90,7 +90,7 @@ def max(*iterable, **kwargs):
     if len(iterable) == 1:
         iterable = tuple(iterable[0])
     if not builtins.any(isinstance(elem, Expression) for elem in iterable):
-        return builtins.max(*iterable, **kwargs)
+        return builtins.max(iterable, **kwargs)
 
     assert len(kwargs)==0, "max over decision variables does not support keyword arguments"
     return Maximum(iterable)
@@ -107,7 +107,7 @@ def min(*iterable, **kwargs):
     if len(iterable) == 1:
         iterable = tuple(iterable[0])
     if not builtins.any(isinstance(elem, Expression) for elem in iterable):
-        return builtins.min(*iterable, **kwargs)
+        return builtins.min(iterable, **kwargs)
 
     assert len(kwargs)==0, "min over decision variables does not support keyword arguments"
     return Minimum(iterable)


### PR DESCRIPTION
Resolves issue #535 where CPMpy's min/max is inconsistent with Python's built-in min/max on iterators with single (non-cpmpy) element. Old implementation with broadcast operator doesn't take this edge-case into account and causes an exception. The builtin works perfectly fine with handling the iterator directly, no need for broadcasting.