### PR TITLE
Gurobi separate licence check

### DIFF
--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -71,7 +71,7 @@ class CPM_gurobi(SolverInterface):
 
     @staticmethod
     def supported():
-        return CPM_gurobi.installed() & CPM_gurobi.license_ok()
+        return CPM_gurobi.installed() and CPM_gurobi.license_ok()
 
     @staticmethod
     def installed():

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -71,8 +71,19 @@ class CPM_gurobi(SolverInterface):
 
     @staticmethod
     def supported():
-        # try to import the package
-        try:
+        return CPM_gurobi.installed() & CPM_gurobi.license_ok()
+
+    @staticmethod
+    def installed():
+        try: 
+            import gurobipy as gp
+            return True
+        except ImportError:
+            return False
+        
+    @staticmethod
+    def license_ok():
+        try: 
             import gurobipy as gp
             global GRB_ENV
             if GRB_ENV is None:
@@ -81,7 +92,8 @@ class CPM_gurobi(SolverInterface):
                 GRB_ENV.setParam("OutputFlag", 0)
                 GRB_ENV.start()
             return True
-        except:
+        except Exception as e:
+            warnings.warn(f"Problem encountered with Gurobi license: {e}")
             return False
 
     def __init__(self, cpm_model=None, subsolver=None):
@@ -92,9 +104,10 @@ class CPM_gurobi(SolverInterface):
         - cpm_model: a CPMpy Model()
         - subsolver: None, not used
         """
-        if not self.supported():
-            raise Exception(
-                "CPM_gurobi: Install the python package 'gurobipy' and make sure your licence is activated!")
+        if not self.installed():
+            raise Exception("CPM_gurobi: Install the python package 'gurobipy'")
+        elif not self.license_ok():
+            raise Exception("CPM_gurobi: A problem occured during license check. Make sure your license is activated!")
         import gurobipy as gp
 
         # TODO: subsolver could be a GRB_ENV if a user would want to hand one over

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -83,6 +83,9 @@ class CPM_gurobi(SolverInterface):
         
     @staticmethod
     def license_ok():
+        if not CPM_gurobi.installed():
+            warnings.warn(f"License check failed, python package 'gurobipy' is not installed! Please check 'CPM_gurobi.installed()' before attempting to check license.")
+            return False
         try: 
             import gurobipy as gp
             global GRB_ENV


### PR DESCRIPTION
Separate the supported check of gurobipy in two:
1) check that python package is **installed**
2) check that **license** is ok

Previous implementation did both at once. When the licence failed, it was not easily known that this was the cause and not an issue with the installation of gurobi. Also added explicit printing of the licence error that gurobi throws, as to give a hint to the user what the exact issue is. I had issues with `HostID mismatch`, which was not clear before.

