### PR TITLE
Improve DIMACS reading and testing

### DIFF
--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -71,7 +71,8 @@ def write_dimacs(model, fname=None):
 
 def read_dimacs(fname):
     """
-        Read a CPMpy model from a DIMACS formatted file
+        Read a CPMpy model from a DIMACS formatted file striclty following the specification: https://web.archive.org/web/20190325181937/https://www.satcompetition.org/2009/format-benchmarks2009.html
+        Note: the p-line has to denote the correct number of variables and clauses
         :param: fname: the name of the DIMACS file
         :param: sep: optional, separator used in the DIMACS file, will try to infer if None
     """

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -72,7 +72,6 @@ def write_dimacs(model, fname=None):
 def read_dimacs(fname):
     """
         Read a CPMpy model from a DIMACS formatted file
-        If the number of variables and constraints is not present in the header, they are inferred.
         :param: fname: the name of the DIMACS file
         :param: sep: optional, separator used in the DIMACS file, will try to infer if None
     """
@@ -80,33 +79,36 @@ def read_dimacs(fname):
     m = cp.Model()
 
     with open(fname, "r") as f:
-
-        lines = f.readlines()
-        for i, line in enumerate(lines): # DIMACS allows for comments, skip comment lines
-            if line.startswith("p cnf"):
-                break
+        typ = None  # CNF/WCNF
+        # TODO infer p-header values (although generally not a good idea)
+        nr_cls = None
+        bvs = None
+        clause = []
+        for line in f.readlines():
+            if line.startswith("p"):
+                try:
+                    typ,typ,nr_vars,nr_cls = line.strip().split(" ")
+                    if typ != "cnf":
+                        raise cp.exceptions.NotSupportedError("WDIMACS (WCNF) files are not supported.")
+                    nr_vars = int(nr_vars)
+                    if nr_vars>0:
+                        bvs = cp.boolvar(shape=nr_vars)
+                    nr_cls = int(nr_cls)
+                except ValueError:
+                    raise cp.exceptions.CPMpyException(f"Invalid DIMACS file p-header: {line}")
+            elif line.startswith("c"):
+                continue
             else:
-                assert line.startswith("c"), f"Expected comment on line {i}, but got {line}"
+                for token in line.strip().split():
+                    if token == "0":
+                        m+=cp.any(clause)
+                        clause = []
+                    else:
+                        i = int(token.strip())
+                        bv = bvs[abs(i)-1]
+                        clause.append(bv if i > 0 else ~bv)
 
-        cnf = "\n".join(lines[i+1:]) # part of file containing clauses
-
-        bvs = []
-        txt_clauses = re.split(r"\n* \n*0", cnf) # clauses end with ` 0` but can have arbitrary newlines
-
-        for txt_ints in txt_clauses:
-            if txt_ints is None or len(txt_ints.strip()) == 0:
-                continue # empty clause or weird format
-
-            clause = []
-            ints = [int(idx.strip()) for idx in txt_ints.split(" ") if len(idx.strip())]
-
-            for i in ints:
-                if abs(i) >= len(bvs):  # var does not exist yet, create
-                    bvs += [cp.boolvar() for _ in range(abs(i) - len(bvs))]
-                bv = bvs[abs(i) - 1]
-                clause.append(bv if i > 0 else ~bv)
-
-            m += cp.any(clause)
+        assert(len(m.constraints) == nr_cls, f"Number of clauses was declared in p-line as {nr_cls}, but was {len(m.constraints)}")
 
     return m
 

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -112,8 +112,8 @@ def read_dimacs(fname):
 
                         clause.append(bv if i > 0 else ~bv)
 
+        assert not clause, f"Expected last clause to be terminated by 0, but it was not"
         assert len(m.constraints) == nr_cls, f"Number of clauses was declared in p-line as {nr_cls}, but was {len(m.constraints)}"
-        assert not clause, f"Expected last clause to be terminated by 0, but was not {clause}"
 
     return m
 

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -100,11 +100,11 @@ def read_dimacs(fname):
             else:
                 assert had_p_line, "Expected p-line before clauses"
                 for token in line.strip().split():
-                    if token == "0":
+                    i = int(token.strip())
+                    if i == 0:
                         m+=cp.any(clause)
                         clause = []
                     else:
-                        i = int(token.strip())
                         try:
                             bv = bvs[abs(i)-1]
                         except IndexError:

--- a/tests/test_tool_dimacs.py
+++ b/tests/test_tool_dimacs.py
@@ -7,8 +7,6 @@ from cpmpy.tools.dimacs import read_dimacs, write_dimacs
 from cpmpy.transformations.get_variables import get_variables_model
 from cpmpy.solvers.solver_interface import ExitStatus
 
-import io
-
 class CNFTool(unittest.TestCase):
 
     def setUp(self) -> None:

--- a/tests/test_tool_dimacs.py
+++ b/tests/test_tool_dimacs.py
@@ -82,6 +82,10 @@ class CNFTool(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.dimacs_to_model("p cnf 2 1\n1 2 3 0")
 
+    def test_non_int_literal(self):
+        with self.assertRaises(ValueError):
+            self.dimacs_to_model("p cnf 2 1\n1 b 3 0")
+
     @pytest.mark.skip(reason="We allow fewer variables, because this is technically correct DIMACS")
     def test_too_few_variables(self):
         with self.assertRaises(AssertionError):

--- a/tests/test_tool_dimacs.py
+++ b/tests/test_tool_dimacs.py
@@ -84,7 +84,12 @@ class CNFTool(unittest.TestCase):
 
     def test_non_int_literal(self):
         with self.assertRaises(ValueError):
-            self.dimacs_to_model("p cnf 2 1\n1 b 3 0")
+            self.dimacs_to_model("p cnf 2 1\n1 b 2 0")
+
+    def test_non_terminated_final_clause(self):
+        with self.assertRaises(AssertionError):
+            self.dimacs_to_model("p cnf 2 2\n1 2 0\n-1 -2 0\n2")
+
 
     @pytest.mark.skip(reason="We allow fewer variables, because this is technically correct DIMACS")
     def test_too_few_variables(self):


### PR DESCRIPTION
This improves the DIMACS reading by:

- Making a certain test which was sometimes failing on my machine more deterministic, and just checking the read models directly rather than relying on solve
- Assuming the DIMACS input is well-formed. While inferring the p-line is possible, this is usually more trouble than it's worth, and bad for performance/debug. The current implementation would make 300 BoolVar's if we encountered an out of order literal (e.g. the DIMACS `1 0 300 0` is supposed to be `[bv1, bv300]`, but makes 300 literals).

