### PR TITLE
accept kwargs for solveAll

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -164,7 +164,7 @@ class Model(object):
         self.cpm_status = s.status()
         return ret
 
-    def solveAll(self, solver=None, display=None, time_limit=None, solution_limit=None):
+    def solveAll(self, solver=None, display=None, time_limit=None, solution_limit=None, **kwargs):
         """
             Compute all solutions and optionally display the solutions.
 
@@ -184,7 +184,7 @@ class Model(object):
             s = SolverLookup.get(solver, self)
 
         # call solver
-        ret = s.solveAll(display=display,time_limit=time_limit,solution_limit=solution_limit, call_from_model=True)
+        ret = s.solveAll(display=display,time_limit=time_limit,solution_limit=solution_limit, call_from_model=True, **kwargs)
         # store CPMpy status (s object has no further use)
         self.cpm_status = s.status()
         return ret

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -31,6 +31,8 @@ import copy
 import warnings
 
 import numpy as np
+
+from .exceptions import NotSupportedError
 from .expressions.core import Expression
 from .expressions.variables import NDVarArray
 from .expressions.utils import is_any_list
@@ -152,6 +154,9 @@ class Model(object):
             - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
             - False     if no solution is found
         """
+        if kwargs is not None and solver is None:
+            raise NotSupportedError("Specify the solver when using kwargs, since they are solver-specific!")
+
         if isinstance(solver, SolverInterface):
             # for advanced use, call its constructor with this model
             s = solver(self)
@@ -177,6 +182,9 @@ class Model(object):
 
             Returns: number of solutions found
         """
+        if kwargs is not None and solver is None:
+            raise NotSupportedError("Specify the solver when using kwargs, since they are solver-specific!")
+
         if isinstance(solver, SolverInterface):
             # for advanced use, call its constructor with this model
             s = solver(self)

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -154,7 +154,7 @@ class Model(object):
             - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
             - False     if no solution is found
         """
-        if kwargs is not None and solver is None:
+        if kwargs and solver is None:
             raise NotSupportedError("Specify the solver when using kwargs, since they are solver-specific!")
 
         if isinstance(solver, SolverInterface):
@@ -182,7 +182,7 @@ class Model(object):
 
             Returns: number of solutions found
         """
-        if kwargs is not None and solver is None:
+        if kwargs and solver is None:
             raise NotSupportedError("Specify the solver when using kwargs, since they are solver-specific!")
 
         if isinstance(solver, SolverInterface):

--- a/tests/test_solveAll.py
+++ b/tests/test_solveAll.py
@@ -49,3 +49,9 @@ class TestSolveAll(unittest.TestCase):
 
             except NotSupportedError as e:
                 pass # solver does not support finding all optimal solutions
+
+    def test_solveAll_keywords(self):
+        a, b = cp.boolvar(shape=2)
+        m = cp.Model(a | b)
+
+        self.assertEqual(3, m.solveAll('ortools', log_search_progress=True))


### PR DESCRIPTION
We didn't accept kwargs for solveAll in our model object, which doesn't make sense since our solverinterface does accept kwargs.

Not sure if I should add a test since any keyword will be solver specific