### PR TITLE
Global function in Z3 objective

### DIFF
--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -36,7 +36,8 @@ from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint
-from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, _IntVarImpl
+from ..expressions.globalfunctions import GlobalFunction
+from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, _IntVarImpl, intvar
 from ..expressions.utils import is_num, is_any_list, is_bool, is_int, is_boolexpr, eval_comparison
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.normalize import toplevel_list
@@ -247,6 +248,12 @@ class CPM_z3(SolverInterface):
         # objective can be a nested expression for z3
         if not isinstance(self.z3_solver, z3.Optimize):
             raise NotSupportedError("Use the z3 optimizer for optimization problems")
+
+        if isinstance(expr, GlobalFunction): # not supported by Z3
+            obj_var = intvar(*expr.get_bounds())
+            self += expr == obj_var
+            expr = obj_var
+
         obj = self._z3_expr(expr)
         if minimize:
             self.z3_solver.minimize(obj)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -479,14 +479,34 @@ class TestSolvers(unittest.TestCase):
             self.assertTrue( cp.Model( iv1**i >= 0 ).solve() )
 
     def test_objective(self):
-        iv = cp.intvar(0,10, shape=2)
-        m = cp.Model(iv >= 1, iv <= 5, maximize=sum(iv))
-        self.assertTrue( m.solve() )
-        self.assertEqual( m.objective_value(), 10 )
 
-        m = cp.Model(iv >= 1, iv <= 5, minimize=sum(iv))
-        self.assertTrue( m.solve() )
-        self.assertEqual( m.objective_value(), 2 )
+        iv = cp.intvar(0, 10, shape=2)
+        m = cp.Model(iv >= 1, iv <= 5)
+        for solver, cls in cp.SolverLookup.base_solvers():
+            print(solver)
+            if cls.supported() is False:
+                continue
+            if solver == "z3": solver += ":opt"
+            if solver == "gcs":
+                continue # optimization is buggy for gcs, see issue #559
+
+            try:
+                m.maximize(sum(iv))
+                self.assertTrue( m.solve(solver=solver))
+                self.assertEqual(m.objective_value(), 10)
+            except NotSupportedError:
+                continue
+
+            # if the above works, so should everything below
+            m.minimize(sum(iv))
+            self.assertTrue( m.solve(solver=solver))
+            self.assertEqual( m.objective_value(), 2 )
+
+            # something slightly more exotic
+            m.maximize(cp.min(iv))
+            self.assertTrue( m.solve(solver=solver))
+            self.assertEqual(m.objective_value(), 5)
+
 
     def test_only_objective(self):
         # from test_sum_unary and #95
@@ -779,6 +799,9 @@ class TestSolvers(unittest.TestCase):
             self.assertFalse(unsat_model.solve(solver=name))
             for v in (x,y,z):
                 self.assertIsNone(v.value())
+
+
+
 
 
 


### PR DESCRIPTION
Posting an objective to Z3 was a little buggy as global functions were not decomposed when unsupported.
This PR fixes that by creating an explicit "objective var" when the objective is a global function.