### PR TITLE
Check if returned obj is int within tolerance

### DIFF
--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -223,7 +223,7 @@ class CPM_ortools(SolverInterface):
             # translate objective
             if self.has_objective():
                 ort_obj_val = self.ort_solver.ObjectiveValue()
-                if round(ort_obj_val) == ort_obj_val: # it is an integer?
+                if np.isclose(ort_obj_val, round(ort_obj_val)): # it is an integer?
                     self.objective_value_ = int(ort_obj_val)  # ensure it is an integer
                 else: # can happen when using floats as coeff in objective
                     self.objective_value_ = float(ort_obj_val)


### PR DESCRIPTION
A possible fix for #578, where the assert to check whether the returned obj from OR-Tools is an `int` fails due to machine precision?

Could do it manually using something like:
```
TOLERANCE = 0.0000000001 # some tolerance due to machine precision
if abs(ort_obj_val - round(ort_obj_val)) < TOLERANCE: # it is an integer?
    ...
```
Alternatively, `numpy` provides a nice function `np.isclose()` exactly for this purpose which has a better implementation than the above

```
# This is only pseudo code, the exact implementation is much more involved
def isclose(a, b, rtol=1e-05, atol=1e-08):
    absolute(a - b) <= (atol + rtol * absolute(b))
```