### PR TITLE
Car sequencing index fix

### DIFF
--- a/examples/car_sequencing.ipynb
+++ b/examples/car_sequencing.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1f59eb5b",
    "metadata": {},
    "outputs": [],
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 14,
    "id": "worldwide-spell",
    "metadata": {},
    "outputs": [],
@@ -71,7 +71,7 @@
     "\n",
     "    # Check that no more than \"at most\" car options are used per \"per_slots\" slots\n",
     "    for o in range(n_options):\n",
-    "        for s in range(n_cars - per_slots[o]):\n",
+    "        for s in range(n_cars - per_slots[o] + 1):\n",
     "            slotrange = range(s, s + per_slots[o])\n",
     "            m += (sum(setup[slotrange, o]) <= at_most[o])\n",
     "\n",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "radical-produce",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 15,
    "id": "broadband-relation",
    "metadata": {},
    "outputs": [
@@ -122,7 +122,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Slots: [3 2 4 3 5 1 5 2 4 0]\n"
+      "Slots: [0 3 4 2 4 3 5 1 2 5]\n"
      ]
     },
     {
@@ -163,11 +163,27 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
+       "      <th>Options 0</th>\n",
+       "      <td>X</td>\n",
+       "      <td></td>\n",
+       "      <td>X</td>\n",
+       "      <td>X</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>Options 3</th>\n",
        "      <td></td>\n",
        "      <td>X</td>\n",
        "      <td></td>\n",
        "      <td>X</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Options 4</th>\n",
+       "      <td>X</td>\n",
+       "      <td></td>\n",
+       "      <td>X</td>\n",
+       "      <td></td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -211,14 +227,6 @@
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>Options 5</th>\n",
-       "      <td>X</td>\n",
-       "      <td>X</td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>Options 2</th>\n",
        "      <td></td>\n",
        "      <td>X</td>\n",
@@ -227,19 +235,11 @@
        "      <td>X</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>Options 4</th>\n",
+       "      <th>Options 5</th>\n",
+       "      <td>X</td>\n",
        "      <td>X</td>\n",
        "      <td></td>\n",
-       "      <td>X</td>\n",
        "      <td></td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Options 0</th>\n",
-       "      <td>X</td>\n",
-       "      <td></td>\n",
-       "      <td>X</td>\n",
-       "      <td>X</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -249,19 +249,19 @@
       "text/plain": [
        "                0  1  2  3  4\n",
        "Config (slots)               \n",
+       "Options 0       X     X  X   \n",
        "Options 3          X     X   \n",
+       "Options 4       X     X      \n",
        "Options 2          X        X\n",
        "Options 4       X     X      \n",
        "Options 3          X     X   \n",
        "Options 5       X  X         \n",
        "Options 1                X   \n",
-       "Options 5       X  X         \n",
        "Options 2          X        X\n",
-       "Options 4       X     X      \n",
-       "Options 0       X     X  X   "
+       "Options 5       X  X         "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -290,7 +290,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "env_choco_windows",
    "language": "python",
    "name": "python3"
   },
@@ -304,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
An anonymous student from the DPSPAI course found a mistake in the indexing for the car sequencing example.

The Minizinc model has the following range: 
```minizinc
s in 1..nSlots - per_slots[o] + 1
```
Which has been incorrectly translated to:
```python
for s in range(n_cars - per_slots[o]):
```
making it completely miss the last car. The range has correctly been shifted as to take the 0-based indexing instead of 1-based indexing into account, but the different behavior with the range upper bound has been forgotten (Python's exclusive vs Minizinc's inclusive)

The correct range:
```python
for s in range(n_cars - per_slots[o] + 1):
```
Some unimportant changes have also been committed, since the notebook output was left uncleared as to make it viewable without having to run the code.