### PR TITLE
Z3 auto subsolver

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -119,6 +119,9 @@ class Model(object):
         self.objective_ = expr
         self.objective_is_min = minimize
 
+    def has_objective(self):
+        return self.objective_ is not None
+
     def minimize(self, expr):
         """
             Minimize the given objective function

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -84,7 +84,10 @@ class CPM_z3(SolverInterface):
         import z3
 
         if subsolver is None:
-            subsolver = "sat"
+            if cpm_model and cpm_model.has_objective():
+                subsolver = "opt"
+            else:
+                subsolver = "sat"
         assert "sat" in subsolver or "opt" in subsolver, "Z3 only has a satisfaction or optimization sub-solver."
 
         # initialise the native solver object

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -485,7 +485,6 @@ class TestSolvers(unittest.TestCase):
         for solver, cls in cp.SolverLookup.base_solvers():
             if cls.supported() is False:
                 continue
-            if solver == "z3": solver += ":opt"
             try:
                 m.maximize(sum(iv))
                 self.assertTrue( m.solve(solver=solver))


### PR DESCRIPTION
A proposal to auto-determine the subsolver type for Z3.

When calling `model.solve(solver='z3')` on a model with an objective function, an exception gets raised since by default the `sat` subsolver gets selected. Instead one has to explicitly write `model.solve(solver='z3:opt')`. For a beginner this is quite confusing, since non of the other solver (as far as I know) require selecting an appropriate subsolver depending on the problem to be solved.

I propose, when no subsolver is provided, to determine the appropriate one depending on the presence of an objective function. This auto-configuration is only possible when going from a model to a CPM_z3 solver object. When directly modeling using CPM_z3, at initialization no objective function will be present to determine subsolver type. So keeping the argument default `"sat"` seems appropriate (instead of `None`).