### PR TITLE
Convert numpy array to list in Table global constraint

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -344,6 +344,8 @@ class Table(GlobalConstraint):
     """
     def __init__(self, array, table):
         array = flatlist(array)
+        if isinstance(table, np.ndarray): # Ensure it is a list
+            table = table.tolist()
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("the first argument of a Table constraint should only contain variables/expressions")
         super().__init__("table", [array, table])


### PR DESCRIPTION
Table global constraint does not work in ortools when a numpy array is given (issue #531 ).

Fixed it by converted a given numpy array to a list. Also tried giving different types besides lists and numpy arrays, and it works.

It fails on numpy arrays because they did not have a len() attribute.