### PR TITLE
Add optional dependencies to `setup.py`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,8 @@ CPMpy is a Constraint Programming and Modeling library in Python, based on numpy
 
    modeling
 
+.. _supported-solvers:
+
 Supported solvers
 -----------------
 
@@ -107,7 +109,6 @@ We hope to upgrade many of these solvers to higher tiers, as well as adding new 
    :caption: Advanced guides:
 
    how_to_debug
-   direct_solver_access
    multiple_solutions
    unsat_core_extraction
    developers

--- a/docs/installation_instructions.rst
+++ b/docs/installation_instructions.rst
@@ -1,7 +1,7 @@
 Installation instructions
 =========================
 
-CPMpy requires Python ``3.6`` or newer. The package is available on `PyPI <https://pypi.org/>`_.
+CPMpy requires Python ``3.8`` or newer. The package is available on `PyPI <https://pypi.org/>`_.
 
 The easiest way is to install using the 'pip' command line package manager. In a terminal, run:
 
@@ -22,6 +22,16 @@ CPMpy has regular small releases with updates and improvements, so it is a good 
 .. code-block:: bash
 
     $ pip install -U cpmpy
+
+
+CPMpy supports a multitude of solvers of different technologies to be used as backend. Easy installation is provided through optional dependencies:
+
+.. code-block:: bash
+
+    # Choose any subset of solvers to install
+    $ pip install cpmpy[choco, cpo, exact, gcs, gurobi, minizinc, pysat, pysdd, z3] 
+
+Some solver require additional steps (like acquiring a (aca.) license). Have a look at :ref:`this <supported-solvers>` overview.
 
 
 Installing from a git repository

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -4,13 +4,21 @@ This page explains and demonstrates how to use CPMpy to model and solve combinat
 
 ## Installation
 
-Installation is available through the `pip` Python package manager. This will also install and use `ortools` as default solver (see how to use alternative solvers [here](#selecting-a-solver)):
+Installation is available through the `pip` Python package manager. This will also install and use `ortools` as default solver:
 
 ```commandline
 pip install cpmpy
 ```
 
-CPMpy requires python verion  3.8 or higher.
+Additional solvers can be downloaded as optional dependencies (see how to use alternative solvers [here](#selecting-a-solver)):
+
+```commandline
+pip install cpmpy[gurobi, choco, exact] # installs 3 additional solving backends
+```
+
+An overview of the available backends can be found [here](index.rst#supported-solvers).
+
+CPMpy requires python version  3.8 or higher.
 
 See [installation instructions](./installation_instructions.rst) for more details. 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "gcs": ["gcspy"],
         "cpo": ["docplex"],
         # Tools
-        "xcsp3": ["pycsp3"],
+        # "xcsp3": ["pycsp3"], <- for when xcsp3 is merged
         # Other
         "test": ["pytest"],
     },

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     #extra dependency, only needed if minizinc is to be used.
     extras_require={
         "FULL":  ["minizinc"],
-        "test": ["pytest"],
+        # Solvers
         "ortools": ["ortools"],
         "z3": ["z3-solver"],
         "choco": ["pychoco>=0.2.1"],
@@ -47,7 +47,12 @@ setup(
         "pysat": ["python-sat"],
         "gurobi": ["gurobipy"],
         "pysdd": ["pysdd"],
-        "xcsp3": ["pycsp3"]
+        "gcs": ["gcspy"],
+        "cpo": ["docplex"],
+        # Tools
+        "xcsp3": ["pycsp3"],
+        # Other
+        "test": ["pytest"],
     },
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,16 @@ setup(
     #extra dependency, only needed if minizinc is to be used.
     extras_require={
         "FULL":  ["minizinc"],
+        "test": ["pytest"],
+        "ortools": ["ortools"],
+        "z3": ["z3-solver"],
+        "choco": ["pychoco>=0.2.1"],
+        "exact": ["exact>=2.1.0"],
+        "minizinc": ["minizinc"],
+        "pysat": ["python-sat"],
+        "gurobi": ["gurobipy"],
+        "pysdd": ["pysdd"],
+        "xcsp3": ["pycsp3"]
     },
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         # "xcsp3": ["pycsp3"], <- for when xcsp3 is merged
         # Other
         "test": ["pytest"],
+        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2"],
     },
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
Add optional dependencies to the `setup.py`'s `extras_require`.
Allows easy-install of solvers through `pip install cpmpy[choco, z3, pysat, ...]`. (with cpmpy-native solver names)
Also useful for bundling optional dependencies, e.g. those required by one of the tools: `pip install cpmpy[xcsp3]`.