### PR TITLE
Distribute tests over 4 available CPUs (test suite from `21m30s -> 8m45s`)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest requests pandas
+          pip install flake8 pytest pytest-xdist[psutil] requests pandas
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install python-sat
           pip install z3-solver
@@ -27,5 +27,5 @@ jobs:
           pip install minizinc
       - name: Test with pytest
         run: |
-          python -m pytest tests/
+          python -n auto -m pytest tests/
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,5 +27,5 @@ jobs:
           pip install minizinc
       - name: Test with pytest
         run: |
-          python -n auto -m pytest tests/
+          python -m pytest -n auto tests/
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,5 +27,5 @@ jobs:
           pip install minizinc
       - name: Test with pytest
         run: |
-          python -m pytest -n auto tests/
+          python -m pytest -n 4 tests/
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-xdist[psutil] requests pandas
+          pip install flake8 pytest pytest-xdist requests pandas
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install python-sat
           pip install z3-solver

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -127,7 +127,7 @@ def comp_constraints(solver):
                            Numexpr != Constant             (CPMpy class 'Comparison')
         - Numeric inequality (>=,>,<,<=): Numexpr >=< Var  (CPMpy class 'Comparison')
     """
-    for comp_name in Comparison.allowed:
+    for comp_name in sorted(Comparison.allowed):
 
         for numexpr in numexprs(solver):
             # numeric vs bool/num var/val (incl global func)


### PR DESCRIPTION
Using [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/), we can run the test suite over multiple CPUs (github provides [4](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners)), reducing the CI time by quite a lot. There is one downside (apart from having the extra dependency in itself), which is that tests need to be deterministic (ie all collected tests need to be the same and in the same order, https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html). So for parametrized tests, that means you need to make sure to sort some test generation code.