### PR TITLE
python >= 3.8

### DIFF
--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -10,7 +10,7 @@ Installation is available through the `pip` Python package manager. This will al
 pip install cpmpy
 ```
 
-CPMpy requires python verion  3.7 or higher.
+CPMpy requires python verion  3.8 or higher.
 
 See [installation instructions](./installation_instructions.rst) for more details. 
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -50,5 +49,5 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7'
+    python_requires='>=3.8'
 )


### PR DESCRIPTION
since we require ortools >= 9.9 and ortools 9.9 requires python >= 3.8