### PR TITLE
remove inline imports

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -298,9 +298,7 @@ class Expression(object):
             return ~self
         if is_false_cst(other):
             return self
-        # avoid cyclic import
-        from .globalconstraints import Xor
-        return Xor([self, other])
+        return cp.Xor([self, other])
 
     def __rxor__(self, other):
         # some simple constant removal
@@ -308,9 +306,7 @@ class Expression(object):
             return ~self
         if is_false_cst(other):
             return self
-        # avoid cyclic import
-        from .globalconstraints import Xor
-        return Xor([other, self])
+        return cp.Xor([other, self])
 
     # Mathematical Operators, including 'r'everse if it exists
     # Addition
@@ -410,8 +406,7 @@ class Expression(object):
         return self
 
     def __abs__(self):
-        from .globalfunctions import Abs
-        return Abs(self)
+        return cp.Abs(self)
 
     def __invert__(self):
         if not (is_boolexpr(self)):

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -65,6 +65,8 @@
 """
 import warnings  # for deprecation warning
 import numpy as np
+import cpmpy as cp
+
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
 from .core import Expression, Operator, Comparison
 from .variables import boolvar, intvar, cpm_array
@@ -131,11 +133,10 @@ class Minimum(GlobalFunction):
             2) constraints that (totally) define new auxiliary variables needed in the decomposition,
                they should be enforced toplevel.
         """
-        from .python_builtins import any, all
         lb, ub = self.get_bounds()
         _min = intvar(lb, ub)
         return [eval_comparison(cpm_op, _min, cpm_rhs)], \
-               [any(x <= _min for x in self.args), all(x >= _min for x in self.args), ]
+               [cp.any(x <= _min for x in self.args), cp.all(x >= _min for x in self.args), ]
 
     def get_bounds(self):
         """
@@ -168,11 +169,10 @@ class Maximum(GlobalFunction):
             2) constraints that (totally) define new auxiliary variables needed in the decomposition,
                they should be enforced toplevel.
         """
-        from .python_builtins import any, all
         lb, ub = self.get_bounds()
         _max = intvar(lb, ub)
         return [eval_comparison(cpm_op, _max, cpm_rhs)], \
-               [any(x >= _max for x in self.args), all(x <= _max for x in self.args)]
+               [cp.any(x >= _max for x in self.args), cp.all(x <= _max for x in self.args)]
 
     def get_bounds(self):
         """
@@ -265,8 +265,6 @@ class Element(GlobalFunction):
                    they should be enforced toplevel.
 
         """
-        from .python_builtins import any
-
         arr, idx = self.args
         return [(idx == i).implies(eval_comparison(cpm_op, arr[i], cpm_rhs)) for i in range(len(arr))] + \
                [idx >= 0, idx < len(arr)], []
@@ -330,10 +328,9 @@ class Among(GlobalFunction):
         """
             Among(arr, vals) can only be decomposed if it's part of a comparison'
         """
-        from .python_builtins import sum, any
         arr, values = self.args
         count_for_each_val = [Count(arr, val) for val in values]
-        return [eval_comparison(cmp_op, sum(count_for_each_val), cmp_rhs)], []
+        return [eval_comparison(cmp_op, cp.sum(count_for_each_val), cmp_rhs)], []
 
     def value(self):
         return int(sum(np.isin(argvals(self.args[0]), self.args[1])))
@@ -362,7 +359,6 @@ class NValue(GlobalFunction):
             International Conference on Principles and Practice of Constraint Programming.
             Berlin, Heidelberg: Springer Berlin Heidelberg, 2010.
         """
-        from .python_builtins import sum, any
 
         lbs, ubs = get_bounds(self.args)
         lb, ub = min(lbs), max(ubs)
@@ -375,9 +371,9 @@ class NValue(GlobalFunction):
         args = cpm_array(self.args)
         # bvar is true if the value is taken by any variable
         for bv, val in zip(bvars, range(lb, ub+1)):
-            constraints += [any(args == val) == bv]
+            constraints += [cp.any(args == val) == bv]
 
-        return [eval_comparison(cmp_op, sum(bvars), cpm_rhs)], constraints
+        return [eval_comparison(cmp_op, cp.sum(bvars), cpm_rhs)], constraints
 
     def value(self):
         return len(set(argval(a) for a in self.args))
@@ -412,7 +408,6 @@ class NValueExcept(GlobalFunction):
             International Conference on Principles and Practice of Constraint Programming.
             Berlin, Heidelberg: Springer Berlin Heidelberg, 2010.
         """
-        from .python_builtins import sum, any
 
         arr, n = self.args
         arr = cpm_array(arr)
@@ -425,13 +420,13 @@ class NValueExcept(GlobalFunction):
         bvars = boolvar(shape=(ub + 1 - lb))
         idx_of_n = n - lb
         if 0 <= idx_of_n < len(bvars):
-            count_of_vals = sum(bvars[:idx_of_n]) + sum(bvars[idx_of_n+1:])
+            count_of_vals = cp.sum(bvars[:idx_of_n]) + cp.sum(bvars[idx_of_n+1:])
         else:
-            count_of_vals = sum(bvars)
+            count_of_vals = cp.sum(bvars)
 
         # bvar is true if the value is taken by any variable
         for bv, val in zip(bvars, range(lb, ub + 1)):
-            constraints += [any(arr == val) == bv]
+            constraints += [cp.any(arr == val) == bv]
 
         return [eval_comparison(cmp_op, count_of_vals, cpm_rhs)], constraints
 

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -29,6 +29,7 @@ Internal utilities for expression handling.
         get_bounds     
 """
 
+import cpmpy
 import numpy as np
 import math
 from collections.abc import Iterable  # for flatten
@@ -39,29 +40,27 @@ from cpmpy.exceptions import IncompleteFunctionError
 def is_bool(arg):
     """ is it a boolean (incl numpy variants)
     """
-    from cpmpy import BoolVal
-    return isinstance(arg, (bool, np.bool_, BoolVal))
+    return isinstance(arg, (bool, np.bool_, cpmpy.BoolVal))
 
 
 def is_int(arg):
     """ can it be interpreted as an integer? (incl bool and numpy variants)
     """
-    return is_bool(arg) or isinstance(arg, (int, np.integer))
+    return isinstance(arg, (bool, np.bool_, cpmpy.BoolVal, int, np.integer))
 
 
 def is_num(arg):
     """ is it an int or float? (incl numpy variants)
     """
-    return is_int(arg) or isinstance(arg, (float, np.floating))
+    return isinstance(arg, (bool, np.bool_, cpmpy.BoolVal, int, np.integer, float, np.floating))
 
 
 def is_false_cst(arg):
     """ is the argument the constant False (can be of type bool, np.bool and BoolVal)
     """
-    from cpmpy import BoolVal
     if arg is False or arg is np.False_:
         return True
-    elif isinstance(arg, BoolVal):
+    elif isinstance(arg, cpmpy.BoolVal):
         return not arg.value()
     return False
 
@@ -69,10 +68,9 @@ def is_false_cst(arg):
 def is_true_cst(arg):
     """ is the argument the constant True (can be of type bool, np.bool and BoolVal)
     """
-    from cpmpy import BoolVal
     if arg is True or arg is np.True_:
         return True
-    elif isinstance(arg, BoolVal):
+    elif isinstance(arg, cpmpy.BoolVal):
         return arg.value()
     return False
 

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -29,7 +29,7 @@ Internal utilities for expression handling.
         get_bounds     
 """
 
-import cpmpy
+import cpmpy as cp
 import numpy as np
 import math
 from collections.abc import Iterable  # for flatten
@@ -40,19 +40,19 @@ from cpmpy.exceptions import IncompleteFunctionError
 def is_bool(arg):
     """ is it a boolean (incl numpy variants)
     """
-    return isinstance(arg, (bool, np.bool_, cpmpy.BoolVal))
+    return isinstance(arg, (bool, np.bool_, cp.BoolVal))
 
 
 def is_int(arg):
     """ can it be interpreted as an integer? (incl bool and numpy variants)
     """
-    return isinstance(arg, (bool, np.bool_, cpmpy.BoolVal, int, np.integer))
+    return isinstance(arg, (bool, np.bool_, cp.BoolVal, int, np.integer))
 
 
 def is_num(arg):
     """ is it an int or float? (incl numpy variants)
     """
-    return isinstance(arg, (bool, np.bool_, cpmpy.BoolVal, int, np.integer, float, np.floating))
+    return isinstance(arg, (bool, np.bool_, cp.BoolVal, int, np.integer, float, np.floating))
 
 
 def is_false_cst(arg):
@@ -60,7 +60,7 @@ def is_false_cst(arg):
     """
     if arg is False or arg is np.False_:
         return True
-    elif isinstance(arg, cpmpy.BoolVal):
+    elif isinstance(arg, cp.BoolVal):
         return not arg.value()
     return False
 
@@ -70,7 +70,7 @@ def is_true_cst(arg):
     """
     if arg is True or arg is np.True_:
         return True
-    elif isinstance(arg, cpmpy.BoolVal):
+    elif isinstance(arg, cp.BoolVal):
         return arg.value()
     return False
 
@@ -180,10 +180,10 @@ def get_bounds(expr):
     """
 
     # import here to avoid circular import
-    from cpmpy.expressions.core import Expression
-    from cpmpy.expressions.variables import cpm_array
+    # from cpmpy.expressions.core import Expression
+    # from cpmpy.expressions.variables import cpm_array
 
-    if isinstance(expr, Expression):
+    if isinstance(expr, cp.expressions.core.Expression):
         return expr.get_bounds()
     elif is_any_list(expr):
         lbs, ubs = zip(*[get_bounds(e) for e in expr])

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -61,6 +61,7 @@ import warnings # for deprecation warning
 from functools import reduce
 
 import numpy as np
+import cpmpy as cp  # to avoid circular import
 from .core import Expression, Operator
 from .utils import is_num, is_int, flatlist, is_boolexpr, is_true_cst, is_false_cst, get_bounds
 
@@ -432,12 +433,11 @@ class NDVarArray(np.ndarray, Expression):
         return super().__repr__()
 
     def __getitem__(self, index):
-        from .globalfunctions import Element # here to avoid circular
         # array access, check if variables are used in the indexing
 
         # index is single expression: direct element
         if isinstance(index, Expression):
-            return Element(self, index)
+            return cp.Element(self, index)
 
         # multi-dimensional index
         if isinstance(index, tuple) and any(isinstance(el, Expression) for el in index):
@@ -451,7 +451,7 @@ class NDVarArray(np.ndarray, Expression):
             for dim, idx in enumerate(index[:-1]):
                 flat_index += idx * math.prod(arr.shape[dim+1:])
             # using index expression as single var for flat array
-            return Element(arr.flatten(), flat_index)
+            return cp.Element(arr.flatten(), flat_index)
 
         ret = super().__getitem__(index)
         # this is a bit ugly,

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -506,15 +506,14 @@ class NDVarArray(np.ndarray, Expression):
         """
             overwrite np.sum(NDVarArray) as people might use it
         """
-        from .python_builtins import sum as cpm_sum
 
         if out is not None:
             raise NotImplementedError()
 
         if axis is None:    # simple case where we want the sum over the whole array
-            return cpm_sum(self)
+            return cp.sum(self)
 
-        return cpm_array(np.apply_along_axis(cpm_sum, axis=axis, arr=self))
+        return cpm_array(np.apply_along_axis(cp.sum, axis=axis, arr=self))
 
 
     def prod(self, axis=None, out=None):
@@ -535,34 +534,30 @@ class NDVarArray(np.ndarray, Expression):
         """
             overwrite np.max(NDVarArray) as people might use it
         """
-        from .python_builtins import max as cpm_max
         if out is not None:
             raise NotImplementedError()
 
         if axis is None:    # simple case where we want the maximum over the whole array
-            return cpm_max(self)
+            return cp.max(self)
 
-        return cpm_array(np.apply_along_axis(cpm_max, axis=axis, arr=self))
+        return cpm_array(np.apply_along_axis(cp.max, axis=axis, arr=self))
 
     def min(self, axis=None, out=None):
         """
             overwrite np.min(NDVarArray) as people might use it
         """
-        from .python_builtins import min as cpm_min
         if out is not None:
             raise NotImplementedError()
 
         if axis is None:    # simple case where we want the minimum over the whole array
-            return cpm_min(self)
+            return cp.min(self)
 
-        return cpm_array(np.apply_along_axis(cpm_min, axis=axis, arr=self))
+        return cpm_array(np.apply_along_axis(cp.min, axis=axis, arr=self))
 
     def any(self, axis=None, out=None):
         """
             overwrite np.any(NDVarArray)
         """
-        from .python_builtins import any as cpm_any
-
         if any(not is_boolexpr(x) for x in self.flat):
             raise TypeError("Cannot call .any() in an array not consisting only of bools")
 
@@ -570,18 +565,15 @@ class NDVarArray(np.ndarray, Expression):
             raise NotImplementedError()
 
         if axis is None:    # simple case where we want a disjunction over the whole array
-            return cpm_any(self)
+            return cp.any(self)
 
-        return cpm_array(np.apply_along_axis(cpm_any, axis=axis, arr=self))
+        return cpm_array(np.apply_along_axis(cp.any, axis=axis, arr=self))
 
 
     def all(self, axis=None, out=None):
         """
             overwrite np.any(NDVarArray)
         """
-
-        from .python_builtins import all as cpm_all
-
         if any(not is_boolexpr(x) for x in self.flat):
             raise TypeError("Cannot call .any() in an array not consisting only of bools")
 
@@ -589,9 +581,9 @@ class NDVarArray(np.ndarray, Expression):
             raise NotImplementedError()
 
         if axis is None:  # simple case where we want a conjunction over the whole array
-            return cpm_all(self)
+            return cp.all(self)
 
-        return cpm_array(np.apply_along_axis(cpm_all, axis=axis, arr=self))
+        return cpm_array(np.apply_along_axis(cp.all, axis=axis, arr=self))
 
     def get_bounds(self):
         lbs, ubs = zip(*[get_bounds(e) for e in self])

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -79,6 +79,7 @@ TODO: small optimisations, e.g. and/or chaining (potentially after negation), se
 """
 import math
 import builtins
+import cpmpy as cp
 
 from .normalize import toplevel_list, simplify_boolean
 from ..expressions.core import *
@@ -92,21 +93,20 @@ def flatten_model(orig_model):
     """
         Receives model, returns new model where every constraint is in 'flat normal form'
     """
-    from ..model import Model  # otherwise circular dependency...
 
     # the top-level constraints
     basecons = flatten_constraint(orig_model.constraints)
 
     # the objective
     if orig_model.objective_ is None:
-        return Model(*basecons)  # no objective, satisfaction problem
+        return cp.Model(*basecons)  # no objective, satisfaction problem
     else:
         (newobj, newcons) = flatten_objective(orig_model.objective_)
         basecons += newcons
         if orig_model.objective_is_min:
-            return Model(*basecons, minimize=newobj)
+            return cp.Model(*basecons, minimize=newobj)
         else:
-            return Model(*basecons, maximize=newobj)
+            return cp.Model(*basecons, maximize=newobj)
 
 
 def flatten_constraint(expr):
@@ -120,7 +120,6 @@ def flatten_constraint(expr):
         TODO, what built-in python error is best?
         RE TODO: we now have custom NotImpl/NotSupported
     """
-    from ..expressions.globalconstraints import GlobalConstraint  # avoid circular import
 
     newlist = []
     # for backwards compatibility reasons, we now consider it a meta-
@@ -248,7 +247,7 @@ def flatten_constraint(expr):
             newlist.extend(lcons)
             newlist.extend(rcons)
 
-        elif isinstance(expr, GlobalConstraint):
+        elif isinstance(expr, cp.expressions.globalconstraints.GlobalConstraint):
             """
     - Global constraint: global([Var]*)          (CPMpy class 'GlobalConstraint')
             """

--- a/cpmpy/transformations/get_variables.py
+++ b/cpmpy/transformations/get_variables.py
@@ -5,6 +5,7 @@ Variables are ordered by appearance, e.g. first encountered first
 """
 import warnings # for deprecation warning
 import numpy as np
+import cpmpy as cp
 
 from ..expressions.core import Expression
 from ..expressions.variables import _NumVarImpl, NegBoolView, NDVarArray
@@ -81,8 +82,8 @@ def print_variables(expr_or_model):
 
         argument 'expr_or_model' can be an expression or a model
     """
-    from ..model import Model
-    if isinstance(expr_or_model, Model):
+
+    if isinstance(expr_or_model, cp.Model):
         vars_ = get_variables_model(expr_or_model)
     else:
         vars_ = get_variables(expr_or_model)

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -5,6 +5,7 @@
 import copy
 
 import numpy as np
+import cpmpy as cp
 
 from ..expressions.core import BoolVal, Expression, Comparison, Operator
 from ..expressions.utils import eval_comparison, is_false_cst, is_true_cst, is_boolexpr, is_num
@@ -50,7 +51,7 @@ def simplify_boolean(lst_of_expr, num_context=False):
     only resulting boolean constant is literal 'false'
     - list_of_expr: list of CPMpy expressions
     """
-    from .negation import recurse_negation # avoid circular import
+
     newlist = []
     for expr in lst_of_expr:
 
@@ -91,7 +92,7 @@ def simplify_boolean(lst_of_expr, num_context=False):
                 elif is_true_cst(cond):
                     newlist.append(bool_expr)
                 elif is_false_cst(bool_expr):
-                    newlist += simplify_boolean([recurse_negation(cond)])
+                    newlist += simplify_boolean([cp.transformations.negation.recurse_negation(cond)])
                 else:
                     newlist.append(cond.implies(bool_expr))
 
@@ -136,7 +137,7 @@ def simplify_boolean(lst_of_expr, num_context=False):
                     if name == "!=" or name == ">":
                         newlist.append(lhs)
                     if name == "==" or name == "<=":
-                        newlist.append(recurse_negation(lhs))
+                        newlist.append(cp.transformations.negation.recurse_negation(lhs))
                     if name == "<":
                         newlist.append(0 if num_context else BoolVal(False))
                     if name == ">=":
@@ -148,14 +149,14 @@ def simplify_boolean(lst_of_expr, num_context=False):
                     if name == "!=":
                         newlist.append(1 if num_context else BoolVal(True))
                     if name == "<" or name == "<=":
-                        newlist.append(recurse_negation(lhs))
+                        newlist.append(cp.transformations.negation.recurse_negation(lhs))
                     if name == ">" or name == ">=":
                         newlist.append(lhs)
                 elif rhs == 1:
                     if name == "==" or name == ">=":
                         newlist.append(lhs)
                     if name == "!=" or name == "<":
-                        newlist.append(recurse_negation(lhs))
+                        newlist.append(cp.transformations.negation.recurse_negation(lhs))
                     if name == ">":
                         newlist.append(0 if num_context else BoolVal(False))
                     if name == "<=":


### PR DESCRIPTION
one example here: inline Element import in var.getitem() caused 1.5 second delay in #512 

we should go over the entire codebase (including solvers, I think I did it there too) and remove all inline imports...