### PR TITLE
Docs improvement format-only

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -52,8 +52,8 @@
     `x ^ y`              `Xor([x, y])`                                         
     ===================  =======================================================
 
-    Python has no built-in operator for __implication__ that can be overloaded.
-    CPMpy hence has a function 'implies()' that can be called:
+    Python has no built-in operator for `implication` that can be overloaded.
+    CPMpy hence has a function :func:`~cpmpy.expressions.core.Expression.implies` that can be called:
 
     ===================  ======================
     Python Operator      CPMpy Object          

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -11,39 +11,55 @@
 
     Here is a list of standard python operators and what object (with what expr.name) it creates:
 
-    **Comparisons**:
+    Comparisons
+    -----------
+    ===================  ==========================
+    Python Operator      CPMpy Object                     
+    ===================  ==========================
+    `x == y`             `Comparison("==", x, y)`         
+    `x != y`             `Comparison("!=", x, y)`         
+    `x < y`              `Comparison("<", x, y)`          
+    `x <= y`             `Comparison("<=", x, y)`         
+    `x > y`              `Comparison(">", x, y)`          
+    `x >= y`             `Comparison(">=", x, y)`         
+    ===================  ==========================
 
-    - x == y        Comparison("==", x, y)
-    - x != y        Comparison("!=", x, y)
-    - x < y         Comparison("<", x, y)
-    - x <= y        Comparison("<=", x, y)
-    - x > y         Comparison(">", x, y)
-    - x >= y        Comparison(">=", x, y)
+    Mathematical Operators
+    ----------------------
+    ===========================  ===============================================
+    Python Operator              CPMpy Object                                  
+    ===========================  ===============================================
+    `-x`                         `Operator("-", [x])`                          
+    `x + y`                      `Operator("sum", [x, y])`                     
+    `sum([x,y,z])`               `Operator("sum", [x, y, z])`                  
+    `sum([c0*x, c1*y, c2*z])`    `Operator("wsum", [[c0, c1, c2], [x, y, z]])` 
+    `x - y`                      `Operator("sum", [x, -y])`                    
+    `x * y`                      `Operator("mul", [x, y])`                     
+    `x / y`                      `Operator("div", [x, y])`                     
+    `x % y`                      `Operator("mod", [x, y])`                     
+    `x ** y`                     `Operator("pow", [x, y])`  
+    ===========================  ===============================================                   
 
-    **Mathematical operators**:
-
-    - −x            Operator("-", [x])
-    - x + y         Operator("sum", [x,y])
-    - sum([x,y,z])  Operator("sum", [x,y,z])
-    - sum([c0*x, c1*y, c2*z])  Operator("wsum", [[c0,c1,c2],[x,y,z]])
-    - x - y         Operator("sum", [x,-y])
-    - x * y         Operator("mul", [x,y])
-    - x / y         Operator("div", [x,y])
-    - x % y         Operator("mod", [x,y])
-    - x ** y        Operator("pow", [x,y])
-
-    **Logical operators**:
-
-    - x & y         Operator("and", [x,y])
-    - x | y         Operator("or", [x,y])
-    - ~x            Operator("not", [x])
-                    or NegBoolView(x) in case x is a Boolean variable
-    - x ^ y         Xor([x,y])  # a global constraint
+    
+    Logical Operators
+    -----------------
+    ===================  =======================================================
+    Python Operator      CPMpy Object  
+    ===================  =======================================================                                        
+    `x & y`              `Operator("and", [x, y])`                             
+    `x | y`              `Operator("or", [x, y])`                              
+    `~x`                 `Operator("not", [x])` or `NegBoolView(x)` if Boolean 
+    `x ^ y`              `Xor([x, y])`                                         
+    ===================  =======================================================
 
     Python has no built-in operator for __implication__ that can be overloaded.
     CPMpy hence has a function 'implies()' that can be called:
 
-    - x.implies(y)  Operator("->", [x,y])
+    ===================  ======================
+    Python Operator      CPMpy Object          
+    ===================  ======================
+    `x.implies(y)`       Operator("->", [x,y]) 
+    ===================  ======================
 
     Apart from operator overloading, expressions implement two important functions:
 

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -80,7 +80,7 @@ from ..exceptions import IncompleteFunctionError, TypeError
 
 class Expression(object):
     """
-    An Expression represents a symbolic function with a self.name and self.args (arguments)
+    An Expression represents a symbolic function with a `self.name` and `self.args` (arguments)
 
     Each Expression is considered to be a function whose value can be used
       in other expressions

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -4,7 +4,7 @@
 ## expressions.py
 ##
 """
-    The `Expression` superclass and common subclasses `Expression` and `Operator`.
+    The :class:`~cpmpy.expressions.core.Expression` superclass and common subclasses :class:`~cpmpy.expressions.core.Comparison` and :class:`~cpmpy.expressions.core.Operator`.
     
     None of these objects should be directly created, they are automatically created through operator
     overloading on variables and expressions.
@@ -47,12 +47,12 @@
 
     Apart from operator overloading, expressions implement two important functions:
 
-    - `is_bool()`   
+    - :func:`~cpmpy.expressions.core.Expression.is_bool`   
         which returns whether the return type of the expression is Boolean.
         If it does, the expression can be used as top-level constraint
         or in logical operators.
 
-    - `value()`     
+    - :func:`~cpmpy.expressions.core.Expression.value`    
         computes the value of this expression, by calling .value() on its
         subexpressions and doing the appropriate computation
         this is used to conveniently print variable values, objective values
@@ -86,11 +86,12 @@ class Expression(object):
       in other expressions
 
     Expressions may implement:
-    - is_bool():    whether its return type is Boolean
-    - value():      the value of the expression, default None
-    - implies(x):   logical implication of this expression towards x
-    - __repr__():   for pretty printing the expression
-    - any __op__ python operator overloading
+
+    - :func:`~cpmpy.expressions.core.Expression.is_bool`:               whether its return type is Boolean
+    - :func:`~cpmpy.expressions.core.Expression.value`:                 the value of the expression, default None
+    - :func:`implies(x) <cpmpy.expressions.core.Expression.implies>`:   logical implication of this expression towards `x`
+    - :func:`~cpmpy.expressions.core.Expression.__repr__`:              for pretty printing the expression
+    - any ``__op__`` python operator overloading
     """
 
     def __init__(self, name, arg_list):
@@ -156,7 +157,7 @@ class Expression(object):
         return hash(self.__repr__())
 
     def has_subexpr(self):
-        """ Does it contains nested Expressions (anything other than a _NumVarImpl or a constant)?
+        """ Does it contains nested :class:`Expressions <cpmpy.expressions.core.Expression>` (anything other than a :class:`~cpmpy.expressions.variables._NumVarImpl` or a constant)?
             Is of importance when deciding whether certain transformations are needed
             along particular paths of the expression tree.
             Results are cached for future calls and reset when the expression changes

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -58,7 +58,7 @@
     ===================  ======================
     Python Operator      CPMpy Object          
     ===================  ======================
-    `x.implies(y)`       Operator("->", [x,y]) 
+    `x.implies(y)`       `Operator("->", [x,y])` 
     ===================  ======================
 
     Apart from operator overloading, expressions implement two important functions:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -291,9 +291,10 @@ class Circuit(GlobalConstraint):
         """
             Decomposition for Circuit
 
-            Not sure where we got it from,
-            MiniZinc has slightly different one:
-            https://github.com/MiniZinc/libminizinc/blob/master/share/minizinc/std/fzn_circuit.mzn
+            ..
+                Not sure where we got it from,
+                MiniZinc has slightly different one:
+                https://github.com/MiniZinc/libminizinc/blob/master/share/minizinc/std/fzn_circuit.mzn
         """
         succ = cpm_array(self.args)
         n = len(succ)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -9,12 +9,12 @@
     Using global constraints
     ------------------------
 
-    Solvers can have specialised implementations for global constraints. CPMpy has GlobalConstraint
+    Solvers can have specialised implementations for global constraints. CPMpy has :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`
     expressions so that they can be passed to the solver as is when supported.
 
-    If a solver does not support a global constraint (see solvers/) then it will be automatically
-    decomposed by calling its `.decompose()` function.
-    The `.decompose()` function returns two arguments:
+    If a solver does not support a global constraint (see :ref:`Solver Interfaces <solver-interfaces>`) then it will be automatically
+    decomposed by calling its :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose()` function.
+    The :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose()` function returns two arguments:
         - a list of simpler constraints replacing the global constraint
         - if the decomposition introduces *new variables*, then the second argument has to be a list
             of constraints that (totally) define those new variables
@@ -34,7 +34,7 @@
     Numeric global constraints
     --------------------------
 
-    CPMpy also implements __Numeric Global Constraints__. For these, the CPMpy GlobalConstraint does not
+    CPMpy also implements `Numeric Global Constraints`. For these, the CPMpy :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` does not
     exactly match what is implemented in the solver, but for good reason!!
 
     For example solvers may implement the global constraint `Minimum(iv1, iv2, iv3) == iv4` through an API
@@ -53,7 +53,7 @@
     Subclassing GlobalConstraint
     ----------------------------
     
-    If you do wish to add a GlobalConstraint, because it is supported by solvers or because you will do
+    If you do wish to add a :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, because it is supported by solvers or because you will do
     advanced analysis and rewriting on it, then preferably define it with a standard decomposition, e.g.:
 
     .. code-block:: python
@@ -65,15 +65,16 @@
             def decompose(self):
                 return [self.args[0] != self.args[1]] # your decomposition
 
-    If it is a __numeric global constraint__ meaning that its return type is numeric (see `Minimum` and `Element`)
-    then set `is_bool=False` in the super() constructor and preferably implement `.value()` accordingly.
+    ..
+        If it is a :class:`~cpmpy.expressions.globalfunctions.GlobalFunction` meaning that its return type is numeric (see :class:`~cpmpy.expressions.globalfunctions.Minimum` and :class:`~cpmpy.expressions.globalfunctions.Element`)
+        then set `is_bool=False` in the super() constructor and preferably implement `.value()` accordingly.
 
 
     Alternative decompositions
     --------------------------
     
     For advanced use cases where you want to use another decomposition than the standard decomposition
-    of a GlobalConstraint expression, you can overwrite the 'decompose' function of the class, e.g.:
+    of a :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` expression, you can overwrite the :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose` function of the class, e.g.:
 
     .. code-block:: python
 
@@ -87,7 +88,7 @@
         Model(constr).solve()
 
     The above will use 'my_circuit_decomp', if the solver does not
-    natively support 'circuit'.
+    natively support :class:`~cpmpy.expressions.globalconstraints.Circuit`.
 
     ===============
     List of classes
@@ -522,7 +523,7 @@ class InDomain(GlobalConstraint):
 
 class Xor(GlobalConstraint):
     """
-        The 'xor' exclusive-or constraint
+        The :class:`Xor` exclusive-or constraint
     """
 
     def __init__(self, arg_list):
@@ -556,7 +557,7 @@ class Cumulative(GlobalConstraint):
     """
         Global cumulative constraint. Used for resource aware scheduling.
         Ensures that the capacity of the resource is never exceeded
-        Equivalent to noOverlap when demand and capacity are equal to 1
+        Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlap` when demand and capacity are equal to 1.
         Supports both varying demand across tasks or equal demand for all jobs
     """
     def __init__(self, start, duration, end, demand, capacity):
@@ -909,7 +910,7 @@ class LexLessEq(GlobalConstraint):
 
 
 class LexChainLess(GlobalConstraint):
-    """ Given a matrix X, LexChainLess enforces that all rows are lexicographically ordered.
+    """ Given a matrix X, :class:`LexChainLess` enforces that all rows are lexicographically ordered.
     """
     def __init__(self, X):
         # Ensure the numpy array is 2D
@@ -959,7 +960,7 @@ class DirectConstraint(Expression):
         See the documentation of the solver (constructor) for details on how that solver handles them.
 
         If you want/need to use what the solver returns (e.g. an identifier for use in other constraints),
-        then use `directvar()` instead, or access the solver object from the solver interface directly.
+        then use :func:`~cpmpy.expressions.variables.directvar` instead, or access the solver object from the solver interface directly.
     """
     def __init__(self, name, arguments, novar=None):
         """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -557,9 +557,9 @@ class Xor(GlobalConstraint):
 class Cumulative(GlobalConstraint):
     """
         Global cumulative constraint. Used for resource aware scheduling.
-        Ensures that the capacity of the resource is never exceeded
+        Ensures that the capacity of the resource is never exceeded.
         Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlap` when demand and capacity are equal to 1.
-        Supports both varying demand across tasks or equal demand for all jobs
+        Supports both varying demand across tasks or equal demand for all jobs.
     """
     def __init__(self, start, duration, end, demand, capacity):
         assert is_any_list(start), "start should be a list"

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -167,6 +167,10 @@ class GlobalConstraint(Expression):
 
 # Global Constraints (with Boolean return type)
 def alldifferent(args):
+    """
+    .. deprecated:: 0.9.0
+          Please use :class:`AllDifferent` instead.
+    """
     warnings.warn("Deprecated, use AllDifferent(v1,v2,...,vn) instead, will be removed in "
                   "stable version", DeprecationWarning)
     return AllDifferent(*args) # unfold list as individual arguments
@@ -215,6 +219,10 @@ class AllDifferentExcept0(AllDifferentExceptN):
 
 
 def allequal(args):
+    """
+    .. deprecated:: 0.9.0
+          Please use :class:`AllEqual` instead.
+    """
     warnings.warn("Deprecated, use AllEqual(v1,v2,...,vn) instead, will be removed in stable version",
                   DeprecationWarning)
     return AllEqual(*args) # unfold list as individual arguments
@@ -257,6 +265,10 @@ class AllEqualExceptN(GlobalConstraint):
 
 
 def circuit(args):
+    """
+    .. deprecated:: 0.9.0
+          Please use :class:`Circuit` instead.
+    """
     warnings.warn("Deprecated, use Circuit(v1,v2,...,vn) instead, will be removed in stable version",
                   DeprecationWarning)
     return Circuit(*args) # unfold list as individual arguments

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -37,16 +37,16 @@
     CPMpy also implements `Numeric Global Constraints`. For these, the CPMpy :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` does not
     exactly match what is implemented in the solver, but for good reason!!
 
-    For example solvers may implement the global constraint `Minimum(iv1, iv2, iv3) == iv4` through an API
-    call `addMinimumEquals([iv1,iv2,iv3], iv4)`.
+    For example solvers may implement the global constraint ``Minimum(iv1, iv2, iv3) == iv4`` through an API
+    call ``addMinimumEquals([iv1,iv2,iv3], iv4)``.
 
-    However, CPMpy also wishes to support the expressions `Minimum(iv1, iv2, iv3) > iv4` as well as
-    `iv4 + Minimum(iv1, iv2, iv3)`. 
+    However, CPMpy also wishes to support the expressions ``Minimum(iv1, iv2, iv3) > iv4`` as well as
+    ``iv4 + Minimum(iv1, iv2, iv3)``. 
 
-    Hence, the CPMpy global constraint only captures the `Minimum(iv1, iv2, iv3)` part, whose return type
+    Hence, the CPMpy global constraint only captures the ``Minimum(iv1, iv2, iv3)`` part, whose return type
     is numeric and can be used in any other CPMpy expression. Only at the time of transforming the CPMpy
     model to the solver API, will the expressions be decomposed and auxiliary variables introduced as needed
-    such that the solver only receives `Minimum(iv1, iv2, iv3) == ivX` expressions.
+    such that the solver only receives ``Minimum(iv1, iv2, iv3) == ivX`` expressions.
     This is the burden of the CPMpy framework, not of the user who wants to express a problem formulation.
 
 
@@ -80,6 +80,7 @@
 
         def my_circuit_decomp(self):
             return [self.args[0] == 1], [] # does not actually enforce circuit
+
         circuit.decompose = my_circuit_decomp # attach it, no brackets!
 
         vars = intvar(1,9, shape=10)
@@ -87,7 +88,7 @@
 
         Model(constr).solve()
 
-    The above will use 'my_circuit_decomp', if the solver does not
+    The above will use ``my_circuit_decomp``, if the solver does not
     natively support :class:`~cpmpy.expressions.globalconstraints.Circuit`.
 
     ===============
@@ -135,8 +136,8 @@ class GlobalConstraint(Expression):
     """
         Abstract superclass of GlobalConstraints
 
-        Like all expressions it has a `.name` and `.args` property.
-        Overwrites the `.is_bool()` method.
+        Like all expressions it has a ``.name`` and ``.args`` property.
+        Overwrites the ``.is_bool()`` method.
     """
 
     def is_bool(self):
@@ -404,7 +405,7 @@ class Table(GlobalConstraint):
 class ShortTable(GlobalConstraint):
     """
         Extension of the `Table` constraint where the `table` matrix may contain wildcards (STAR), meaning there are
-         no restrictions for the corresponding variable in that tuple.
+        no restrictions for the corresponding variable in that tuple.
     """
     def __init__(self, array, table):
         array = flatlist(array)
@@ -710,8 +711,8 @@ class NoOverlap(GlobalConstraint):
 
 class GlobalCardinalityCount(GlobalConstraint):
     """
-    GlobalCardinalityCount(vars,vals,occ): The number of occurrences of each value vals[i] in the list of variables vars
-    must be equal to occ[i].
+    The number of occurrences of each value `vals[i]` in the list of variables `vars`
+    must be equal to `occ[i]`.
     """
 
     def __init__(self, vars, vals, occ, closed=False):
@@ -951,7 +952,7 @@ class LexChainLessEq(GlobalConstraint):
 
 class DirectConstraint(Expression):
     """
-        A DirectConstraint will directly call a function of the underlying solver when added to a CPMpy solver
+        A ``DirectConstraint`` will directly call a function of the underlying solver when added to a CPMpy solver
 
         It can not be reified, it is not flattened, it can not contain other CPMpy expressions than variables.
         When added to a CPMpy solver, it will literally just directly call a function on the underlying solver,
@@ -981,7 +982,7 @@ class DirectConstraint(Expression):
 
     def callSolver(self, CPMpy_solver, Native_solver):
         """
-            Call the `directname`() function of the native solver,
+            Call the `directname()` function of the native solver,
             with stored arguments replacing CPMpy variables with solver variables as needed.
 
             SolverInterfaces will call this function when this constraint is added.

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -128,10 +128,12 @@ class Minimum(GlobalFunction):
     def decompose_comparison(self, cpm_op, cpm_rhs):
         """
         Decomposition if it's part of a comparison
+
         Returns two lists of constraints:
-            1) constraints representing the comparison
-            2) constraints that (totally) define new auxiliary variables needed in the decomposition,
-               they should be enforced toplevel.
+
+        1) constraints representing the comparison
+        2) constraints that (totally) define new auxiliary variables needed in the decomposition,
+           they should be enforced toplevel.
         """
         lb, ub = self.get_bounds()
         _min = intvar(lb, ub)
@@ -164,10 +166,12 @@ class Maximum(GlobalFunction):
     def decompose_comparison(self, cpm_op, cpm_rhs):
         """
         Decomposition if it's part of a comparison
+
         Returns two lists of constraints:
-            1) constraints representing the comparison
-            2) constraints that (totally) define new auxiliary variables needed in the decomposition,
-               they should be enforced toplevel.
+
+        1) constraints representing the comparison
+        2) constraints that (totally) define new auxiliary variables needed in the decomposition,
+           they should be enforced toplevel.
         """
         lb, ub = self.get_bounds()
         _max = intvar(lb, ub)
@@ -195,10 +199,12 @@ class Abs(GlobalFunction):
     def decompose_comparison(self, cpm_op, cpm_rhs):
         """
         Decomposition if it's part of a comparison
+
         Returns two lists of constraints:
-            1) constraints representing the comparison
-            2) constraints that (totally) define new auxiliary variables needed in the decomposition,
-               they should be enforced toplevel.
+
+        1) constraints representing the comparison
+        2) constraints that (totally) define new auxiliary variables needed in the decomposition,
+           they should be enforced toplevel.
         """
         arg = self.args[0]
         lb, ub = get_bounds(arg)
@@ -270,10 +276,12 @@ class Element(GlobalFunction):
             `Element(arr,ix)` represents the array lookup itself (a numeric variable)
             When used in a comparison relation: Element(arr,idx) <CMP_OP> CMP_RHS
             it is a constraint, and that one can be decomposed.
+
             Returns two lists of constraints:
-                1) constraints representing the comparison
-                2) constraints that (totally) define new auxiliary variables needed in the decomposition,
-                   they should be enforced toplevel.
+
+            1) constraints representing the comparison
+            2) constraints that (totally) define new auxiliary variables needed in the decomposition,
+               they should be enforced toplevel.
 
         """
         arr, idx = self.args
@@ -366,6 +374,7 @@ class NValue(GlobalFunction):
         NValue(arr) can only be decomposed if it's part of a comparison
 
         Based on "simple decomposition" from:
+        
             Bessiere, Christian, et al. "Decomposition of the NValue constraint."
             International Conference on Principles and Practice of Constraint Programming.
             Berlin, Heidelberg: Springer Berlin Heidelberg, 2010.
@@ -415,6 +424,7 @@ class NValueExcept(GlobalFunction):
         NValue(arr) can only be decomposed if it's part of a comparison
 
         Based on "simple decomposition" from:
+
             Bessiere, Christian, et al. "Decomposition of the NValue constraint."
             International Conference on Principles and Practice of Constraint Programming.
             Berlin, Heidelberg: Springer Berlin Heidelberg, 2010.

--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -84,7 +84,7 @@ def max(*iterable, **kwargs):
 
         if iterable does not contain CPMpy expressions, the built-in is called
         else a Maximum functional global constraint is constructed; no keyword
-          arguments are supported in that case
+        arguments are supported in that case
     """
     if len(iterable) == 1:
         iterable = tuple(iterable[0])
@@ -101,7 +101,7 @@ def min(*iterable, **kwargs):
 
         if iterable does not contain CPMpy expressions, the built-in is called
         else a Minimum functional global constraint is constructed; no keyword
-          arguments are supported in that case
+        arguments are supported in that case
     """
     if len(iterable) == 1:
         iterable = tuple(iterable[0])

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -29,7 +29,7 @@
     In CPMpy all variables are considered an array with a given shape. For 'single' variables the shape 
     is '1'. For an array of length `n` the shape is 'n'. An `n*m` matrix has shape (n,m), and tensors 
     with more than 2 dimensions are all supported too. For the implementation of this, 
-    CPMpy builts on numpy's n-dimensional ndarray and inherits many of its benefits 
+    CPMpy builts on numpy's n-dimensional `ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_ 
     (vectorized operators and advanced indexing).
 
     This module contains the cornerstone ``boolvar()`` and ``intvar()`` functions, which create (numpy arrays of) 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -76,14 +76,14 @@ def boolvar(shape=1, name=None):
     Boolean decision variables will take either the value `True` or `False`.
     
     Arguments:
-    shape -- the shape of the n-dimensional array of variables (int or tuple of ints, default: 1)
-    name -- name to give to the variables (string or list/tuple/array of string, default: None)
+        shape (int or tuple of int, optional) : The shape of the n-dimensional array of variables. Default is 1.
+    
+        name (str, list of str, tuple of str, or None, optional) : 
+            Name(s) to assign to the variables. Default is None.
 
-    If name is None then a name 'BV<unique number>' will be assigned to it.
-    If name is a string, then assign it as the suffix of variable names.
-    If name is a list/tuple/array of string, then assign them as the variable names accordingly.
-
-    If shape is different from 1, then each element of the array will have the location
+            - If `name` is None, a name of the form ``BV<unique number>`` will be assigned to the variables.
+            - If `name` is a string, it will be used as the suffix of the variable names.
+            - If `name` is a list/tuple/array of strings, they will be assigned to the variable names accordingly.
     of this specific variable in the array append to its name.
 
     For example,
@@ -151,18 +151,18 @@ def intvar(lb, ub, shape=1, name=None):
     the decision variable can take, as well as the highest value (ub).
 
     Arguments:
-    lb -- lower bound on the values the variable can take (int)
-    ub -- upper bound on the values the variable can take (int)
-    shape -- the shape of the n-dimensional array of variables (int or tuple of ints, default: 1)
-    name -- name to give to the variables (string or list/tuple/array of string, default: None)
+        lb (int) : Lower bound on the values the variable can take.
+        ub (int) : Upper bound on the values the variable can take.
+        shape (int or tuple of int, optional) :
+            The shape of the n-dimensional array of variables. Default is 1.
+        name (str, list of str, tuple of str, or None, optional) :
+            Name(s) to assign to the variables. Default is None.
 
-    The range of values between lb..ub is called the __domain__ of the integer variable.
-    All variables in an array start from the same domain.
-    Specific values in the domain of individual variables can be forbidden with constraints.
+            - If `name` is None, a name of the form ``IV<unique number>`` will be assigned to the variables.
+            - If `name` is a string, it will be used as the suffix of the variable names.
+            - If `name` is a list/tuple/array of strings, they will be assigned to the variable names accordingly.
 
-    If name is None then a name 'IV<unique number>' will be assigned to it.
-    If name is a string, then assign it as the suffix of variable names.
-    If name is a list/tuple/array of string, then assign them as the variable names accordingly.
+    Notes:
 
     If shape is different from 1, then each element of the array will have the location
     of this specific variable in the array append to its name.

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -25,15 +25,15 @@
     Boolean and Integer decision variables are the key elements of a CP model.
 
     All variables in CPMpy are n-dimensional array objects and have defined dimensions. 
-    Following the numpy library, the dimension sizes of an n-dimenionsal array is called its __shape__. 
+    Following the numpy library, the dimension sizes of an n-dimenionsal array is called its ``shape``. 
     In CPMpy all variables are considered an array with a given shape. For 'single' variables the shape 
     is '1'. For an array of length `n` the shape is 'n'. An `n*m` matrix has shape (n,m), and tensors 
     with more than 2 dimensions are all supported too. For the implementation of this, 
     CPMpy builts on numpy's n-dimensional ndarray and inherits many of its benefits 
     (vectorized operators and advanced indexing).
 
-    This module contains the cornerstone `boolvar()` and `intvar()` functions, which create (numpy arrays of) 
-    variables. There is also a helper function `cpm_array()` for wrapping standard numpy arrays so they can be 
+    This module contains the cornerstone ``boolvar()`` and ``intvar()`` functions, which create (numpy arrays of) 
+    variables. There is also a helper function ``cpm_array()`` for wrapping standard numpy arrays so they can be 
     indexed by a variable. Apart from these 3 functions, none of the classes in this module should be directly 
     instantiated; they are created by these 3 helper functions.
 
@@ -229,10 +229,10 @@ def cpm_array(arr):
     N-dimensional wrapper, to wrap standard numpy arrays or lists.
 
     In CP modeling languages, indexing an array by an integer variable is common, e.g. `[1,2,3,4][var1] == var2`.
-    This is called an __element__ constraint. Python does not allow expressing it on standard arrays,
+    This is called an `element` constraint. Python does not allow expressing it on standard arrays,
     but CPMpy-numpy arrays do allow it, so you first have to wrap the array.
 
-    Note that 'arr' will be transformed to vector and indexed as such, 2-dimensional indexing is not supported (yet?).
+    Note that `arr` will be transformed to vector and indexed as such, 2-dimensional indexing is not supported (yet?).
 
     .. code-block:: python
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -67,6 +67,10 @@ from .utils import is_num, is_int, flatlist, is_boolexpr, is_true_cst, is_false_
 
 
 def BoolVar(shape=1, name=None):
+    """
+    .. deprecated:: 0.9.0
+          Please use :func:`~cpmpy.expressions.variables.boolvar` instead.
+    """
     warnings.warn("Deprecated, use boolvar() instead, will be removed in stable version", DeprecationWarning)
     return boolvar(shape=shape, name=name)
 
@@ -141,6 +145,10 @@ def boolvar(shape=1, name=None):
 
 
 def IntVar(lb, ub, shape=1, name=None):
+    """
+    .. deprecated:: 0.9.0
+          Please use :func:`~cpmpy.expressions.variables.intvar` instead.
+    """
     warnings.warn("Deprecated, use intvar() instead, will be removed in stable version", DeprecationWarning)
     return intvar(lb, ub, shape=shape, name=name)
 
@@ -208,6 +216,10 @@ def intvar(lb, ub, shape=1, name=None):
     return r
 
 def cparray(arr):
+    """
+    .. deprecated:: 0.9.0
+          Please use :func:`~cpmpy.expressions.variables.cpm_array` instead.
+    """
     warnings.warn("Deprecated, use cpm_array() instead, will be removed in stable version", DeprecationWarning)
     return cpm_array(arr)
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -246,6 +246,10 @@ def cpm_array(arr):
         Model([ data[iv1] == iv2 ])
 
     As an alternative, you can also write the :class:`~cpmpy.expressions.globalfunctions.Element` constraint directly on `data`: 
+    
+    .. code-block:: python
+
+        Element(data, iv1) == iv2
     """
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -30,7 +30,7 @@
     is '1'. For an array of length `n` the shape is 'n'. An `n*m` matrix has shape (n,m), and tensors 
     with more than 2 dimensions are all supported too. For the implementation of this, 
     CPMpy builts on numpy's n-dimensional `ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_ 
-    (vectorized operators and advanced indexing).
+    and inherits many of its benefits (vectorized operators and advanced indexing).
 
     This module contains the cornerstone ``boolvar()`` and ``intvar()`` functions, which create (numpy arrays of) 
     variables. There is also a helper function ``cpm_array()`` for wrapping standard numpy arrays so they can be 
@@ -77,8 +77,8 @@ def BoolVar(shape=1, name=None):
 
 def boolvar(shape=1, name=None):
     """
-    Boolean decision variables will take either the value `True` or `False`.
-    
+    Create Boolean decision variables that take either the value `True` or `False`.
+
     Arguments:
         shape (int or tuple of int, optional) : The shape of the n-dimensional array of variables. Default is 1.
     

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -245,7 +245,7 @@ def cpm_array(arr):
 
         Model([ data[iv1] == iv2 ])
 
-    As an alternative, you can also write the `Element` constraint directly on `data`: `Element(data, iv1) == iv2`
+    As an alternative, you can also write the :class:`~cpmpy.expressions.globalfunctions.Element` constraint directly on `data`: 
     """
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -88,45 +88,38 @@ def boolvar(shape=1, name=None):
             - If `name` is None, a name of the form ``BV<unique number>`` will be assigned to the variables.
             - If `name` is a string, it will be used as the suffix of the variable names.
             - If `name` is a list/tuple/array of strings, they will be assigned to the variable names accordingly.
-    of this specific variable in the array append to its name.
 
-    For example,
-    - `print(boolvar(shape=3, name="x"))` will print `[x[0], x[1], x[2]]`
-    - `print(boolvar(shape=3, name=list("xyz"))` will print `[x, y, z]`
+    Notes:
 
+        - If `shape` is not 1, each element of the array will have its specific location appended to its name.
+        - Examples:
+            - ``boolvar(shape=3, name="x")`` will create the variables ``[x[0], x[1], x[2]]``.
+            - ``boolvar(shape=3, name=list("xyz"))`` will create the variables ``[x, y, z]``.
 
-    The following examples show how to create Boolean variables of different shapes:
+    Examples:
 
-    - Creating a single (unit-sized or scalar) Boolean variable:
+        Creating a single Boolean variable:
+        
         .. code-block:: python
 
-            # creation of a unit Boolean variable
             x = boolvar(name="x")
-
-    - the creation of a vector boolean variables. 
-
+        
+        Creating a vector of Boolean variables:
+        
         .. code-block:: python
 
-            # creation of a vector of size 3 of Boolean variables
             x = boolvar(shape=3, name="x")
 
-            # note that with Python's unpacking, you can assign them
-            # to intermediate variables. This allows for fine-grained use of variables when
-            # defining the constraints of the model
+            # Assigning them to individual variables:
             e, x, a, m, p, l = boolvar(shape=6, name=list("exampl"))
 
-    - the creation of a matrix or higher-order tensor of Boolean variables. 
+        Creating a matrix or higher-order tensor of Boolean variables:
+        
         .. code-block:: python
 
-            # creation of a 9x9 matrix of Boolean variables:
             matrix = boolvar(shape=(9, 9), name="matrix")
-            # creation of a 2x2 matrix of Boolean variables, and give a name for each element:
             matrix2 = boolvar(shape=(2, 2), name=[['a', 'b'], ['c', 'd']])
-
-            # creation of a __tensor of Boolean variables where (3, 8, 7) reflects
-            # the dimensions of the tensor, a matrix of multiple-dimensions.
-            # In this case, we create an 3D-array of dimensions 3 x 8 x 7.
-            tensor = BoolVar(shape=(3, 8, 7), name="tensor")
+            tensor = boolvar(shape=(3, 8, 7), name="tensor")
     """
     if shape == 0 or shape is None:
         raise NullShapeError(shape)
@@ -172,10 +165,18 @@ def intvar(lb, ub, shape=1, name=None):
 
     Notes:
 
-    If shape is different from 1, then each element of the array will have the location
-    of this specific variable in the array append to its name.
+        The range of values between ``lb..ub`` is called the `domain` of the integer variable.
+        All variables in an array start from the same domain.
+        Specific values in the domain of individual variables can be forbidden with constraints.
 
-    The following examples show how to create integer variables of different shapes:
+        If `shape` is not 1, each element of the array will have its specific location appended to its name.
+
+        - ``intvar(0, 2, shape=3, name="x")`` will create the variables ``[x[0], x[1], x[2]]``.
+
+        If `shape` is not 1 and a list of names has been provided (with the same length as the array), each decision variable will receive its respective name.
+
+        - ``intvar(0, 2, shape=3, name=list("xyz"))`` will create the variables ``[x, y, z]``.
+
     Examples:
 
         Creation of a single (unit-sized or scalar) integer variable with a given lower bound (**lb**) of 3 and upper bound (**ub**) of 8. Variable `x` can thus take values 3, 4, 5, 6, 7, 8 (upper bound included!).

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -176,15 +176,16 @@ def intvar(lb, ub, shape=1, name=None):
     of this specific variable in the array append to its name.
 
     The following examples show how to create integer variables of different shapes:
+    Examples:
 
-    - Creation of a single (unit-sized or scalar) integer variable with a given lower bound (**lb**) of 3 and upper bound (**ub**) 8. Variable `x` can thus take values 3, 4, 5, 6, 7, 8 (upper bound included!).
+        Creation of a single (unit-sized or scalar) integer variable with a given lower bound (**lb**) of 3 and upper bound (**ub**) of 8. Variable `x` can thus take values 3, 4, 5, 6, 7, 8 (upper bound included!).
 
         .. code-block:: python
 
             # creation of a unit integer variable with lowerbound of 3 and upperbound of 8 
             x = intvar(3, 8, name="x")
 
-    - Creation of a vector of integer variables with all having the same given lower bound and upper bound:
+        Creation of a vector of integer variables with all having the same given lower bound and upper bound:
 
         .. code-block:: python
 
@@ -194,7 +195,8 @@ def intvar(lb, ub, shape=1, name=None):
             # Python's unpacking can assign multiple intermediate variables at once
             e, x, a, m, p, l = intvar(3, 8, shape=6, name=list("exampl"))
 
-    - Creation of a 4D-array/tensor (of dimensions 100 x 100 x 100 x 100) of integer variables.
+        Creation of a 4D-array/tensor (of dimensions 100 x 100 x 100 x 100) of integer variables.
+        
         .. code-block:: python
 
             arrx s= intvar(3, 8, shape=(100, 100, 100, 100), name="arrx")

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -50,9 +50,10 @@ class Model(object):
         """
             Arguments of constructor:
 
-            - `*args`: Expression object(s) or list(s) of Expression objects
-            - `minimize`: Expression object representing the objective to minimize
-            - `maximize`: Expression object representing the objective to maximize
+            Arguments:
+                `*args`: Expression object(s) or list(s) of Expression objects
+                `minimize`: Expression object representing the objective to minimize
+                `maximize`: Expression object representing the objective to maximize
 
             At most one of minimize/maximize can be set, if none are set, it is assumed to be a satisfaction problem
         """
@@ -113,8 +114,9 @@ class Model(object):
         """
             Post the given expression to the solver as objective to minimize/maximize
 
-            - expr: Expression, the CPMpy expression that represents the objective function
-            - minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
+            Arguments:
+                expr (Expression):      the CPMpy expression that represents the objective function
+                minimize (bool):        whether it is a minimization problem (True) or maximization problem (False)
 
             'objective()' can be called multiple times, only the last one is stored
         """
@@ -144,13 +146,15 @@ class Model(object):
     def solve(self, solver=None, time_limit=None, **kwargs):
         """ Send the model to a solver and get the result
 
-        :param solver: name of a solver to use. Run SolverLookup.solvernames() to find out the valid solver names on your system. (default: None = first available solver)
-        :type string: None (default) or a name in SolverLookup.solvernames() or a SolverInterface class (Class, not object!)
+        Arguments:
+            solver (string or a name in SolverLookup.solvernames() or a SolverInterface class (Class, not object!), optional): 
+                name of a solver to use. Run SolverLookup.solvernames() to find out the valid solver names on your system. (default: None = first available solver)
+            time_limit (int or float, optional): time limit in seconds
 
-        :param time_limit: optional, time limit in seconds
-        :type time_limit: int or float
+            
+        Returns:
+            bool: the computed output:
 
-        :return: Bool: the computed output:
             - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
             - False     if no solution is found
         """
@@ -176,9 +180,9 @@ class Model(object):
             Delegated to the solver, who might implement this efficiently
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
-                        default/None: nothing displayed
-                - solution_limit: stop after this many solutions (default: None)
+                display:            either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                                    default/None: nothing displayed
+                solution_limit:     stop after this many solutions (default: None)
 
             Returns: number of solutions found
         """
@@ -203,7 +207,8 @@ class Model(object):
 
             Status information includes exit status (optimality) and runtime.
 
-            :return: an object of :class:`SolverStatus`
+            Returns:
+                an object of :class:`SolverStatus`
         """
         return self.cpm_status
 
@@ -211,7 +216,8 @@ class Model(object):
         """
             Returns the value of the objective function of the latste solver run on this model
 
-            :return: an integer or 'None' if it is not run, or a satisfaction problem
+            Returns:
+                an integer or 'None' if it is not run, or a satisfaction problem
         """
         return self.objective_.value()
 
@@ -233,9 +239,10 @@ class Model(object):
 
     def to_file(self, fname):
         """
-            Serializes this model to a .pickle format
+            Serializes this model to a ``.pickle`` format
 
-            :param: fname: Filename of the resulting serialized model
+            Arguments:
+                fname (FileDescriptorOrPath): Filename of the resulting serialized model
         """
         with open(fname,"wb") as f:
             pickle.dump(self, file=f)
@@ -246,7 +253,8 @@ class Model(object):
         """
             Reads a Model instance from a binary pickled file
 
-            :return: an object of :class: `Model`
+            Returns:
+                an object of :class: `Model`
         """
         with open(fname, "rb") as f:
             m = pickle.load(f)

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -203,7 +203,7 @@ class Model(object):
 
             Status information includes exit status (optimality) and runtime.
 
-        :return: an object of :class:`SolverStatus`
+            :return: an object of :class:`SolverStatus`
         """
         return self.cpm_status
 
@@ -211,7 +211,7 @@ class Model(object):
         """
             Returns the value of the objective function of the latste solver run on this model
 
-        :return: an integer or 'None' if it is not run, or a satisfaction problem
+            :return: an integer or 'None' if it is not run, or a satisfaction problem
         """
         return self.objective_.value()
 

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -86,8 +86,10 @@ class Model(object):
         """
             Add one or more constraints to the model
 
-            m = Model()
-            m += [x > 0]
+            .. code-block:: python
+
+                m = Model()
+                m += [x > 0]
         """
         if is_any_list(con):
             # catch some beginner mistakes: check that top-level Expressions in the list have Boolean return type

--- a/cpmpy/solvers/__init__.py
+++ b/cpmpy/solvers/__init__.py
@@ -20,6 +20,7 @@
         exact
         choco
         gcs
+        cpo
         utils
 
     ===============
@@ -37,6 +38,7 @@
         CPM_exact
         CPM_choco
         CPM_gcs
+        CPM_cpo
 
     =================
     List of functions
@@ -57,4 +59,5 @@ from .z3 import CPM_z3
 from .exact import CPM_exact
 from .choco import CPM_choco
 from .gcs import CPM_gcs
+from .cpo import CPM_cpo
 

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -8,6 +8,8 @@
 
     Requires that the 'pychoco' python package is installed:
 
+    .. code-block:: console
+
         $ pip install pychoco
 
 

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -344,7 +344,7 @@ class CPM_choco(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
             :param cpm_expr: CPMpy expression, or list thereof
             :type cpm_expr: Expression or list of Expression

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -65,8 +65,9 @@ class CPM_choco(SolverInterface):
     https://pychoco.readthedocs.io/en/latest/
 
     Creates the following attributes (see parent constructor for more):
-    chc_model: the pychoco.Model() created by _model()
-    chc_solver: the choco Model().get_solver() instance used in solve()
+    
+    - ``chc_model`` : the pychoco.Model() created by _model()
+    - ``chc_solver`` : the choco Model().get_solver() instance used in solve()
 
     """
 
@@ -297,7 +298,7 @@ class CPM_choco(SolverInterface):
                 expr: Expression, the CPMpy expression that represents the objective function
                 minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
 
-            'objective()' can be called multiple times, only the last one is stored
+            ``objective()`` can be called multiple times, only the last one is stored
 
             (technical side note: constraints created during conversion of the objective
             are premanently posted to the solver. Choco accepts variables to maximize or minimize

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -100,8 +100,8 @@ class CPM_choco(SolverInterface):
         calling solve(), a prime way to use more advanced solver features
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model() (optional)
-        - subsolver: None
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: None
         """
         if not self.supported():
             raise Exception("CPM_choco: Install the python package 'pychoco' to use this solver interface.")
@@ -134,8 +134,8 @@ class CPM_choco(SolverInterface):
             Call the Choco solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional)
-            - kwargs:      any keyword argument, sets parameters of solver object
+                time_limit (float, optional):   maximum solve time in seconds 
+                kwargs:                         any keyword argument, sets parameters of solver object
 
         """
         # ensure all vars are known to solver
@@ -201,12 +201,13 @@ class CPM_choco(SolverInterface):
             Compute all (optimal) solutions, map them to CPMpy and optionally display the solutions.
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
                         default/None: nothing displayed
-                - solution_limit: stop after this many solutions (default: None)
-                - time_limit:  maximum solve time in seconds (float, default: None)
+                solution_limit: stop after this many solutions (default: None)
+                time_limit (float, optional):   maximum solve time in seconds
 
-            Returns: number of solutions found
+            Returns: 
+                number of solutions found
         """
 
         # ensure all vars are known to solver
@@ -292,8 +293,9 @@ class CPM_choco(SolverInterface):
         """
             Post the given expression to the solver as objective to minimize/maximize
 
-            - expr: Expression, the CPMpy expression that represents the objective function
-            - minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
+            Arguments:
+                expr: Expression, the CPMpy expression that represents the objective function
+                minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
 
             'objective()' can be called multiple times, only the last one is stored
 
@@ -344,10 +346,10 @@ class CPM_choco(SolverInterface):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
 
         cpm_cons = toplevel_list(cpm_expr)

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -300,9 +300,10 @@ class CPM_choco(SolverInterface):
 
             ``objective()`` can be called multiple times, only the last one is stored
 
-            (technical side note: constraints created during conversion of the objective
-            are premanently posted to the solver. Choco accepts variables to maximize or minimize
-            so it is needed to post constraints and create auxiliary variables)
+            .. note::
+                technical side note: constraints created during conversion of the objective
+                are premanently posted to the solver. Choco accepts variables to maximize or minimize
+                so it is needed to post constraints and create auxiliary variables
         """
 
         # make objective function non-nested

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -14,8 +14,9 @@
 
 
     Documentation of the solver's own Python API:
-    https://pypi.org/project/pychoco/
-    https://pychoco.readthedocs.io/en/latest/
+    
+    - https://pypi.org/project/pychoco/
+    - https://pychoco.readthedocs.io/en/latest/
 
     ===============
     List of classes
@@ -63,8 +64,9 @@ class CPM_choco(SolverInterface):
     $ pip install pychoco
 
     See detailed installation instructions at:
-    https://pypi.org/project/pychoco/
-    https://pychoco.readthedocs.io/en/latest/
+    
+    - https://pypi.org/project/pychoco/
+    - https://pychoco.readthedocs.io/en/latest/
 
     Creates the following attributes (see parent constructor for more):
     

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -97,8 +97,8 @@ class CPM_cpo(SolverInterface):
         Constructor of the native solver object
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model() (optional)
-        - subsolver: str, name of a subsolver (optional)
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: str, name of a subsolver (optional)
         """
         if not self.installed():
             raise Exception("CPM_cpo: Install the python package 'docplex'")
@@ -117,8 +117,8 @@ class CPM_cpo(SolverInterface):
             Call the CP Optimizer solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional)
-            - kwargs:      any keyword argument, sets parameters of solver object
+                time_limit (float, optional):   maximum solve time in seconds 
+                kwargs:                         any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
             # LogVerbosity, this parameter determines the verbosity of the search log

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -1,18 +1,3 @@
-import shutil
-import warnings
-
-from .solver_interface import SolverInterface, SolverStatus, ExitStatus
-from .. import DirectConstraint
-from ..expressions.core import Expression, Comparison, Operator, BoolVal
-from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.globalfunctions import GlobalFunction
-from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
-from ..expressions.utils import is_num, is_any_list, eval_comparison, argval, argvals, get_bounds
-from ..transformations.get_variables import get_variables
-from ..transformations.normalize import toplevel_list
-from ..transformations.decompose_global import decompose_in_tree
-from ..transformations.safening import no_partial_functions
-
 """
     Interface to CP Optimizers API
 
@@ -31,6 +16,23 @@ from ..transformations.safening import no_partial_functions
 
         CPM_cpo
 """
+
+import shutil
+import warnings
+
+from .solver_interface import SolverInterface, SolverStatus, ExitStatus
+from .. import DirectConstraint
+from ..expressions.core import Expression, Comparison, Operator, BoolVal
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalfunctions import GlobalFunction
+from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
+from ..expressions.utils import is_num, is_any_list, eval_comparison, argval, argvals, get_bounds
+from ..transformations.get_variables import get_variables
+from ..transformations.normalize import toplevel_list
+from ..transformations.decompose_global import decompose_in_tree
+from ..transformations.safening import no_partial_functions
+
+
 
 class CPM_cpo(SolverInterface):
     """

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -36,10 +36,13 @@ from ..transformations.safening import no_partial_functions
 
 class CPM_cpo(SolverInterface):
     """
-    Interface to CP Optimizers API
+    Interface to CP Optimizers API.
 
     Requires that the 'docplex' python package is installed:
-    $ pip install docplex
+
+    .. code-block:: console
+    
+        $ pip install docplex
 
     docplex documentation:
     https://ibmdecisionoptimization.github.io/docplex-doc/
@@ -51,11 +54,14 @@ class CPM_cpo(SolverInterface):
 
     See detailed installation instructions at:
     https://www.ibm.com/docs/en/icos/22.1.2?topic=2212-installing-cplex-optimization-studio
+
     Academic license:
     https://community.ibm.com/community/user/ai-datascience/blogs/xavier-nodet1/2020/07/09/cplex-free-for-students
 
     Creates the following attributes (see parent constructor for more):
-    - cpo_model: object, CP Optimizers model object
+
+    - ``cpo_model``: object, CP Optimizers model object
+
     """
 
     _docp = None  # Static attribute to hold the docplex.cp module
@@ -123,17 +129,21 @@ class CPM_cpo(SolverInterface):
                 kwargs:                         any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
-            # LogVerbosity, this parameter determines the verbosity of the search log
-              Choose a value from  [‘Quiet’, ‘Terse’, ‘Normal’, ‘Verbose’]. Default value is ‘Quiet’.
-            # OptimalityTolerance: This parameter sets an absolute tolerance on the objective value for optimization models.
-            The value is a positive float. Default value is 1e-09.
-            # RelativeOptimalityTolerance This parameter sets a relative tolerance on the objective value for optimization models.
-            The optimality of a solution is proven if either of the two parameters’ criteria is fulfilled.
-            # Presolve: This parameter controls the presolve of the model to produce more compact formulations and to achieve more domain reduction. Possible values for this parameter are On (presolve is activated) and Off (presolve is deactivated).
-            The value is a symbol in [‘On’, ‘Off’]. Default value is ‘On’.
-            # Workers: This parameter sets the number of workers to run in parallel to solve your model.
-            # The value is a positive integer. Default value is Auto. (Auto = use all available CPU cores)
-            # all solver parameters are documented here: https://ibmdecisionoptimization.github.io/docplex-doc/cp/docplex.cp.parameters.py.html#docplex.cp.parameters.CpoParameters
+
+
+            =============================   ============
+            Argument                        Description
+            =============================   ============
+            LogVerbosity                    Determines the verbosity of the search log. Choose a value from  ['Quiet', 'Terse', 'Normal', 'Verbose']. Default value is 'Quiet'.
+            OptimalityTolerance             This parameter sets an absolute tolerance on the objective value for optimization models. The value is a positive float. Default value is 1e-09.
+            RelativeOptimalityTolerance     This parameter sets a relative tolerance on the objective value for optimization models. The optimality of a solution is proven if either of the two parameters' criteria is fulfilled.
+            Presolve                        This parameter controls the presolve of the model to produce more compact formulations and to achieve more domain reduction. Possible values for this parameter are On (presolve is activated) and Off (presolve is deactivated).
+                                            The value is a symbol in ['On', 'Off']. Default value is 'On'.
+            Workers                         This parameter sets the number of workers to run in parallel to solve your model. The value is a positive integer. Default value is Auto. (Auto = use all available CPU cores)
+            =============================   ============
+
+            All solver parameters are documented here: https://ibmdecisionoptimization.github.io/docplex-doc/cp/docplex.cp.parameters.py.html#docplex.cp.parameters.CpoParameters
+
         """
 
         # ensure all vars are known to solver
@@ -198,7 +208,7 @@ class CPM_cpo(SolverInterface):
 
             If the problem is an optimization problem, returns only optimal solutions.
 
-           Args:
+            Arguments:
                 display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping.
                          Default is None, meaning nothing is displayed.
                 time_limit: Stop after this many seconds. Default is None.
@@ -276,11 +286,11 @@ class CPM_cpo(SolverInterface):
         """
             Post the given expression to the solver as objective to minimize/maximize
 
-            'objective()' can be called multiple times, only the last one is stored
+            ``objective()`` can be called multiple times, only the last one is stored
 
-            (technical side note: any constraints created during conversion of the objective
-
-            are permanently posted to the solver)
+            .. note::
+            
+                technical side note: any constraints created during conversion of the objective are permanently posted to the solver
         """
         dom = self.get_docp().modeler
         if self.has_objective():
@@ -302,12 +312,12 @@ class CPM_cpo(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         # apply transformations
         cpm_cons = toplevel_list(cpm_expr)
@@ -333,10 +343,10 @@ class CPM_cpo(SolverInterface):
             the user knows and cares about (and will be populated with a value after solve). All other variables
             are auxiliary variables created by transformations.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: self
+            :return: self
         """
 
         # add new user vars to the set

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -549,6 +549,7 @@ class CPM_exact(SolverInterface):
     def solution_hint(self, cpm_vars, vals):
         """
         Exact supports warmstarting the solver with a partial feasible assignment.
+
         :param cpm_vars: list of CPMpy variables
         :param vals: list of (corresponding) values for the variables
         """

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -55,11 +55,13 @@ class CPM_exact(SolverInterface):
 
     Requires that the 'exact' python package is installed:
     $ pip install exact
+
     See https://pypi.org/project/exact for more information.
 
     Creates the following attributes (see parent constructor for more):
-        - xct_solver: the Exact instance used in solve() and solveAll()
-        - assumption_dict: maps Exact variables to (Exact value, CPM assumption expression)
+
+    - ``xct_solver`` : the Exact instance used in solve() and solveAll()
+    - ``assumption_dict`` : maps Exact variables to (Exact value, CPM assumption expression)
     """
 
     @staticmethod
@@ -144,7 +146,7 @@ class CPM_exact(SolverInterface):
         """
             Call Exact
 
-            Overwrites self.cpm_status
+            Overwrites ``self.cpm_status``
 
             :param assumptions: CPMpy Boolean variables (or their negation) that are assumed to be true.
                            For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -331,7 +331,7 @@ class CPM_exact(SolverInterface):
 
     def objective(self, expr, minimize):
         """
-            Post the given expression to the solver as objective to minimize/maximize
+            Post the given expression to the solver as objective to minimize/maximize.
 
             Arguments:
                 expr: Expression, the CPMpy expression that represents the objective function

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -6,6 +6,12 @@
 """
     Interface to Exact
 
+    Requires that the 'exact' python package is installed:
+
+    .. code-block:: console
+    
+        $ pip install exact
+
     Exact solves decision and optimization problems formulated as integer linear programs. 
     Under the hood, it converts integer variables to binary (0-1) variables and applies highly efficient 
     propagation routines and strong cutting-planes / pseudo-Boolean conflict analysis.

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -90,8 +90,8 @@ class CPM_exact(SolverInterface):
         Exact solver object xct_solver.
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model() (optional)
-        - subsolver: None
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: None
 
         Exact takes options at initialization instead of solving.
         The Exact solver parameters are defined by https://gitlab.com/nonfiction-software/exact/-/blob/main/src/Options.hpp
@@ -219,12 +219,12 @@ class CPM_exact(SolverInterface):
             Compute all solutions and optionally, display the solutions.
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
                         default/None: nothing displayed
-                - time_limit: stop after this many seconds (default: None)
-                - solution_limit: stop after this many solutions (default: None)
-                - call_from_model: whether the method is called from a CPMpy Model instance or not
-                - any other keyword argument
+                time_limit: stop after this many seconds (default: None)
+                solution_limit: stop after this many solutions (default: None)
+                call_from_model: whether the method is called from a CPMpy Model instance or not
+                any other keyword argument
 
             Returns: number of solutions found
         """
@@ -325,8 +325,9 @@ class CPM_exact(SolverInterface):
         """
             Post the given expression to the solver as objective to minimize/maximize
 
-            - expr: Expression, the CPMpy expression that represents the objective function
-            - minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
+            Arguments:
+                expr: Expression, the CPMpy expression that represents the objective function
+                minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
 
         """
         self.objective_ = expr

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -147,7 +147,7 @@ class CPM_exact(SolverInterface):
             Overwrites self.cpm_status
 
             :param assumptions: CPMpy Boolean variables (or their negation) that are assumed to be true.
-                           For repeated solving, and/or for use with s.get_core(): if the model is UNSAT,
+                           For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
                            get_core() returns a small subset of assumption variables that are unsat together.
             :type assumptions: list of CPMpy Boolean variables
 
@@ -391,7 +391,7 @@ class CPM_exact(SolverInterface):
         Implemented through chaining multiple solver-independent **transformation functions** from
         the `cpmpy/transformations/` directory.
 
-        See the 'Adding a new solver' docs on readthedocs for more information.
+        See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
         :param cpm_expr: CPMpy expression, or list thereof
         :type cpm_expr: Expression or list of Expression

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -79,8 +79,8 @@ class CPM_gcs(SolverInterface):
         """
         Constructor of the native solver object
         Arguments:
-        - cpm_model: Model(), a CPMpy Model() (optional)
-        - subsolver: None (not supported)
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: None (not supported)
         """
         if not self.supported():
             raise Exception("CPM_gcs: Install the python package 'gcspy' to use this solver interface.")
@@ -107,18 +107,20 @@ class CPM_gcs(SolverInterface):
               verify=False, verify_time_limit=None, veripb_args = [], display_verifier_output=True, **kwargs):
         """
             Run the Glasgow Constraint Solver, get just one (optimal) solution.
-            Arguments:
-            - time_limit:        maximum solve time in seconds (float, optional).
-            - prove:             whether to produce a VeriPB proof (.opb model file and .pbp proof file).
-            - proof_name:        name for the the proof files.
-            - proof_location:    location for the proof files (default to current working directory).
-            - verify:            whether to verify the result of the solve run (overrides prove if prove is False)
-            - verify_time_limit: time limit for verification (ignored if verify=False) 
-            - veripb_args:       list of command line arguments to pass to veripb e.g. `--trace --useColor` (run `veripb --help` for a full list)
-            - display_verifier_output: whether to print the output from VeriPB
-            - kwargs:            currently GCS does not support any additional keyword arguments.
 
-            Returns: whether a solution was found.
+            Arguments:
+                time_limit (float, optional):   maximum solve time in seconds.
+                prove:                          whether to produce a VeriPB proof (.opb model file and .pbp proof file).
+                proof_name:                     name for the the proof files.
+                proof_location:                 location for the proof files (default to current working directory).
+                verify:                         whether to verify the result of the solve run (overrides prove if prove is False)
+                verify_time_limit:              time limit for verification (ignored if verify=False) 
+                veripb_args:                    list of command line arguments to pass to veripb e.g. ``--trace --useColor`` (run ``veripb --help`` for a full list)
+                display_verifier_output:        whether to print the output from VeriPB
+                **kwargs:                       currently GCS does not support any additional keyword arguments.
+
+            Returns: 
+                whether a solution was found.
         """
         # ensure all user vars are known to solver
         self.solver_vars(list(self.user_vars))
@@ -197,20 +199,22 @@ class CPM_gcs(SolverInterface):
             Run the Glasgow Constraint Solver, and get a number of solutions, with optional solution callbacks. 
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
-                        default/None: nothing displayed
-                - solution_limit:       stop after this many solutions (default: None)
-                - time_limit:           maximum solve time in seconds (float, default: None)
-                - call_from_model:      whether the method is called from a CPMpy Model instance or not
-                - prove:                whether to produce a VeriPB proof (.opb model file and .pbp proof file).
-                - proof_name:           name for the the proof files.
-                - proof_location:       location for the proof files (default to current working directory).
-                - verify:               whether to verify the result of the solve run (overrides prove if prove is False)
-                - verify_time_limit:    time limit for verification (ignored if verify=False) 
-                - veripb_args:          list of command line arguments to pass to veripb e.g. `--trace --useColor` (run `veripb --help` for a full list)
-                - display_verifier_output: whether to print the output from VeriPB
-                - kwargs:               currently GCS does not support any additional keyword arguments.
-            Returns: number of solutions found
+                display:                        either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                                                default/None: nothing displayed
+                solution_limit:                 stop after this many solutions (default: None)
+                time_limit (float, optional):   maximum solve time in seconds (default: None)
+                call_from_model:                whether the method is called from a CPMpy Model instance or not
+                prove:                          whether to produce a VeriPB proof (.opb model file and .pbp proof file).
+                proof_name:                     name for the the proof files.
+                proof_location:                 location for the proof files (default to current working directory).
+                verify:                         whether to verify the result of the solve run (overrides prove if prove is False)
+                verify_time_limit:              time limit for verification (ignored if verify=False) 
+                veripb_args:                    list of command line arguments to pass to veripb e.g. ``--trace --useColor`` (run ``veripb --help`` for a full list)
+                display_verifier_output:        whether to print the output from VeriPB
+                **kwargs:                       currently GCS does not support any additional keyword arguments.
+
+            Returns: 
+                number of solutions found
         """
         if self.has_objective():
             raise NotSupportedError("Glasgow Constraint Solver: does not support finding all optimal solutions.")
@@ -334,10 +338,10 @@ class CPM_gcs(SolverInterface):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         cpm_cons = toplevel_list(cpm_expr)
         supported = {

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #-*- coding:utf-8 -*-
 ##
-## ortools.py
+## gcs.py
 ##
 """
     Interface to the Glasgow Constraint Solver's API for the cpmpy library.
@@ -16,12 +16,15 @@
 
     See:
     https://github.com/ciaranm/glasgow-constraint-solver
+
     ===============
     List of classes
     ===============
+
     .. autosummary::
         :nosignatures:
-        GlasgowConstraintSolver
+
+        CPM_gcs
 """
 from cpmpy.transformations.comparison import only_numexpr_equality
 from cpmpy.transformations.reification import reify_rewrite, only_bv_reifies
@@ -48,8 +51,10 @@ class CPM_gcs(SolverInterface):
     """
     Interface to Glasgow Constraint Solver's API.
 
-    Requires that the 'gcspy' python package is installed:
+    Requires that the 'gcspy' python package is installed: $ pip install gcspy
+
     Current installation instructions:
+
     - Ensure you have C++20 compiler such as GCC 10.3  / clang 15
     - (on Debian-based systems, see https://apt.llvm.org for easy installation)
     - If necessary `export CXX=<your up to date C++ compiler (e.g. clang++-15)>`
@@ -57,6 +62,7 @@ class CPM_gcs(SolverInterface):
     - `git clone https://github.com/ciaranm/glasgow-constraint-solver.git`
     - `cd glasgow-constraint-solver/python`
     - `pip install .`
+
     NB: if for any reason you need to retry the build, ensure you remove glasgow-constraints-solver/generator before rebuilding.
 
     For the verifier functionality, the 'veripb' tool is also required.
@@ -86,6 +92,7 @@ class CPM_gcs(SolverInterface):
     def __init__(self, cpm_model=None, subsolver=None):
         """
         Constructor of the native solver object
+
         Arguments:
             cpm_model: Model(), a CPMpy Model() (optional)
             subsolver: None (not supported)

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -347,7 +347,7 @@ class CPM_gcs(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
             :param cpm_expr: CPMpy expression, or list thereof
             :type cpm_expr: Expression or list of Expression

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -53,15 +53,16 @@ class CPM_gcs(SolverInterface):
     NB: if for any reason you need to retry the build, ensure you remove glasgow-constraints-solver/generator before rebuilding.
 
     For the verifier functionality, the 'veripb' tool is also required.
-    See `https://gitlab.com/MIAOresearch/software/VeriPB#installation` for installation instructions. 
+    See https://gitlab.com/MIAOresearch/software/VeriPB#installation for installation instructions. 
 
     Creates the following attributes (see parent constructor for more):
-    - gcs: the gcspy solver object
-    - objective_var: optional: the variable used as objective
-    - proof_location: location of the last proof produced by the solver
-    - proof_name: name of the last proof (means <proof_name>.opb and <proof_name>.pbp will be present at the proof location)
-    - veripb_return_code: return code from the last VeriPB check.
-    - proof_check_timeout: whether the last VeriPB check timed out.
+
+    - ``gcs`` : the gcspy solver object
+    - ``objective_var`` : optional: the variable used as objective
+    - ``proof_location`` : location of the last proof produced by the solver
+    - ``proof_name`` : name of the last proof (means <proof_name>.opb and <proof_name>.pbp will be present at the proof location)
+    - ``veripb_return_code`` : return code from the last VeriPB check.
+    - ``proof_check_timeout`` : whether the last VeriPB check timed out.
     """
 
     @staticmethod
@@ -380,12 +381,13 @@ class CPM_gcs(SolverInterface):
         Verify a solver-produced proof using VeriPB.
 
         Requires that the 'veripb' tool is installed and on system path. 
-        See `https://gitlab.com/MIAOresearch/software/VeriPB#installation` for installation instructions. 
+        See https://gitlab.com/MIAOresearch/software/VeriPB#installation for installation instructions. 
+
         Arguments:
             - name:             name for the the proof files (default to self.proof_name)
             - location:         location for the proof files (default to current working directory).
             - time_limit:       time limit for verification (ignored if verify=False) 
-            - veripb_args:      list of command line arguments to pass to veripb e.g. `--trace --useColor` (run `veripb --help` for a full list)
+            - veripb_args:      list of command line arguments to pass to veripb e.g. ``--trace --useColor`` (run ``veripb --help`` for a full list)
             - display_output:   whether to print the output from VeriPB
         """
         if not which("veripb"):

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -317,10 +317,13 @@ class CPM_gcs(SolverInterface):
 
     def objective(self, expr, minimize=True):
         """
-            Post the given expression to the solver as objective to minimize/maximize
-            'objective()' can be called multiple times, only the last one is stored
-            (technical side note: any constraints created during conversion of the objective
-            are permanently posted to the solver)
+            Post the given expression to the solver as objective to minimize/maximize.
+
+            ``objective()`` can be called multiple times, only the last one is stored.
+
+            .. note::
+                technical side note: any constraints created during conversion of the objective
+                are permanently posted to the solver
         """
         # make objective function non-nested
         (flat_obj, flat_cons) = flatten_objective(expr)

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -5,6 +5,13 @@
 ##
 """
     Interface to the Glasgow Constraint Solver's API for the cpmpy library.
+
+    Requires that the 'gcspy' python package is installed:
+
+    .. code-block:: console
+
+        $ pip install gcspy
+
     The key feature of this solver is the ability to produce proof logs.
 
     See:

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -252,8 +252,9 @@ class CPM_gurobi(SolverInterface):
 
             'objective()' can be called multiple times, only the last one is stored
 
-            (technical side note: any constraints created during conversion of the objective
-                are premanently posted to the solver)
+            .. note::
+                technical side note: any constraints created during conversion of the objective
+                are premanently posted to the solver
         """
         from gurobipy import GRB
 

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -64,9 +64,9 @@ class CPM_gurobi(SolverInterface):
     https://support.gurobi.com/hc/en-us/articles/360044290292-How-do-I-install-Gurobi-for-Python-
 
     Creates the following attributes (see parent constructor for more):
-        - grb_model: object, TEMPLATE's model object
+    
+    - ``grb_model``: object, TEMPLATE's model object
 
-    The `DirectConstraint`, when used, calls a function on the `grb_model` object.
     The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function on the ``grb_model`` object.
     """
 
@@ -141,10 +141,11 @@ class CPM_gurobi(SolverInterface):
 
             Arguments that correspond to solver parameters:
             Examples of gurobi supported arguments include:
-                - Threads : int
-                - MIPFocus: int
-                - ImproveStartTime : bool
-                - FlowCoverCuts: int
+
+            - ``Threads`` : int
+            - ``MIPFocus`` : int
+            - ``ImproveStartTime`` : bool
+            - ``FlowCoverCuts`` : int
 
             For a full list of gurobi parameters, please visit https://www.gurobi.com/documentation/9.5/refman/parameters.html#sec:Parameters
         """

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -106,8 +106,8 @@ class CPM_gurobi(SolverInterface):
         Constructor of the native solver object
 
         Arguments:
-        - cpm_model: a CPMpy Model()
-        - subsolver: None, not used
+            cpm_model: a CPMpy Model()
+            subsolver: None, not used
         """
         if not self.installed():
             raise Exception("CPM_gurobi: Install the python package 'gurobipy' to use this solver interface.")
@@ -135,8 +135,8 @@ class CPM_gurobi(SolverInterface):
             Call the gurobi solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional)
-            - kwargs:      any keyword argument, sets parameters of solver object
+                - time_limit (float, optional):  maximum solve time in seconds 
+                - **kwargs:                      any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
             Examples of gurobi supported arguments include:
@@ -306,10 +306,10 @@ class CPM_gurobi(SolverInterface):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
@@ -452,12 +452,12 @@ class CPM_gurobi(SolverInterface):
             a more efficient native implementation
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
                         default/None: nothing displayed
-                - time_limit: stop after this many seconds (default: None)
-                - solution_limit: stop after this many solutions (default: None)
-                - call_from_model: whether the method is called from a CPMpy Model instance or not
-                - any other keyword argument
+                time_limit: stop after this many seconds (default: None)
+                solution_limit: stop after this many solutions (default: None)
+                call_from_model: whether the method is called from a CPMpy Model instance or not
+                any other keyword argument
 
             Returns: number of solutions found
         """

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -8,6 +8,8 @@
 
     Requires that the 'gurobipy' python package is installed:
 
+    .. code-block:: console
+
         $ pip install gurobipy
     
     

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -138,8 +138,8 @@ class CPM_gurobi(SolverInterface):
             Call the gurobi solver
 
             Arguments:
-                - time_limit (float, optional):  maximum solve time in seconds 
-                - **kwargs:                      any keyword argument, sets parameters of solver object
+                time_limit (float, optional):  maximum solve time in seconds 
+                **kwargs:                      any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
             Examples of gurobi supported arguments include:

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -17,7 +17,7 @@
     You can read more about available licences at https://www.gurobi.com/downloads/
 
     Documentation of the solver's own Python API:
-    https://www.gurobi.com/documentation/current/refman/py_python_api_details.html
+    https://docs.gurobi.com/projects/optimizer/en/current/reference/python.html
 
     ===============
     List of classes

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -67,6 +67,7 @@ class CPM_gurobi(SolverInterface):
         - grb_model: object, TEMPLATE's model object
 
     The `DirectConstraint`, when used, calls a function on the `grb_model` object.
+    The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function on the ``grb_model`` object.
     """
 
     @staticmethod
@@ -304,7 +305,7 @@ class CPM_gurobi(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
             :param cpm_expr: CPMpy expression, or list thereof
             :type cpm_expr: Expression or list of Expression

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -87,7 +87,7 @@ class CPM_minizinc(SolverInterface):
     - ``mzn_txt_solve``: str, the 'solve' item in text form, so it can be overwritten
     - ``mzn_result``: object, containing solve results
 
-    The `DirectConstraint`, when used, adds a constraint with that name and the given args to the MiniZinc model.
+    The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, adds a constraint with that name and the given args to the MiniZinc model.
     """
 
     required_version = (2, 8, 2)
@@ -247,7 +247,7 @@ class CPM_minizinc(SolverInterface):
             The minizinc solver parameters are partly defined in its API:
             https://minizinc-python.readthedocs.io/en/latest/api.html#minizinc.instance.Instance.solve
 
-            Does not store the minizinc.Instance() or minizinc.Result()
+            Does not store the ``minizinc.Instance()`` or ``minizinc.Result()``
         """
 
         # ensure all vars are known to solver

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -392,7 +392,7 @@ class CPM_minizinc(SolverInterface):
     def solver_var(self, cpm_var) -> str:
         """
             Creates solver variable for cpmpy variable
-            or returns from cache if previously created
+            or returns from cache if previously created.
 
             Returns:
                 minizinc-friendly 'string' name of var.
@@ -700,7 +700,7 @@ class CPM_minizinc(SolverInterface):
         """
             Compute all solutions and optionally display the solutions.
 
-            MiniZinc-specific implementation
+            MiniZinc-specific implementation.
 
             Arguments:
                 display:            either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -131,9 +131,10 @@ class CPM_minizinc(SolverInterface):
         """
             Returns solvers supported by MiniZinc on your system
 
-            WARNING, some of them may not actually be installed on your system
-            (namely cplex, gurobi, scip, xpress)
-            the following are bundled in the bundle: chuffed, coin-bc, gecode
+            .. warning::
+                WARNING, some of them may not actually be installed on your system
+                (namely cplex, gurobi, scip, xpress).
+                The following are bundled in the bundle: chuffed, coin-bc, gecode
         """
         import minizinc
         solver_dict = minizinc.default_driver.available_solvers()
@@ -407,8 +408,9 @@ class CPM_minizinc(SolverInterface):
             Returns:
                 minizinc-friendly 'string' name of var.
 
-            XXX WARNING, this assumes it is never given a 'NegBoolView'
-            might not be true... e.g. in revar after solve?
+            .. warning::
+                WARNING, this assumes it is never given a 'NegBoolView'
+                might not be true... e.g. in revar after solve?
         """
         if is_num(cpm_var):
             if cpm_var < -2147483646 or cpm_var > 2147483646:

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -156,8 +156,8 @@ class CPM_minizinc(SolverInterface):
         Constructor of the native solver object
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model() (optional)
-        - subsolver: str, name of a subsolver (optional)
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: str, name of a subsolver (optional)
                           has to be one of solvernames()
         """
         if not self.installed():
@@ -224,9 +224,10 @@ class CPM_minizinc(SolverInterface):
             Creates and calls an Instance with the already created mzn_model and mzn_solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional)
-            - kwargs:      any keyword argument, sets parameters of solver object
-
+                time_limit (float, optional):       maximum solve time in seconds 
+                **kwargs (any keyword argument):    sets parameters of solver object
+                
+            
             Arguments that correspond to solver parameters:
                 - free_search=True              Allow the solver to ignore the search definition within the instance. (Only available when the -f flag is supported by the solver). (Default: 0)
                 - optimisation_level=0          Set the MiniZinc compiler optimisation level. (Default: 1; 0=none, 1=single pass, 2=double pass, 3=root node prop, 4,5=probing)
@@ -392,7 +393,8 @@ class CPM_minizinc(SolverInterface):
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
 
-            Returns minizinc-friendly 'string' name of var
+            Returns:
+                minizinc-friendly 'string' name of var.
 
             XXX WARNING, this assumes it is never given a 'NegBoolView'
             might not be true... e.g. in revar after solve?
@@ -454,10 +456,10 @@ class CPM_minizinc(SolverInterface):
             Decompose globals not supported (and flatten globalfunctions)
             ensure it is a list of constraints
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "count", "nvalue", "alldifferent", "alldifferent_except0", "allequal",
@@ -700,14 +702,15 @@ class CPM_minizinc(SolverInterface):
             MiniZinc-specific implementation
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
-                        default/None: nothing displayed
-                - time_limit: stop after this many seconds (default: None)
-                - solution_limit: stop after this many solutions (default: None)
-                - call_from_model: whether the method is called from a CPMpy Model instance or not
-                - kwargs:      any keyword argument, sets parameters of solver object, overwrites construction-time kwargs
+                display:            either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                                    default/None: nothing displayed
+                time_limit:         stop after this many seconds (default: None)
+                solution_limit:     stop after this many solutions (default: None)
+                call_from_model:    whether the method is called from a CPMpy Model instance or not
+                **kwargs:           any keyword argument, sets parameters of solver object, overwrites construction-time kwargs
 
-            Returns: number of solutions found
+            Returns: 
+                number of solutions found
         """
         # XXX: check that no objective function??
         if self.has_objective():

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -8,6 +8,8 @@
 
     Requires that the 'minizinc' python package is installed:
 
+    .. code-block:: console
+
         $ pip install minizinc
 
     as well as the Minizinc bundled binary packages, downloadable from:

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -79,10 +79,11 @@ class CPM_minizinc(SolverInterface):
 
 
     Creates the following attributes (see parent constructor for more):
-        - mzn_model: object, the minizinc.Model instance
-        - mzn_solver: object, the minizinc.Solver instance
-        - mzn_txt_solve: str, the 'solve' item in text form, so it can be overwritten
-        - mzn_result: object, containing solve results
+
+    - ``mzn_model``: object, the minizinc.Model instance
+    - ``mzn_solver``: object, the minizinc.Solver instance
+    - ``mzn_txt_solve``: str, the 'solve' item in text form, so it can be overwritten
+    - ``mzn_result``: object, containing solve results
 
     The `DirectConstraint`, when used, adds a constraint with that name and the given args to the MiniZinc model.
     """
@@ -221,7 +222,7 @@ class CPM_minizinc(SolverInterface):
         """
             Call the MiniZinc solver
             
-            Creates and calls an Instance with the already created mzn_model and mzn_solver
+            Creates and calls an Instance with the already created ``mzn_model`` and ``mzn_solver``
 
             Arguments:
                 time_limit (float, optional):       maximum solve time in seconds 

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -232,9 +232,17 @@ class CPM_minizinc(SolverInterface):
                 
             
             Arguments that correspond to solver parameters:
-                - free_search=True              Allow the solver to ignore the search definition within the instance. (Only available when the -f flag is supported by the solver). (Default: 0)
-                - optimisation_level=0          Set the MiniZinc compiler optimisation level. (Default: 1; 0=none, 1=single pass, 2=double pass, 3=root node prop, 4,5=probing)
-                - ...                           I am not sure where solver-specific arguments are documented, but the docs say that command line arguments can be passed by ommitting the '-' (e.g. 'f' instead of '-f')?
+
+            =======================  ===========
+            Keyword                  Description
+            =======================  ===========
+            free_search=True              Allow the solver to ignore the search definition within the instance. (Only available when the -f flag is supported by the solver). (Default: 0)
+            optimisation_level=0          Set the MiniZinc compiler optimisation level. (Default: 1; 0=none, 1=single pass, 2=double pass, 3=root node prop, 4,5=probing)
+            =======================  ===========             
+            
+            
+            I am not sure where solver-specific arguments are documented, but the docs say that command line arguments can be passed by ommitting the '-' (e.g. 'f' instead of '-f')?
+            
             The minizinc solver parameters are partly defined in its API:
             https://minizinc-python.readthedocs.io/en/latest/api.html#minizinc.instance.Instance.solve
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -303,8 +303,9 @@ class CPM_ortools(SolverInterface):
 
             'objective()' can be called multiple times, only the last one is stored
 
-            (technical side note: any constraints created during conversion of the objective
-            are premanently posted to the solver)
+            .. note::
+                technical side note: any constraints created during conversion of the objective
+                are premanently posted to the solver
         """
         # make objective function non-nested
         (flat_obj, flat_cons) = flatten_objective(expr)

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -675,7 +675,7 @@ try:
         then retrieve the solution count with ``cb.solution_count()``
 
         Arguments:
-            - verbose whether to print info on every solution found (bool, default: False)
+            verbose (bool, default: False): whether to print info on every solution found 
     """
 
         def __init__(self, verbose=False):
@@ -709,10 +709,10 @@ try:
                 cb = OrtSolutionPrinter(s, display=vars)
                 s.solve(enumerate_all_solutions=True, solution_callback=cb)
 
-            for multiple variabes (single or NDVarArray), use:
-            `cb = OrtSolutionPrinter(s, display=[v, x, z])`
+            For multiple variables (single or NDVarArray), use:
+            ``cb = OrtSolutionPrinter(s, display=[v, x, z])``.
 
-            for a custom print function, use for example:
+            For a custom print function, use for example:
             
             .. code-block:: python
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -140,18 +140,27 @@ class CPM_ortools(SolverInterface):
 
             You can use any of these parameters as keyword argument to `solve()` and they will
             be forwarded to the solver. Examples include:
-                - num_search_workers=8          number of parallel workers (default: 8)
-                - log_search_progress=True      to log the search process to stdout (default: False)
-                - cp_model_presolve=False       to disable presolve (default: True, almost always beneficial)
-                - cp_model_probing_level=0      to disable probing (default: 2, also valid: 1, maybe 3, etc...)
-                - linearization_level=0         to disable linearisation (default: 1, can also set to 2)
-                - optimize_with_core=True       to do max-sat like lowerbound optimisation (default: False)
-                - use_branching_in_lp=True      to generate more info in lp propagator (default: False)
-                - polish_lp_solution=True       to spend time in lp propagator searching integer values (default: False)
-                - symmetry_level=1              only do symmetry breaking in presolve (default: 2, also possible: 0)
 
-            example:
-            o.solve(num_search_workers=8, log_search_progress=True)
+            =============================   ============
+            Argument                        Description
+            =============================   ============
+            ``num_search_workers=8``          number of parallel workers (default: 8)
+            ``log_search_progress=True``      to log the search process to stdout (default: False)
+            ``cp_model_presolve=False``       to disable presolve (default: True, almost always beneficial)
+            ``cp_model_probing_level=0``      to disable probing (default: 2, also valid: 1, maybe 3, etc...)
+            ``linearization_level=0``         to disable linearisation (default: 1, can also set to 2)
+            ``optimize_with_core=True``       to do max-sat like lowerbound optimisation (default: False)
+            ``use_branching_in_lp=True``      to generate more info in lp propagator (default: False)
+            ``polish_lp_solution=True``       to spend time in lp propagator searching integer values (default: False)
+            ``symmetry_level=1``              only do symmetry breaking in presolve (default: 2, also possible: 0)
+            =============================   ============
+           
+
+            Examples:
+
+                .. code-block:: python
+                
+                    o.solve(num_search_workers=8, log_search_progress=True)
 
         """
         from ortools.sat.python import cp_model as ort

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -135,6 +135,7 @@ class CPM_ortools(SolverInterface):
                 solution_callback (an `ort.CpSolverSolutionCallback` object):   CPMpy includes its own, namely `OrtSolutionCounter`. If you want to count all solutions, 
                                                                                 don't forget to also add the keyword argument 'enumerate_all_solutions=True'.
                 
+                
             The ortools solver parameters are defined in its 'sat_parameters.proto' description:
             https://github.com/google/or-tools/blob/stable/ortools/sat/sat_parameters.proto
 
@@ -327,7 +328,7 @@ class CPM_ortools(SolverInterface):
 
             Used especially to post an expression as objective function
 
-            Accepted by ORTools:
+            Accepted by OR-Tools:
             - Decision variable: Var
             - Linear: sum([Var])                                   (CPMpy class 'Operator', name 'sum')
                       wsum([Const],[Var])                          (CPMpy class 'Operator', name 'wsum')
@@ -572,11 +573,11 @@ class CPM_ortools(SolverInterface):
 
     def solution_hint(self, cpm_vars, vals):
         """
-        or-tools supports warmstarting the solver with a feasible solution
+        OR-Tools supports warmstarting the solver with a feasible solution.
 
         More specifically, it will branch that variable on that value first if possible. This is known as 'phase saving' in the SAT literature, but then extended to integer variables.
 
-        The solution hint does NOT need to satisfy all constraints, it should just provide reasonable default values for the variables. It can decrease solving times substantially, especially when solving a similar model repeatedly
+        The solution hint does NOT need to satisfy all constraints, it should just provide reasonable default values for the variables. It can decrease solving times substantially, especially when solving a similar model repeatedly.
 
         :param cpm_vars: list of CPMpy variables
         :param vals: list of (corresponding) values for the variables
@@ -591,7 +592,6 @@ class CPM_ortools(SolverInterface):
 
 
     def get_core(self):
-        from ortools.sat.python import cp_model as ort
         """
             For use with :func:`s.solve(assumptions=[...]) <solve()>`. Only meaningful if the solver returned UNSAT. In that case, ``get_core()`` returns a small subset of assumption variables that are unsat together.
 
@@ -599,10 +599,11 @@ class CPM_ortools(SolverInterface):
 
             Note that there is no guarantee that the core is minimal, though this interface does open up the possibility to add more advanced Minimal Unsatisfiabile Subset algorithms on top. All contributions welcome!
 
-            For pure or-tools example, see http://github.com/google/or-tools/blob/master/ortools/sat/samples/assumptions_sample_sat.py
+            For pure OR-Tools example, see http://github.com/google/or-tools/blob/master/ortools/sat/samples/assumptions_sample_sat.py
 
-            Requires or-tools >= 8.2!!!
+            Requires ortools >= 8.2!!!
         """
+        from ortools.sat.python import cp_model as ort
         assert (self.ort_status == ort.INFEASIBLE), "get_core(): solver must return UNSAT"
         assert (self.assumption_dict is not None),  "get_core(): requires a list of assumption variables, e.g. s.solve(assumptions=[...])"
 
@@ -660,7 +661,7 @@ try:
 
     class OrtSolutionCounter(ort.CpSolverSolutionCallback):
         """
-        Native or-tools callback for solution counting.
+        Native ortools callback for solution counting.
 
         It is based on ortools' built-in `ObjectiveSolutionPrinter`
         but with output printing being optional
@@ -700,7 +701,9 @@ try:
 
     class OrtSolutionPrinter(OrtSolutionCounter):
         """
-            Native or-tools callback for solution printing.
+            Native OR-Tools callback for solution printing.
+
+            Subclasses :class:`OrtSolutionCounter`, see those docs too.
 
             Use with :class:`CPM_ortools` as follows:
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -91,8 +91,8 @@ class CPM_ortools(SolverInterface):
         calling solve(), a prime way to use more advanced solver features
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model() (optional)
-        - subsolver: None, not used
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: None, not used
         """
         if not self.supported():
             raise Exception("CPM_ortools: Install the python package 'ortools' to use this solver interface.")
@@ -124,14 +124,14 @@ class CPM_ortools(SolverInterface):
             Call the CP-SAT solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional)
-            - assumptions: list of CPMpy Boolean variables (or their negation) that are assumed to be true.
-                           For repeated solving, and/or for use with s.get_core(): if the model is UNSAT,
-                           get_core() returns a small subset of assumption variables that are unsat together.
-                           Note: the or-tools interface is stateless, so you can incrementally call solve() with assumptions, but or-tools will always start from scratch...
-            - solution_callback: an `ort.CpSolverSolutionCallback` object. CPMpy includes its own, namely `OrtSolutionCounter`. If you want to count all solutions, don't forget to also add the keyword argument 'enumerate_all_solutions=True'.
-
-            Additional keyword arguments:
+                time_limit (float, optional):  maximum solve time in seconds 
+                assumptions:    list of CPMpy Boolean variables (or their negation) that are assumed to be true.
+                                For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
+                                get_core() returns a small subset of assumption variables that are unsat together.
+                                Note: the or-tools interface is stateless, so you can incrementally call solve() with assumptions, but or-tools will always start from scratch...
+                solution_callback (an `ort.CpSolverSolutionCallback` object):   CPMpy includes its own, namely `OrtSolutionCounter`. If you want to count all solutions, 
+                                                                                don't forget to also add the keyword argument 'enumerate_all_solutions=True'.
+                
             The ortools solver parameters are defined in its 'sat_parameters.proto' description:
             https://github.com/google/or-tools/blob/stable/ortools/sat/sat_parameters.proto
 
@@ -239,12 +239,13 @@ class CPM_ortools(SolverInterface):
             It is just a wrapper around the use of `OrtSolutionPrinter()` in fact.
 
             Arguments:
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping. 
                         default/None: nothing displayed
-                - solution_limit: stop after this many solutions (default: None)
-                - call_from_model: whether the method is called from a CPMpy Model instance or not
+                solution_limit: stop after this many solutions (default: None)
+                call_from_model: whether the method is called from a CPMpy Model instance or not
 
-            Returns: number of solutions found
+            Returns: 
+                number of solutions found
         """
         if self.has_objective():
             raise NotSupportedError("OR-tools does not support finding all optimal solutions.")
@@ -350,10 +351,10 @@ class CPM_ortools(SolverInterface):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         cpm_cons = toplevel_list(cpm_expr)
         supported = {"min", "max", "abs", "element", "alldifferent", "xor", "table", "negative_table", "cumulative", "circuit", "inverse", "no_overlap"}
@@ -380,10 +381,10 @@ class CPM_ortools(SolverInterface):
             the user knows and cares about (and will be populated with a value after solve). All other variables
             are auxiliary variables created by transformations.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: self
+            :return: self
         """
         # add new user vars to the set
         get_variables(cpm_expr, collect=self.user_vars)
@@ -703,10 +704,10 @@ try:
             optionally retrieve the solution count with `cb.solution_count()`
 
             Arguments:
-                - verbose: whether to print info on every solution found (bool, default: False)
-                - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                verbose (bool, default = False): whether to print info on every solution found 
+                display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
                             default/None: nothing displayed
-                - solution_limit: stop after this many solutions (default: None)
+                solution_limit (default = None): stop after this many solutions 
         """
         def __init__(self, solver, display=None, solution_limit=None, verbose=False):
             super().__init__(verbose)

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -62,8 +62,9 @@ class CPM_ortools(SolverInterface):
     https://developers.google.com/optimization/install
 
     Creates the following attributes (see parent constructor for more):
-        - ort_model: the ortools.sat.python.cp_model.CpModel() created by _model()
-        - ort_solver: the ortools cp_model.CpSolver() instance used in solve()
+
+    - ``ort_model``: the ortools.sat.python.cp_model.CpModel() created by _model()
+    - ``ort_solver``: the ortools cp_model.CpSolver() instance used in solve()
 
     The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function on the ``ort_model`` object.
     """

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -65,7 +65,7 @@ class CPM_ortools(SolverInterface):
         - ort_model: the ortools.sat.python.cp_model.CpModel() created by _model()
         - ort_solver: the ortools cp_model.CpSolver() instance used in solve()
 
-    The `DirectConstraint`, when used, calls a function on the `ort_model` object.
+    The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function on the ``ort_model`` object.
     """
 
     @staticmethod
@@ -349,7 +349,7 @@ class CPM_ortools(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
             :param cpm_expr: CPMpy expression, or list thereof
             :type cpm_expr: Expression or list of Expression
@@ -581,7 +581,7 @@ class CPM_ortools(SolverInterface):
     def get_core(self):
         from ortools.sat.python import cp_model as ort
         """
-            For use with s.solve(assumptions=[...]). Only meaningful if the solver returned UNSAT. In that case, get_core() returns a small subset of assumption variables that are unsat together.
+            For use with :func:`s.solve(assumptions=[...]) <solve()>`. Only meaningful if the solver returned UNSAT. In that case, ``get_core()`` returns a small subset of assumption variables that are unsat together.
 
             CPMpy will return only those variables that are False (in the UNSAT core)
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -9,6 +9,8 @@
     The 'ortools' python package is bundled by default with CPMpy.
     It can be installed through `pip`:
 
+    .. code-block:: console
+    
         $ pip install ortools
 
     Google OR-Tools is open source software for combinatorial optimization, which seeks
@@ -655,10 +657,13 @@ try:
         but with output printing being optional
 
         use with CPM_ortools as follows:
-        `cb = OrtSolutionCounter()`
-        `s.solve(enumerate_all_solutions=True, solution_callback=cb)`
 
-        then retrieve the solution count with `cb.solution_count()`
+        .. code-block:: python
+            
+            cb = OrtSolutionCounter()
+            s.solve(enumerate_all_solutions=True, solution_callback=cb)
+
+        then retrieve the solution count with ``cb.solution_count()``
 
         Arguments:
             - verbose whether to print info on every solution found (bool, default: False)
@@ -688,19 +693,23 @@ try:
         """
             Native or-tools callback for solution printing.
 
-            Subclasses OrtSolutionCounter, see those docs too
+            Use with :class:`CPM_ortools` as follows:
 
-            use with CPM_ortools as follows:
-            `cb = OrtSolutionPrinter(s, display=vars)`
-            `s.solve(enumerate_all_solutions=True, solution_callback=cb)`
+            .. code-block:: python
+
+                cb = OrtSolutionPrinter(s, display=vars)
+                s.solve(enumerate_all_solutions=True, solution_callback=cb)
 
             for multiple variabes (single or NDVarArray), use:
             `cb = OrtSolutionPrinter(s, display=[v, x, z])`
 
             for a custom print function, use for example:
-            ```def myprint():
-        print(f"x0={x[0].value()}, x1={x[1].value()}")
-        cb = OrtSolutionPrinter(s, printer=myprint)```
+            
+            .. code-block:: python
+
+                def myprint():
+                    print(f"x0={x[0].value()}, x1={x[1].value()}")
+                    cb = OrtSolutionPrinter(s, printer=myprint)
 
             Optionally retrieve the solution count with ``cb.solution_count()``.
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -19,7 +19,7 @@
     that uses SAT (satisfiability) methods and lazy-clause generation.
 
     Documentation of the solver's own Python API:
-    https://google.github.io/or-tools/python/ortools/sat/python/cp_model.html
+    https://developers.google.com/optimization/reference/python/sat/python/cp_model
 
     ===============
     List of classes

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -702,7 +702,7 @@ try:
         print(f"x0={x[0].value()}, x1={x[1].value()}")
         cb = OrtSolutionPrinter(s, printer=myprint)```
 
-            optionally retrieve the solution count with `cb.solution_count()`
+            Optionally retrieve the solution count with ``cb.solution_count()``.
 
             Arguments:
                 verbose (bool, default = False): whether to print info on every solution found 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -249,7 +249,7 @@ class CPM_pysat(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
             :param cpm_expr: CPMpy expression, or list thereof
             :type cpm_expr: Expression or list of Expression
@@ -366,7 +366,7 @@ class CPM_pysat(SolverInterface):
 
     def get_core(self):
         """
-            For use with s.solve(assumptions=[...]). Only meaningful if the solver returned UNSAT. In that case, get_core() returns a small subset of assumption variables that are unsat together.
+            For use with :func:`s.solve(assumptions=[...]) <solve()>`. Only meaningful if the solver returned UNSAT. In that case, get_core() returns a small subset of assumption variables that are unsat together.
 
             CPMpy will return only those assumptions which are False (in the UNSAT core)
 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -69,7 +69,7 @@ class CPM_pysat(SolverInterface):
     - ``pysat_vpool``: a pysat.formula.IDPool for the variable mapping
     - ``pysat_solver``: a pysat.solver.Solver() (default: glucose4)
 
-    The `DirectConstraint`, when used, calls a function on the `pysat_solver` object.
+    The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function on the ``pysat_solver`` object.
     """
 
     @staticmethod

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -16,7 +16,7 @@
     https://pysathq.github.io/
 
     This solver can be used if the model only has Boolean variables,
-    and only logical constraints (and,or,implies,==,!=) or cardinality constraints.
+    and only logical constraints (`and`, `or`, `implies`, `==`, `!=`) or cardinality constraints.
 
     Documentation of the solver's own Python API:
     https://pysathq.github.io/docs/html/api/solvers.html
@@ -62,8 +62,9 @@ class CPM_pysat(SolverInterface):
     https://pysathq.github.io/installation
 
     Creates the following attributes (see parent constructor for more):
-        - pysat_vpool: a pysat.formula.IDPool for the variable mapping
-        - pysat_solver: a pysat.solver.Solver() (default: glucose4)
+
+    - ``pysat_vpool``: a pysat.formula.IDPool for the variable mapping
+    - ``pysat_solver``: a pysat.solver.Solver() (default: glucose4)
 
     The `DirectConstraint`, when used, calls a function on the `pysat_solver` object.
     """
@@ -226,8 +227,8 @@ class CPM_pysat(SolverInterface):
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
 
-            Transforms cpm_var into CNF literal using self.pysat_vpool
-            (positive or negative integer)
+            Transforms cpm_var into CNF literal using ``self.pysat_vpool``
+            (positive or negative integer).
 
             so vpool is the varmap (we don't use _varmap here)
         """

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -23,8 +23,9 @@
     Documentation of the solver's own Python API:
     https://pysathq.github.io/docs/html/api/solvers.html
 
-    WARNING: CPMpy uses 'model' to refer to a constraint specification,
-    the PySAT docs use 'model' to refer to a solution.
+    .. warning::
+        WARNING: CPMpy uses 'model' to refer to a constraint specification,
+        the PySAT docs use 'model' to refer to a solution.
 
     ===============
     List of classes

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -8,6 +8,8 @@
 
     Requires that the 'python-sat' python package is installed:
 
+    .. code-block:: console
+
         $ pip install python-sat[aiger,approxmc,cryptosat,pblib]
 
     PySAT is a Python (2.7, 3.4+) toolkit, which aims at providing a simple and unified

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -225,12 +225,12 @@ class CPM_pysat(SolverInterface):
     def solver_var(self, cpm_var):
         """
             Creates solver variable for cpmpy variable
-            or returns from cache if previously created
+            or returns from cache if previously created.
 
             Transforms cpm_var into CNF literal using ``self.pysat_vpool``
             (positive or negative integer).
 
-            so vpool is the varmap (we don't use _varmap here)
+            So vpool is the varmap (we don't use _varmap here).
         """
 
         # special case, negative-bool-view

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -110,9 +110,8 @@ class CPM_pysat(SolverInterface):
         Only supports satisfaction problems (no objective)
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model(), optional
-        - subsolver: str, name of the pysat solver, e.g. glucose4
-            see .solvernames() to get the list of available solver(names)
+            cpm_model (Model(), a CPMpy Model(), optional):
+            subsolver (str, name of the pysat solver, e.g. glucose4):  see .solvernames() to get the list of available solver(names)
         """
         if not self.supported():
             raise Exception("CPM_pysat: Install the python package 'python-sat' to use this solver interface "
@@ -150,12 +149,14 @@ class CPM_pysat(SolverInterface):
             Call the PySAT solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional). Auto-interrups in case the
-                           runtime exceeds given time_limit.
-                           Warning: the time_limit is not very accurate at subsecond level
-            - assumptions: list of CPMpy Boolean variables that are assumed to be true.
-                           For use with s.get_core(): if the model is UNSAT, get_core() returns a small subset of assumption variables that are unsat together.
-                           Note: the PySAT interface is statefull, so you can incrementally call solve() with assumptions and it will reuse learned clauses
+                time_limit (float, optional):   Maximum solve time in seconds. Auto-interrups in case the
+                                                runtime exceeds given time_limit.
+                                                
+                                                .. warning::
+                                                    Warning: the time_limit is not very accurate at subsecond level
+                assumptions: list of CPMpy Boolean variables that are assumed to be true.
+                            For use with :func:`s.get_core() <get_core()>`: if the model is UNSAT, get_core() returns a small subset of assumption variables that are unsat together.
+                            Note: the PySAT interface is statefull, so you can incrementally call solve() with assumptions and it will reuse learned clauses
         """
 
         # ensure all vars are known to solver
@@ -250,10 +251,10 @@ class CPM_pysat(SolverInterface):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = decompose_in_tree(cpm_cons)

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -8,6 +8,8 @@
 
     Requires that the 'PySDD' python package is installed:
 
+    .. code-block:: console
+
         $ pip install PySDD
 
     PySDD is a knowledge compilation package for Sentential Decision Diagrams (SDD)
@@ -373,8 +375,11 @@ class CPM_pysdd(SolverInterface):
             Returns a graphviz Dot object
 
             Display (in a notebook) with:
-            import graphviz
-            graphviz.Source(m.dot())
+
+            .. code-block:: python
+
+                import graphviz
+                graphviz.Source(m.dot())
         """
         if self.pysdd_root is None:
             from pysdd.sdd import SddManager

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -150,7 +150,8 @@ class CPM_pysdd(SolverInterface):
         """
             Compute all solutions and optionally display the solutions.
 
-            WARNING: setting 'display' will SIGNIFICANTLY slow down solution counting...
+            .. warning::
+                WARNING: setting 'display' will SIGNIFICANTLY slow down solution counting...
 
             Arguments:
                 - display: either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -62,7 +62,7 @@ class CPM_pysdd(SolverInterface):
     - ``pysdd_manager`` : a pysdd.sdd.SddManager
     - ``pysdd_root`` : a pysdd.sdd.SddNode (changes whenever a formula is added)
 
-    The `DirectConstraint`, when used, calls a function on the `pysdd_manager` object and replaces the root node with a conjunction of the previous root node and the result of this function call.
+    The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function on the ``pysdd_manager`` object and replaces the root node with a conjunction of the previous root node and the result of this function call.
     """
 
     @staticmethod
@@ -109,8 +109,9 @@ class CPM_pysdd(SolverInterface):
             See if an arbitrary model exists
 
             This is a knowledge compiler:
-                - building it is the (computationally) hard part
-                - checking for a solution is trivial after that
+
+            - building it is the (computationally) hard part
+            - checking for a solution is trivial after that
         """
 
         # ensure all vars are known to solver
@@ -240,7 +241,7 @@ class CPM_pysdd(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the ':ref:`Adding a new solver` docs on readthedocs for more information.
 
             For PySDD, it can be beneficial to add a big model (collection of constraints) at once...
 

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -14,7 +14,7 @@
     https://pysdd.readthedocs.io/en/latest/
 
     This solver can ONLY be used for solution checking and enumeration over Boolean variables!
-    That is, only logical constraints (and,or,implies,==,!=) and Boolean global constraints.
+    That is, only logical constraints (`and`, `or`, `implies`, `==`, `!=`) and Boolean global constraints.
 
     Documentation of the solver's own Python API:
     https://pysdd.readthedocs.io/en/latest/classes/SddManager.html
@@ -55,9 +55,10 @@ class CPM_pysdd(SolverInterface):
     https://pysdd.readthedocs.io/en/latest/usage/installation.html
 
     Creates the following attributes (see parent constructor for more):
-        - pysdd_vtree: a pysdd.sdd.Vtree
-        - pysdd_manager: a pysdd.sdd.SddManager
-        - pysdd_root: a pysdd.sdd.SddNode (changes whenever a formula is added)
+
+    - ``pysdd_vtree`` : a pysdd.sdd.Vtree
+    - ``pysdd_manager`` : a pysdd.sdd.SddManager
+    - ``pysdd_root`` : a pysdd.sdd.SddNode (changes whenever a formula is added)
 
     The `DirectConstraint`, when used, calls a function on the `pysdd_manager` object and replaces the root node with a conjunction of the previous root node and the result of this function call.
     """

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -84,8 +84,8 @@ class CPM_pysdd(SolverInterface):
         Only supports satisfaction problems and solution enumeration
 
         Arguments:
-        - cpm_model: Model(), a CPMpy Model(), optional
-        - subsolver: None
+            cpm_model: Model(), a CPMpy Model(), optional
+            subsolver: None
         """
         if not self.supported():
             raise Exception("CPM_pysdd: Install the python package 'pysdd' to use this solver interface")
@@ -155,7 +155,8 @@ class CPM_pysdd(SolverInterface):
                 - time_limit, solution_limit, kwargs: not used
                 - call_from_model: whether the method is called from a CPMpy Model instance or not
 
-            Returns: number of solutions found
+            Returns: 
+                number of solutions found            
         """
         # ensure all vars are known to solver
         self.solver_vars(list(self.user_vars))
@@ -239,10 +240,10 @@ class CPM_pysdd(SolverInterface):
 
             For PySDD, it can be beneficial to add a big model (collection of constraints) at once...
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         # works on list of nested expressions
         cpm_cons = toplevel_list(cpm_expr)

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -46,8 +46,8 @@ class SolverInterface(object):
             Check for support in current system setup. Return True if the system
             has package installed or supports solver, else returns False.
 
-        Returns:
-            [bool]: Solver support by current system setup.
+            Returns:
+                [bool]: Solver support by current system setup.
         """
         return False
 
@@ -119,8 +119,9 @@ class SolverInterface(object):
         """
             Post the given expression to the solver as objective to minimize/maximize
 
-            - expr: Expression, the CPMpy expression that represents the objective function
-            - minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
+            Arguments:
+                expr: Expression, the CPMpy expression that represents the objective function
+                minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
 
             'objective()' can be called multiple times, only the last one is stored
         """
@@ -158,7 +159,7 @@ class SolverInterface(object):
         """
             Returns the value of the objective function of the latest solver run on this model
 
-        :return: an integer or 'None' if it is not run, or a satisfaction problem
+            :return: an integer or 'None' if it is not run, or a satisfaction problem
         """
         return self.objective_value_
 
@@ -186,10 +187,10 @@ class SolverInterface(object):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
         return toplevel_list(cpm_expr)  # replace by the transformations your solver needs
 
@@ -238,7 +239,8 @@ class SolverInterface(object):
                 - call_from_model: whether the method is called from a CPMpy Model instance or not
                 - any other keyword argument
 
-            Returns: number of solutions found
+            Returns: 
+                number of solutions found
         """
         if self.has_objective():
             raise NotSupportedError(f"Solver of type {self} does not support finding all optimal solutions!")

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -123,7 +123,7 @@ class SolverInterface(object):
                 expr: Expression, the CPMpy expression that represents the objective function
                 minimize: Bool, whether it is a minimization problem (True) or maximization problem (False)
 
-            'objective()' can be called multiple times, only the last one is stored
+            ``objective()`` can be called multiple times, only the last one is stored
         """
         raise NotImplementedError("Solver does not support objective functions")
 

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -137,15 +137,15 @@ class SolverInterface(object):
 
             Overwrites self.cpm_status
 
-        :param model: CPMpy model to be parsed.
-        :type model: Model
+            :param model: CPMpy model to be parsed.
+            :type model: Model
 
-        :param time_limit: optional, time limit in seconds
-        :type time_limit: int or float
+            :param time_limit: optional, time limit in seconds
+            :type time_limit: int or float
 
-        :return: Bool:
-            - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
-            - False     if no solution is found
+            :return: Bool:
+                - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
+                - False     if no solution is found
         """
         return False
 
@@ -207,10 +207,10 @@ class SolverInterface(object):
             the user knows and cares about (and will be populated with a value after solve). All other variables
             are auxiliary variables created by transformations.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: self
+            :return: self
         """
         # add new user vars to the set
         get_variables(cpm_expr, collect=self.user_vars)
@@ -301,14 +301,14 @@ class SolverInterface(object):
             Take a CPMpy Model and SolverStatus object and return
             the proper answer (True/False/objective_value)
 
-        :param cpm_status: status extracted from the solver
-        :type cpm_status: SolverStatus
+            :param cpm_status: status extracted from the solver
+            :type cpm_status: SolverStatus
 
-        :param objective_value: None or Int, as computed by solver [DEPRECATED]
+            :param objective_value: None or Int, as computed by solver [DEPRECATED]
 
-        :return: Bool
-            - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
-            - False     if no solution is found
+            :return: Bool
+                - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
+                - False     if no solution is found
         """
         return (cpm_status.exitstatus == ExitStatus.OPTIMAL or \
                 cpm_status.exitstatus == ExitStatus.FEASIBLE)

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -283,12 +283,12 @@ class SolverInterface(object):
 
     def get_core(self):
         """
-        For use with s.solve(assumptions=[...]). Only meaningful if the solver returned UNSAT.
+        For use with :func:`s.solve(assumptions=[...]) <solve()>`. Only meaningful if the solver returned UNSAT.
 
         Typically implemented in SAT-based solvers
         
         Returns a small subset of assumption literals that are unsat together.
-        (a literal is either a `_BoolVarImpl` or a `NegBoolView` in case of its negation, e.g. x or ~x)
+        (a literal is either a :class:`~cpmpy.expressions.variables._BoolVarImpl` or a :class:`~cpmpy.expressions.variables.NegBoolView` in case of its negation, e.g. x or ~x)
         Setting these literals to True makes the model UNSAT, setting any to False makes it SAT
         """
         raise NotSupportedError("Solver does not support unsat core extraction")

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -140,7 +140,7 @@ def get_supported_solvers():
     """
         Returns a list of solvers supported on this machine.
 
-    :return: a list of SolverInterface sub-classes :list[SolverInterface]:
+        :return: a list of SolverInterface sub-classes :list[SolverInterface]:
     """
     warnings.warn("Deprecated, use Model.solvernames() instead, will be removed in stable version", DeprecationWarning)
     return [sv for sv in builtin_solvers if sv.supported()]

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -36,12 +36,12 @@ def param_combinations(all_params, remaining_keys=None, cur_params=None):
         For example usage, see `examples/advanced/hyperparameter_search.py`
         https://github.com/CPMpy/cpmpy/blob/master/examples/advanced/hyperparameter_search.py
 
-        - all_params is a dict of {key: list} items, e.g.:
-          {'val': [1,2], 'opt': [True,False]}
+        - all_params is a dict of `{key: list}` items, e.g.:
+          ``{'val': [1,2], 'opt': [True,False]}``
 
-        - output is an generator over all {key:value} combinations
+        - output is an generator over all `{key:value}` combinations
           of the keys and values. For the example above:
-          generator([{'val':1,'opt':True},{'val':1,'opt':False},{'val':2,'opt':True},{'val':2,'opt':False}])
+          ``generator([{'val':1,'opt':True},{'val':1,'opt':False},{'val':2,'opt':True},{'val':2,'opt':False}])``
     """
     if remaining_keys is None or cur_params is None:
         # init

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -139,6 +139,9 @@ builtin_solvers = [CPM_ortools, CPM_gurobi, CPM_minizinc, CPM_pysat, CPM_exact, 
 def get_supported_solvers():
     """
         Returns a list of solvers supported on this machine.
+       
+        .. deprecated:: 0.9.4
+            Please use :class:`SolverLookup` object instead.
 
         :return: a list of SolverInterface sub-classes :list[SolverInterface]:
     """

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -7,6 +7,8 @@
     Interface to z3's API
 
     Requires that the 'z3-solver' python package is installed:
+
+    .. code-block:: console
     
         $ pip install z3-solver
 
@@ -124,10 +126,11 @@ class CPM_z3(SolverInterface):
             Arguments that correspond to solver parameters:
                 - ... (no common examples yet)
             The full list doesn't seem to be documented online, you have to run its help() function:
-            ```
-            import z3
-            z3.Solver().help()
-            ```
+            
+            .. code-block:: python
+
+                import z3
+                z3.Solver().help()
 
             Warning! Some parameternames in z3 have a '.' in their name,
             such as (arbitrarily chosen): 'sat.lookahead_simplify'

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -58,6 +58,7 @@ class CPM_z3(SolverInterface):
         - z3_solver: object, z3's Solver() object
 
     The `DirectConstraint`, when used, calls a function in the `z3` namespace and `z3_solver.add()`'s the result.
+    The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function in the `z3` namespace and ``z3_solver.add()``'s the result.
     """
 
     @staticmethod
@@ -274,7 +275,7 @@ class CPM_z3(SolverInterface):
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
 
-            See the 'Adding a new solver' docs on readthedocs for more information.
+            See the :ref:`Adding a new solver` docs on readthedocs for more information.
 
             :param cpm_expr: CPMpy expression, or list thereof
             :type cpm_expr: Expression or list of Expression
@@ -464,7 +465,7 @@ class CPM_z3(SolverInterface):
 
     def get_core(self):
         """
-            For use with s.solve(assumptions=[...]). Only meaningful if the solver returned UNSAT. In that case, get_core() returns a small subset of assumption variables that are unsat together.
+            For use with :func:`s.solve(assumptions=[...]) <solve()>`. Only meaningful if the solver returned UNSAT. In that case, get_core() returns a small subset of assumption variables that are unsat together.
 
             CPMpy will return only those variables that are False (in the UNSAT core)
 

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -118,11 +118,11 @@ class CPM_z3(SolverInterface):
             Call the z3 solver
 
             Arguments:
-                - time_limit:  maximum solve time in seconds (float, optional)
-                - assumptions: list of CPMpy Boolean variables (or their negation) that are assumed to be true.
-                            For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
-                            get_core() returns a small subset of assumption variables that are unsat together.
-                - kwargs:      any keyword argument, sets parameters of solver object
+                time_limit (float, optional):       maximum solve time in seconds
+                assumptions:                        list of CPMpy Boolean variables (or their negation) that are assumed to be true.
+                                                    For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
+                                                    get_core() returns a small subset of assumption variables that are unsat together.
+                **kwargs:                           any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
 

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -114,11 +114,11 @@ class CPM_z3(SolverInterface):
             Call the z3 solver
 
             Arguments:
-            - time_limit:  maximum solve time in seconds (float, optional)
-            - assumptions: list of CPMpy Boolean variables (or their negation) that are assumed to be true.
-                           For repeated solving, and/or for use with s.get_core(): if the model is UNSAT,
-                           get_core() returns a small subset of assumption variables that are unsat together.
-            - kwargs:      any keyword argument, sets parameters of solver object
+                - time_limit:  maximum solve time in seconds (float, optional)
+                - assumptions: list of CPMpy Boolean variables (or their negation) that are assumed to be true.
+                            For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
+                            get_core() returns a small subset of assumption variables that are unsat together.
+                - kwargs:      any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
                 - ... (no common examples yet)
@@ -276,10 +276,10 @@ class CPM_z3(SolverInterface):
 
             See the 'Adding a new solver' docs on readthedocs for more information.
 
-        :param cpm_expr: CPMpy expression, or list thereof
-        :type cpm_expr: Expression or list of Expression
+            :param cpm_expr: CPMpy expression, or list thereof
+            :type cpm_expr: Expression or list of Expression
 
-        :return: list of Expression
+            :return: list of Expression
         """
 
         cpm_cons = toplevel_list(cpm_expr)

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -55,9 +55,9 @@ class CPM_z3(SolverInterface):
     https://github.com/Z3Prover/z3#python
 
     Creates the following attributes (see parent constructor for more):
-        - z3_solver: object, z3's Solver() object
+        
+    - ``z3_solver``: object, z3's Solver() object
 
-    The `DirectConstraint`, when used, calls a function in the `z3` namespace and `z3_solver.add()`'s the result.
     The :class:`~cpmpy.expressions.globalconstraints.DirectConstraint`, when used, calls a function in the `z3` namespace and ``z3_solver.add()``'s the result.
     """
 
@@ -246,7 +246,7 @@ class CPM_z3(SolverInterface):
         """
             Post the given expression to the solver as objective to minimize/maximize
 
-            'objective()' can be called multiple times, only the last one is stored
+            ``objective()`` can be called multiple times, only the last one is stored
 
             (technical side note: any constraints created during conversion of the objective
             are premanently posted to the solver)

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -19,7 +19,8 @@
     Documentation of the solver's own Python API:
     https://z3prover.github.io/api/html/namespacez3py.html
 
-    Terminology note: a 'model' for z3 is a solution!
+    .. note::
+        Terminology note: a 'model' for z3 is a solution!
 
     ===============
     List of classes
@@ -132,13 +133,15 @@ class CPM_z3(SolverInterface):
                 import z3
                 z3.Solver().help()
 
-            Warning! Some parameternames in z3 have a '.' in their name,
-            such as (arbitrarily chosen): 'sat.lookahead_simplify'
-            You have to construct a dictionary of keyword arguments upfront:
-            ```
-            params = {"sat.lookahead_simplify": True}
-            s.solve(**params)
-            ```
+            .. warning::
+                Warning! Some parameternames in z3 have a '.' in their name,
+                such as (arbitrarily chosen): ``sat.lookahead_simplify``
+                You have to construct a dictionary of keyword arguments upfront:
+                
+                .. code-block:: python
+
+                    params = {"sat.lookahead_simplify": True}
+                    s.solve(**params)
         """
         import z3
 
@@ -251,8 +254,9 @@ class CPM_z3(SolverInterface):
 
             ``objective()`` can be called multiple times, only the last one is stored
 
-            (technical side note: any constraints created during conversion of the objective
-            are premanently posted to the solver)
+            .. note::
+                technical side note: any constraints created during conversion of the objective
+                are premanently posted to the solver
         """
         import z3
         # objective can be a nested expression for z3

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -125,7 +125,9 @@ class CPM_z3(SolverInterface):
                 - kwargs:      any keyword argument, sets parameters of solver object
 
             Arguments that correspond to solver parameters:
-                - ... (no common examples yet)
+
+            - ... (no common examples yet)
+
             The full list doesn't seem to be documented online, you have to run its help() function:
             
             .. code-block:: python

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -6,11 +6,11 @@
 """
     This file implements helper functions for exporting CPMpy models from and to DIMACS format.
     DIMACS is a textual format to represent CNF problems.
-    The header of the file should be formatted as `p cnf <n_vars> <n_constraints>`
+    The header of the file should be formatted as ``p cnf <n_vars> <n_constraints>``.
     If the number of variables and constraints are not given, it is inferred by the parser.
 
     Each remaining line of the file is formatted as a list of integers.
-    An integer represents a Boolean variable and a negative Boolean variable is represented using a `-` sign.
+    An integer represents a Boolean variable and a negative Boolean variable is represented using a `'-'` sign.
 """
 
 import cpmpy as cp

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -32,7 +32,7 @@ def write_dimacs(model, fname=None):
 
         # TODO: implement pseudoboolean constraints in to_cnf
         :param model: a CPMpy model
-        :fname: optional, file name to write the DIMACS output to
+        :param fname: optional, file name to write the DIMACS output to
     """
 
     constraints = toplevel_list(model.constraints)
@@ -74,8 +74,10 @@ def read_dimacs(fname):
         Read a CPMpy model from a DIMACS formatted file striclty following the specification:
         https://web.archive.org/web/20190325181937/https://www.satcompetition.org/2009/format-benchmarks2009.html
         Note: the p-line has to denote the correct number of variables and clauses
-        :param: fname: the name of the DIMACS file
-        :param: sep: optional, separator used in the DIMACS file, will try to infer if None
+        .. note::
+            The p-line has to denote the correct number of variables and clauses
+        :param fname: the name of the DIMACS file
+        :param sep: optional, separator used in the DIMACS file, will try to infer if None
     """
 
     m = cp.Model()

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -30,7 +30,9 @@ def write_dimacs(model, fname=None):
         Writes CPMpy model to DIMACS format
         Uses the "to_cnf" transformation from CPMpy
 
-        # TODO: implement pseudoboolean constraints in to_cnf
+        .. todo::
+            TODO: implement pseudoboolean constraints in to_cnf
+
         :param model: a CPMpy model
         :param fname: optional, file name to write the DIMACS output to
     """

--- a/cpmpy/tools/dimacs.py
+++ b/cpmpy/tools/dimacs.py
@@ -73,11 +73,12 @@ def write_dimacs(model, fname=None):
 
 def read_dimacs(fname):
     """
-        Read a CPMpy model from a DIMACS formatted file striclty following the specification:
+        Read a CPMpy model from a DIMACS formatted file strictly following the specification:
         https://web.archive.org/web/20190325181937/https://www.satcompetition.org/2009/format-benchmarks2009.html
-        Note: the p-line has to denote the correct number of variables and clauses
+        
         .. note::
             The p-line has to denote the correct number of variables and clauses
+        
         :param fname: the name of the DIMACS file
         :param sep: optional, separator used in the DIMACS file, will try to infer if None
     """

--- a/cpmpy/tools/explain/__init__.py
+++ b/cpmpy/tools/explain/__init__.py
@@ -16,6 +16,7 @@
         mus
         mss
         mcs
+        marco
         utils
 """
 

--- a/cpmpy/tools/explain/marco.py
+++ b/cpmpy/tools/explain/marco.py
@@ -12,7 +12,8 @@ from .utils import make_assump_model
 def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True, return_mcs=True):
     """
         Enumerating minimal unsatisfiable subsets (MUSes) and minimal correction sets (MCSes)
-         of unsatisfiable constraints.
+        of unsatisfiable constraints.
+        
         Iteratively generates a subset of constraints (the seed) and checks whether it is SAT.
         When the seed is SAT, it is grown to an MSS to derive an MCS.
         This MCS is then added to the Map solver as a set to hit

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -28,9 +28,9 @@ def mus(soft, hard=[], solver="ortools"):
         Will extract an unsat core and then shrink the core further
         by repeatedly ommitting one assumption variable.
 
-        :param: soft: soft constraints, list of expressions
-        :param: hard: hard constraints, optional, list of expressions
-        :param: solver: name of a solver, see SolverLookup.solvernames()
+        :param soft: soft constraints, list of expressions
+        :param hard: hard constraints, optional, list of expressions
+        :param solver: name of a solver, see SolverLookup.solvernames()
             "z3" and "gurobi" are incremental, "ortools" restarts the solver
     """
     # make assumption (indicator) variables and soft-constrained model
@@ -179,9 +179,9 @@ def mus_naive(soft, hard=[], solver="ortools"):
         Best to only use for testing on solvers that do not support assumptions.
         For others, use `mus()`
 
-        :param: soft: soft constraints, list of expressions
-        :param: hard: hard constraints, optional, list of expressions
-        :param: solver: name of a solver, see SolverLookup.solvernames()
+        :param soft: soft constraints, list of expressions
+        :param hard: hard constraints, optional, list of expressions
+        :param solver: name of a solver, see SolverLookup.solvernames()
     """
     # ensure toplevel list
     soft = toplevel_list(soft, merge_and=False)

--- a/cpmpy/tools/explain/utils.py
+++ b/cpmpy/tools/explain/utils.py
@@ -21,9 +21,9 @@ from cpmpy.transformations.normalize import toplevel_list
 
 def make_assump_model(soft, hard=[], name=None):
     """
-        Construct implied version of all soft constraints
+        Construct implied version of all soft constraints.
         Can be used to extract cores (see :func:`tools.mus() <cpmpy.tools.explain.mus.mus>`).
-        Provide name for assumption variables with `name` param
+        Provide name for assumption variables with `name` param.
     """
     # ensure toplevel list
     soft2 = toplevel_list(soft, merge_and=False)

--- a/cpmpy/tools/explain/utils.py
+++ b/cpmpy/tools/explain/utils.py
@@ -22,7 +22,7 @@ from cpmpy.transformations.normalize import toplevel_list
 def make_assump_model(soft, hard=[], name=None):
     """
         Construct implied version of all soft constraints
-        Can be used to extract cores (see tools.mus)
+        Can be used to extract cores (see :func:`tools.mus() <cpmpy.tools.explain.mus.mus>`).
         Provide name for assumption variables with `name` param
     """
     # ensure toplevel list

--- a/cpmpy/tools/maximal_propagate.py
+++ b/cpmpy/tools/maximal_propagate.py
@@ -13,11 +13,11 @@ def maximal_propagate(constraints, vars=None, solver="ortools", method="union"):
         Returns all values for variables for which at least one model exists.
         I.e., returns a globally consistent constraint network.
 
-        :param: constraints: list of CPMpy constraints
-        :param: vars: list of variables, optional, list of variables to propagate.
-        :param: solver: name of a solver, see SolverLookup.solvernames().
-                            for faster propgation, use incremental solver such as pysat, z3 or gurobi.
-        :param: method: method of propagation, optional, for large domains, use 'union',
+        :param constraints: list of CPMpy constraints
+        :param vars: list of variables, optional, list of variables to propagate.
+        :param solver: name of a solver, see :func:`SolverLookup.solvernames() <cpmpy.solvers.utils.SolverLookup.solvernames>`
+                            for faster propagation, use incremental solver such as pysat, z3 or gurobi.
+        :param method: method of propagation, optional, for large domains, use 'union',
                                                     for small domains use 'intersect'
     """
     if vars is None or len(vars) == 0:

--- a/cpmpy/tools/tune_solver.py
+++ b/cpmpy/tools/tune_solver.py
@@ -126,9 +126,9 @@ class GridSearchTuner(ParameterTuner):
 
     def tune(self, time_limit=None, max_tries=None, fix_params={}):
         """
-            :param: time_limit: Time budget to run tuner in seconds. Solver will be interrupted when time budget is exceeded
-            :param: max_tries: Maximum number of configurations to test
-            :param: fix_params: Non-default parameters to run solvers with.
+            :param time_limit: Time budget to run tuner in seconds. Solver will be interrupted when time budget is exceeded
+            :param max_tries: Maximum number of configurations to test
+            :param fix_params: Non-default parameters to run solvers with.
         """
         if time_limit is not None:
             start_time = time.time()

--- a/cpmpy/transformations/__init__.py
+++ b/cpmpy/transformations/__init__.py
@@ -23,5 +23,6 @@
         negation
         normalize
         reification
+        safening
         to_cnf
 """

--- a/cpmpy/transformations/__init__.py
+++ b/cpmpy/transformations/__init__.py
@@ -1,5 +1,5 @@
 """
-    Methods to transform CPMpy expressions into other CPMpy expressions
+    Methods to transform CPMpy expressions into other CPMpy expressions.
 
     Input and output are always CPMpy expressions, so transformations can
     be chained and called multiple times, as needed.

--- a/cpmpy/transformations/comparison.py
+++ b/cpmpy/transformations/comparison.py
@@ -1,5 +1,5 @@
 """
-  Transformations regarding Comparison constraints (originally).
+  Transformations regarding :class:`~cpmpy.expressions.core.Comparison` constraints (originally).
   Now, it is regarding numeric expressions in general, including nested ones.
   
   Let with <op> one of == or !=,<,<=,>,>=
@@ -12,7 +12,7 @@
   The NumExpr can be a sum, wsum or global function with a non-bool return type.
     
   This file implements:
-    - only_numexpr_equality():    transforms `NumExpr <op> IV` (also reified) to `(NumExpr == A) & (A <op> IV)` if not supported
+    - :func:`only_numexpr_equality()`:    transforms `NumExpr <op> IV` (also reified) to `(NumExpr == A) & (A <op> IV)` if not supported
 """
 
 import copy

--- a/cpmpy/transformations/comparison.py
+++ b/cpmpy/transformations/comparison.py
@@ -26,7 +26,7 @@ def only_numexpr_equality(constraints, supported=frozenset()):
         transforms `NumExpr <op> IV` to `(NumExpr == A) & (A <op> IV)` if not supported
         also for the reified uses of NumExpr
 
-        :param supported  a (frozen)set of expression names that supports all comparisons in the solver
+        :param supported:  a (frozen)set of expression names that supports all comparisons in the solver
     """
 
     # shallow copy (could support inplace too this way...)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -26,7 +26,7 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
         :param nested: if True, new constraints will have been added to the `_toplevel` list too
         
         Special care taken for unsupported global constraints in reified contexts and for numeric global constraints
-            in a comparison.
+        in a comparison.
 
         Supported numerical global functions remain in the expression tree as is. They can be rewritten using
         :func:`cpmpy.transformations.reification.reify_rewrite`

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -188,6 +188,10 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
 # old way of doing decompositions post-flatten
 # will be removed in any future version!
 def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
+    """
+    .. deprecated:: 0.9.16
+          Please use :func:`decompose_in_tree()` instead.
+    """
     warnings.warn("Deprecated, use `decompose_in_tree()` instead, will be removed in stable version", DeprecationWarning)
     """
         DEPRECATED!!! USE `decompose_in_tree()` instead!
@@ -272,6 +276,10 @@ def decompose_global(lst_of_expr, supported=set(), supported_reif=set()):
     return newlist
 
 def do_decompose(cpm_expr):
+    """
+    .. deprecated:: 0.9.13
+          Please use :func:`decompose_in_tree()` instead.
+    """
     warnings.warn("Deprecated, never meant to be used outside this transformation; will be removed in stable version",
                   DeprecationWarning)
     """

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -19,12 +19,12 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
     """
         Decomposes any global constraint not supported by the solver
         Accepts a list of CPMpy expressions as input and returns a list of CPMpy expressions,
-            if nested is True, new constraints will have been added to the `_toplevel` list too
-
-        - supported: a set of supported global constraints or global functions
-        - supported_reified: a set of supported reified global constraints (globals with Boolean return type only)
-        - toplevel: a list of constraints that should be added toplevel, carried as pass by reference to recursive calls
-
+            
+        :param supported: a set of supported global constraints or global functions
+        :param supported_reified: a set of supported reified global constraints (globals with Boolean return type only)
+        :param _toplevel: a list of constraints that should be added toplevel, carried as pass by reference to recursive calls
+        :param nested: if True, new constraints will have been added to the `_toplevel` list too
+        
         Special care taken for unsupported global constraints in reified contexts and for numeric global constraints
             in a comparison.
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -29,9 +29,9 @@ def decompose_in_tree(lst_of_expr, supported=set(), supported_reified=set(), _to
             in a comparison.
 
         Supported numerical global functions remain in the expression tree as is. They can be rewritten using
-            `cpmpy.transformations.reification.reify_rewrite`
-            The following `bv -> NumExpr <comp> Var/Const` can be rewritten as  [bv -> IV0 <comp> Var/Const, NumExpr == IV0].
-            So even if numerical constraints are not supported in reified context, we can rewrite them to non-reified versions if they are total.
+        :func:`cpmpy.transformations.reification.reify_rewrite`
+        The following `bv -> NumExpr <comp> Var/Const` can be rewritten as  [bv -> IV0 <comp> Var/Const, NumExpr == IV0].
+        So even if numerical constraints are not supported in reified context, we can rewrite them to non-reified versions if they are total.
     """
     if _toplevel is None:
         _toplevel = []

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -84,8 +84,9 @@ of the form specified above.
 The flattening does not promise to do common subexpression elimination or to automatically group
 commutative expressions (``and``, ``or``, ``sum``, ``wsum``, ...) but such optimisations should be added later.
 
-TODO: update behind_the_scenes.rst doc with the new 'flat normal form'
-TODO: small optimisations, e.g. and/or chaining (potentially after negation), see test_flatten
+.. todo::
+    TODO: update behind_the_scenes.rst doc with the new 'flat normal form'
+    TODO: small optimisations, e.g. and/or chaining (potentially after negation), see test_flatten
 """
 import math
 import builtins
@@ -127,8 +128,10 @@ def flatten_constraint(expr):
         output: see definition of 'flat normal form' above.
 
         it will return 'Exception' if something is not supported
-        TODO, what built-in python error is best?
-        RE TODO: we now have custom NotImpl/NotSupported
+
+        .. todo::
+            TODO, what built-in python error is best?
+            RE TODO: we now have custom NotImpl/NotSupported
     """
 
     newlist = []

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -68,7 +68,7 @@ Objective: (up to one nesting)
     - Linear: sum([Var])                                   (CPMpy class 'Operator', name 'sum')
               wsum([Const],[Var])                          (CPMpy class 'Operator', name 'wsum')
 
-The output after calling flatten_model() or flatten_constraint() will ONLY contain expressions
+The output after calling :func:`flatten_model()` or :func:`flatten_constraint()` will ONLY contain expressions
 of the form specified above.
 
 The flattening does not promise to do common subexpression elimination or to automatically group

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -72,7 +72,7 @@ The output after calling :func:`flatten_model()` or :func:`flatten_constraint()`
 of the form specified above.
 
 The flattening does not promise to do common subexpression elimination or to automatically group
-commutative expressions (and, or, sum, wsum, ...) but such optimisations should be added later.
+commutative expressions (``and``, ``or``, ``sum``, ``wsum``, ...) but such optimisations should be added later.
 
 TODO: update behind_the_scenes.rst doc with the new 'flat normal form'
 TODO: small optimisations, e.g. and/or chaining (potentially after negation), see test_flatten

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -15,58 +15,68 @@ The three families of possible constraints are:
 Base constraints: (no nesting)
 ------------------------------
 
-    - Boolean variable
-    - Boolean operators: and([Var]), or([Var])             (CPMpy class 'Operator', is_bool())
-    - Boolean impliciation: Var -> Var                     (CPMpy class 'Operator', is_bool())
-    - Boolean equality: Var == Var                         (CPMpy class 'Comparison')
-                        Var == Constant                    (CPMpy class 'Comparison')
-    - Global constraint (Boolean): global([Var]*)          (CPMpy class 'GlobalConstraint', is_bool())
+=============================  ====================================  ==============
+Boolean variable               ``Var``                                                                                                                                                    
+Boolean operators              ``and([Var])``, ``or([Var])``         :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                        
+Boolean implication            ``Var -> Var``                        :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                                                                                
+Boolean equality               ``Var == Var``, ``Var == Constant``   :class:`~cpmpy.expressions.core.Comparison`                                                                          
+Global constraint (Boolean)    ``global([Var]*)``                    :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                                           
+=============================  ====================================  ==============
 
 Comparison constraints: (up to one nesting on one side)
 -------------------------------------------------------
 
-    - Numeric equality:  Numexpr == Var                    (CPMpy class 'Comparison')
-                         Numexpr == Constant               (CPMpy class 'Comparison')
-    - Numeric disequality: Numexpr != Var                  (CPMpy class 'Comparison')
-                           Numexpr != Constant             (CPMpy class 'Comparison')
-    - Numeric inequality (>=,>,<,<=): Numexpr >=< Var      (CPMpy class 'Comparison')
+===============================  ============================================  ==============
+Numeric equality                 ``Numexpr == Var``, ``Numexpr == Constant``   :class:`~cpmpy.expressions.core.Comparison`
+Numeric disequality              ``Numexpr != Var``, ``Numexpr != Constant``   :class:`~cpmpy.expressions.core.Comparison`
+Numeric inequality (>=,>,<,<=)   ``Numexpr >=< Var``                           :class:`~cpmpy.expressions.core.Comparison`
+===============================  ============================================  ==============                                                    
 
-    Numexpr:
+**Numexpr:**
 
-        - Operator (non-Boolean) with all args Var/constant (examples: +,*,/,mod,wsum)
-                                                           (CPMpy class 'Operator', not is_bool())
-        - Global constraint (non-Boolean) (examples: Max,Min,Element)
-                                                           (CPMpy class 'GlobalConstraint', not is_bool()))
+==================================================  ======================================  ==============
+Operator (non-Boolean) with all args Var/constant   ``+``, ``*``, ``/``, ``mod``, ``wsum``  :class:`~cpmpy.expressions.core.Operator`, not :func:`~cpmpy.expressions.core.Operator.is_bool()`                      
+Global constraint (non-Boolean)                     ``Max``, ``Min``, ``Element``           :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, not :func:`~cpmpy.expressions.core.Operator.is_bool()` 
+==================================================  ======================================  ==============
 
-    wsum: wsum([Const],[Var]) represents sum([Const]*[Var]) # TODO: not implemented yet
+**wsum:**
+
+.. todo::
+    wsum([Const],[Var]) represents sum([Const]*[Var]) # TODO: not implemented yet
 
 Reify/imply constraint: (up to two nestings on one side)
 --------------------------------------------------------
+=================================  =========================================  ==============
+Reification (double implication)   ``Boolexpr == Var``                        :class:`~cpmpy.expressions.core.Comparison`                                                   
+Implication                        ``Boolexpr -> Var``, ``Var -> Boolexpr``   :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()` 
+=================================  =========================================  ==============
 
-    - Reification (double implication): Boolexpr == Var    (CPMpy class 'Comparison')
-    - Implication: Boolexpr -> Var                         (CPMpy class 'Operator', is_bool())
-                   Var -> Boolexpr                         (CPMpy class 'Operator', is_bool())
+**Boolexpr:**
 
-    Boolexpr:
+==================================  =============================  ==============
+Boolean operators                   ``and([Var])``, ``or([Var])``  :class:`~cpmpy.expressions.core.Operator`, not :func:`~cpmpy.expressions.core.Operator.is_bool()`                      
+Boolean equality                    ``Var == Var``                 :class:`~cpmpy.expressions.core.Comparison`                                                                            
+Global constraint (Boolean)         ``global([Var]*)``             :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, :func:`~cpmpy.expressions.core.Operator.is_bool()`     
+Comparison constraint (see above)                                  :class:`~cpmpy.expressions.core.Comparison`       
+==================================  =============================  ==============                                                                     
 
-        - Boolean operators: and([Var]), or([Var])             (CPMpy class 'Operator', is_bool())
-        - Boolean equality: Var == Var                         (CPMpy class 'Comparison')
-        - Global constraint (Boolean): global([Var]*)          (CPMpy class 'GlobalConstraint', is_bool())
-        - Comparison constraint (see above)                    (CPMpy class 'Comparison')
     
-    Reification of a comparison is the most complex case as it can allow up to 3 levels of nesting in total, e.g.:
+Reification of a comparison is the most complex case as it can allow up to 3 levels of nesting in total, e.g.:
 
-        - (wsum([1,2,3],[IV1,IV2,IV3]) > 5) == BV
-        - (IV1 == IV2) == BV
-        - (BV1 == BV2) == BV3
+- (wsum([1,2,3],[IV1,IV2,IV3]) > 5) == BV
+- (IV1 == IV2) == BV
+- (BV1 == BV2) == BV3
 
 Objective: (up to one nesting)
 ------------------------------
+======================  ========================================  ============
+Type                    Example                                   Notes                                                  
+======================  ========================================  ============
+Satisfaction problem    ``None``                                                                                         
+Decision variable       ``Var``                                   :class:`~cpmpy.expressions.core.Operator`, name `sum`  
+Linear                  ``sum([Var])``, ``wsum([Const],[Var])``   :class:`~cpmpy.expressions.core.Operator`, name `wsum` 
+======================  ========================================  ============
 
-    - Satisfaction problem: None
-    - Decision variable: Var
-    - Linear: sum([Var])                                   (CPMpy class 'Operator', name 'sum')
-              wsum([Const],[Var])                          (CPMpy class 'Operator', name 'wsum')
 
 The output after calling :func:`flatten_model()` or :func:`flatten_constraint()` will ONLY contain expressions
 of the form specified above.

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -288,8 +288,11 @@ def flatten_constraint(expr):
 def flatten_objective(expr, supported=frozenset(["sum","wsum"])):
     """
     - Decision variable: Var
-    - Linear: sum([Var])                                   (CPMpy class 'Operator', name 'sum')
-              wsum([Const],[Var])                          (CPMpy class 'Operator', name 'wsum')
+    - Linear: 
+        ======================                       ========
+        sum([Var])                                   (CPMpy class 'Operator', name 'sum')
+        wsum([Const],[Var])                          (CPMpy class 'Operator', name 'wsum')
+        ======================                       ========
     """
     # lets be very explicit here
     if is_any_list(expr):
@@ -371,20 +374,28 @@ def normalized_boolexpr(expr):
     """
         input is any Boolean (is_bool()) expression
         output are all 'flat normal form' Boolean expressions that can be 'reified', meaning that
-            - subexpr == BoolVar
-            - subexpr -> BoolVar
+
+        .. code-block:: text
+
+            subexpr == BoolVar
+            subexpr -> BoolVar
 
         are valid output expressions.
 
         Currently, this is the case for subexpr:
-        - Boolean operators: and([Var]), or([Var])             (CPMpy class 'Operator', is_bool())
-        - Boolean equality: Var == Var                         (CPMpy class 'Comparison')
-        - Global constraint: global([Var]*)                    (CPMpy class 'GlobalConstraint')
-        - Comparison constraint (see elsewhere)                (CPMpy class 'Comparison')
 
-        output: (base_expr, base_cons) with:
-            base_expr: same as 'expr', but all arguments are variables
-            base_cons: list of flat normal constraints
+        =====================================  =============================  ==============
+        Boolean operators                      ``and([Var])``, ``or([Var])``  :class:`~cpmpy.expressions.core.Operator`, not :func:`~cpmpy.expressions.core.Operator.is_bool()`                      
+        Boolean equality                       ``Var == Var``                 :class:`~cpmpy.expressions.core.Comparison`                                                                            
+        Global constraint (Boolean)            ``global([Var]*)``             :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, :func:`~cpmpy.expressions.core.Operator.is_bool()`     
+        Comparison constraint (see elsewhere)                                 :class:`~cpmpy.expressions.core.Comparison`       
+        =====================================  =============================  ==============                                                                     
+
+        Result:
+            (base_expr, base_cons) with:
+            
+            - base_expr: same as 'expr', but all arguments are variables
+            - base_cons: list of flat normal constraints
     """
     assert(not __is_flat_var(expr))
     assert(expr.is_bool()) 
@@ -469,9 +480,11 @@ def normalized_numexpr(expr):
         - Global constraint (non-Boolean) (examples: Max,Min,Element)
                                                            (CPMpy class 'GlobalConstraint', not is_bool()))
 
-        output: (base_expr, base_cons) with:
-            base_expr: same as 'expr', but all arguments are variables
-            base_cons: list of flat normal constraints
+        Result:
+            (base_expr, base_cons) with:
+            
+            - base_expr: same as 'expr', but all arguments are variables
+            - base_cons: list of flat normal constraints
     """
     # XXX a boolexpr is also a valid numexpr... e.g. 30*(iv > 5) + ... see mario obj.
     if __is_flat_var(expr):

--- a/cpmpy/transformations/get_variables.py
+++ b/cpmpy/transformations/get_variables.py
@@ -78,7 +78,7 @@ def get_variables(expr, collect=None):
 
 def print_variables(expr_or_model):
     """
-        Print variables _and their domains_
+        Print variables and their domains
 
         argument 'expr_or_model' can be an expression or a model
     """

--- a/cpmpy/transformations/get_variables.py
+++ b/cpmpy/transformations/get_variables.py
@@ -78,7 +78,7 @@ def get_variables(expr, collect=None):
 
 def print_variables(expr_or_model):
     """
-        Print variables and their domains
+        Print variables **and their domains**
 
         argument 'expr_or_model' can be an expression or a model
     """

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -17,23 +17,38 @@ Linear comparison:
 
 Indicator constraints:
 ----------------------
-- BoolVar -> LinExpr == Constant
-- BoolVar -> LinExpr >= Constant
-- BoolVar -> LinExpr <= Constant
 
-- BoolVar -> GenExpr                    (GenExpr.name in supported, GenExpr.is_bool())
-- BoolVar -> GenExpr >= Var/Constant    (GenExpr.name in supported, GenExpr.is_num())
-- BoolVar -> GenExpr <= Var/Constant    (GenExpr.name in supported, GenExpr.is_num())
-- BoolVar -> GenExpr == Var/Constant    (GenExpr.name in supported, GenExpr.is_num())
++------------------------------------+
+| ``BoolVar -> LinExpr == Constant`` |
++------------------------------------+
+| ``BoolVar -> LinExpr >= Constant`` |
++------------------------------------+
+| ``BoolVar -> LinExpr <= Constant`` |
++------------------------------------+
+
++-----------------------------------------+-------------------------------------------------+
+| ``BoolVar -> GenExpr``                  |  (GenExpr.name in supported, GenExpr.is_bool()) |
++-----------------------------------------+-------------------------------------------------+
+| ``BoolVar -> GenExpr >= Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
++-----------------------------------------+-------------------------------------------------+
+| ``BoolVar -> GenExpr <= Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
++-----------------------------------------+-------------------------------------------------+
+| ``BoolVar -> GenExpr == Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
++-----------------------------------------+-------------------------------------------------+
 
 Where BoolVar is a boolean variable or its negation.
 
 General comparisons or expressions
 -----------------------------------
-- GenExpr                               (GenExpr.name in supported, GenExpr.is_bool())
-- GenExpr == Var/Constant               (GenExpr.name in supported, GenExpr.is_num())
-- GenExpr <= Var/Constant               (GenExpr.name in supported, GenExpr.is_num())
-- GenExpr >= Var/Constant               (GenExpr.name in supported, GenExpr.is_num())
++------------------------------+-------------------------------------------------+
+| ``GenExpr``                  | (GenExpr.name in supported, GenExpr.is_bool())  |
++------------------------------+-------------------------------------------------+
+| ``GenExpr == Var/Constant``  | (GenExpr.name in supported, GenExpr.is_num())   |
++------------------------------+-------------------------------------------------+
+| ``GenExpr <= Var/Constant``  | (GenExpr.name in supported, GenExpr.is_num())   |
++------------------------------+-------------------------------------------------+
+| ``GenExpr >= Var/Constant``  | (GenExpr.name in supported, GenExpr.is_num())   |
++------------------------------+-------------------------------------------------+
 
 
 """

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -10,10 +10,11 @@ Linear comparison:
 - LinExpr >= Constant
 - LinExpr <= Constant
 
-    LinExpr can be any of:
-        - NumVar
-        - sum
-        - wsum
+LinExpr can be any of:
+
+- NumVar
+- sum
+- wsum
 
 Indicator constraints:
 ----------------------

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -64,10 +64,10 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum"}, reified=False):
     """
     Transforms all constraints to a linear form.
     This function assumes all constraints are in 'flat normal form' with only boolean variables on the lhs of an implication.
-    Only apply after 'cpmpy.transformations.flatten_model.flatten_constraint()' 'and only_implies()'.
+    Only apply after :func:'cpmpy.transformations.flatten_model.flatten_constraint()' and :func:'cpmpy.transformations.reification.only_implies()'.
 
-    `AllDifferent` has a special linearization and is decomposed as such if not in `supported`.
-    Any other unsupported global constraint should be decomposed using `cpmpy.transformations.decompose_global.decompose_global()`
+    :class:`~cpmpy.expressions.globalconstraints.AllDifferent` has a special linearization and is decomposed as such if not in `supported`.
+    Any other unsupported global constraint should be decomposed using :func:`cpmpy.transformations.decompose_global.decompose_in_tree()`
 
     """
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -27,29 +27,25 @@ Indicator constraints:
 | ``BoolVar -> LinExpr <= Constant`` |
 +------------------------------------+
 
-+-----------------------------------------+-------------------------------------------------+
-| ``BoolVar -> GenExpr``                  |  (GenExpr.name in supported, GenExpr.is_bool()) |
-+-----------------------------------------+-------------------------------------------------+
-| ``BoolVar -> GenExpr >= Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
-+-----------------------------------------+-------------------------------------------------+
-| ``BoolVar -> GenExpr <= Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
-+-----------------------------------------+-------------------------------------------------+
-| ``BoolVar -> GenExpr == Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
-+-----------------------------------------+-------------------------------------------------+
+========================================   ==============================================
+``BoolVar -> GenExpr``                     (GenExpr.name in supported, GenExpr.is_bool()) 
+``BoolVar -> GenExpr >= Var/Constant``     (GenExpr.name in supported, GenExpr.is_num())  
+``BoolVar -> GenExpr <= Var/Constant``     (GenExpr.name in supported, GenExpr.is_num())  
+``BoolVar -> GenExpr == Var/Constant``     (GenExpr.name in supported, GenExpr.is_num())  
+========================================   ==============================================
 
 Where ``BoolVar`` is a boolean variable or its negation.
 
 General comparisons or expressions
 -----------------------------------
-+------------------------------+-------------------------------------------------+
-| ``GenExpr``                  | (GenExpr.name in supported, GenExpr.is_bool())  |
-+------------------------------+-------------------------------------------------+
-| ``GenExpr == Var/Constant``  | (GenExpr.name in supported, GenExpr.is_num())   |
-+------------------------------+-------------------------------------------------+
-| ``GenExpr <= Var/Constant``  | (GenExpr.name in supported, GenExpr.is_num())   |
-+------------------------------+-------------------------------------------------+
-| ``GenExpr >= Var/Constant``  | (GenExpr.name in supported, GenExpr.is_num())   |
-+------------------------------+-------------------------------------------------+
+
+============================  ==============================================
+``GenExpr``                   (GenExpr.name in supported, GenExpr.is_bool())  
+``GenExpr == Var/Constant``   (GenExpr.name in supported, GenExpr.is_num())  
+``GenExpr <= Var/Constant``   (GenExpr.name in supported, GenExpr.is_num())  
+``GenExpr >= Var/Constant``   (GenExpr.name in supported, GenExpr.is_num()) 
+============================  ============================================== 
+
 
 
 """

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -37,7 +37,7 @@ Indicator constraints:
 | ``BoolVar -> GenExpr == Var/Constant``  |  (GenExpr.name in supported, GenExpr.is_num())  |
 +-----------------------------------------+-------------------------------------------------+
 
-Where BoolVar is a boolean variable or its negation.
+Where ``BoolVar`` is a boolean variable or its negation.
 
 General comparisons or expressions
 -----------------------------------

--- a/cpmpy/transformations/negation.py
+++ b/cpmpy/transformations/negation.py
@@ -130,6 +130,10 @@ def recurse_negation(expr):
 
 
 def negated_normal(expr):
+    """
+    .. deprecated:: 0.9.16
+          Please use :func:`recurse_negation()` instead.
+    """
     warnings.warn("Deprecated, use `recurse_negation()` instead which will negate and push down all negations in "
                   "the expression (or use `push_down_negation` on the full expression tree); will be removed in "
                   "stable version", DeprecationWarning)

--- a/cpmpy/transformations/negation.py
+++ b/cpmpy/transformations/negation.py
@@ -13,9 +13,9 @@ from ..expressions.utils import is_any_list, is_bool, is_boolexpr
 def push_down_negation(lst_of_expr, toplevel=True):
     """
         Transformation that checks all elements from the list,
-        and pushes down any negation it finds with the `recurse_negation()` function.
+        and pushes down any negation it finds with the :func:`recurse_negation()` function.
 
-        Assumes the input is a list (typically from `toplevel_list()`) en ensures the output is
+        Assumes the input is a list (typically from :func:`~cpmpy.transformations.normalize.toplevel_list()`) en ensures the output is
         a toplevel_list if the input was.
     """
     if isinstance(lst_of_expr, np.ndarray) and not (lst_of_expr.dtype == object):
@@ -68,8 +68,8 @@ def recurse_negation(expr):
         Negate 'expr' by pushing the negation down into it and its args
 
         Comparison: swap comparison sign
-        Operator.is_bool(): apply DeMorgan
-        Global: leave "NOT" operator before global constraint. Use `decompose_globals` for this (AFTER ISSUE #293)
+        :func:`Operator.is_bool() <cpmpy.expressions.core.Operator.is_bool()>`: apply DeMorgan
+        Global: leave "NOT" operator before global constraint. Use :func:`cpmpy.transformations.decompose_global.decompose_in_tree()` for this (AFTER ISSUE #293)
     """
 
     if isinstance(expr, (_BoolVarImpl,BoolVal)):

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -17,8 +17,9 @@ def toplevel_list(cpm_expr, merge_and=True):
     """
     unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with :func:`~cpmpy.expressions.core.Expression.is_bool()` true.
 
-    :param cpm_expr: Expression or list of Expressions
-    :param merge_and: if True then a toplevel 'and' will have its arguments merged at top level
+    Arguments:
+        cpm_expr:   Expression or list of Expressions
+        merge_and:  if True then a toplevel 'and' will have its arguments merged at top level
     """
     # very efficient version with limited function lookups and list operations
     def unravel(lst, append):
@@ -50,7 +51,8 @@ def simplify_boolean(lst_of_expr, num_context=False):
     removes boolean constants from all CPMpy expressions
     only resulting boolean constant is literal 'false'
     
-    :param list_of_expr: list of CPMpy expressions
+    Arguments:
+        list_of_expr: list of CPMpy expressions
     """
 
     newlist = []

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -17,8 +17,8 @@ def toplevel_list(cpm_expr, merge_and=True):
     """
     unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with `.is_bool()` true.
 
-    - cpm_expr: Expression or list of Expressions
-    - merge_and: if True then a toplevel 'and' will have its arguments merged at top level
+    :param cpm_expr: Expression or list of Expressions
+    :param merge_and: if True then a toplevel 'and' will have its arguments merged at top level
     """
     # very efficient version with limited function lookups and list operations
     def unravel(lst, append):
@@ -49,7 +49,8 @@ def simplify_boolean(lst_of_expr, num_context=False):
     """
     removes boolean constants from all CPMpy expressions
     only resulting boolean constant is literal 'false'
-    - list_of_expr: list of CPMpy expressions
+    
+    :param list_of_expr: list of CPMpy expressions
     """
 
     newlist = []

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -15,7 +15,7 @@ from ..expressions.globalconstraints import GlobalConstraint
 
 def toplevel_list(cpm_expr, merge_and=True):
     """
-    unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with `.is_bool()` true.
+    unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with :func:`~cpmpy.expressions.core.Expression.is_bool()` true.
 
     :param cpm_expr: Expression or list of Expressions
     :param merge_and: if True then a toplevel 'and' will have its arguments merged at top level

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -3,25 +3,21 @@
 
     There are three types of reification (BV=BoolVar, BE=BoolExpr):
 
-    +--------------+------------------------------------------------------------+
-    | ``BV -> BE`` | single implication, from var to expression                 |
-    +--------------+------------------------------------------------------------+
-    | ``BV <- BE`` | single implication, from expression to var                 |
-    +--------------+------------------------------------------------------------+
-    | ``BE == BV`` | full reification / double implication (e.g. ``BV <-> BE``) |
-    +--------------+------------------------------------------------------------+
+    =============  ============================================================
+    ``BV -> BE``   single implication, from var to expression                 
+    ``BV <- BE``   single implication, from expression to var                
+    ``BE == BV``   full reification / double implication (e.g. ``BV <-> BE``) 
+    =============  ============================================================
 
     Using logical operations, they can be decomposed and rewritten to each other.
 
     This file implements:
 
-    +---------------------------+------------------------------------------------------------------+
-    | :func:`only_bv_reifies()` | transforms all reifications to ``BV -> BE`` or ``BV == BE``      |
-    +---------------------------+------------------------------------------------------------------+
-    | :func:`only_implies()`    | transforms all reifications to ``BV -> BE`` form                 |
-    +---------------------------+------------------------------------------------------------------+
-    | :func:`reify_rewrite()`   | rewrites reifications not supported by a solver to ones that are |
-    +---------------------------+------------------------------------------------------------------+
+    ==========================  =================================================================
+    :func:`only_bv_reifies()`   transforms all reifications to ``BV -> BE`` or ``BV == BE``      
+    :func:`only_implies()`      transforms all reifications to ``BV -> BE`` form                 
+    :func:`reify_rewrite()`     rewrites reifications not supported by a solver to ones that are 
+    ==========================  =================================================================
 """
 import copy
 from ..expressions.core import Operator, Comparison, Expression

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -57,7 +57,7 @@ def only_bv_reifies(constraints):
 
 def only_implies(constraints):
     """
-        Transforms all reifications to BV -> BE form
+        Transforms all reifications to ``BV -> BE`` form
 
         More specifically:
 
@@ -69,7 +69,7 @@ def only_implies(constraints):
             BV == BE :: ~BV -> ~BE, BV -> BE
 
         Assumes all constraints are in 'flat normal form' and all reifications have a variable in lhs. Hence, only apply
-        AFTER `flatten()` and 'only_bv_reifies()'.
+        AFTER :func:`~cpmpy.transformations.flatten_model.flatten_constraint()` and :func:`only_bv_reifies()`.
     """
     newcons = []
     retransform = []
@@ -118,7 +118,7 @@ def reify_rewrite(constraints, supported=frozenset()):
         to a version that uses standard constraints and reification over equalities between variables.
 
         Input is expected to be in Flat Normal Form without unsupported globals present.
-        (so after `flatten_constraint()` and 'decompose_global()')
+        (so after :func:`~cpmpy.transformations.flatten_model.flatten_constraint()` and :func:`~cpmpy.transformations.decompose_global.decompose_global()`)
         Output will also be in Flat Normal Form
 
         Boolean expressions ``and``, ``or``, and ``->`` and comparison expression ``IV1==IV2`` are assumed to support reification

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -2,16 +2,26 @@
   Transformations regarding reification constraints.
 
   There are three types of reification (BV=BoolVar, BE=BoolExpr):
-    - BV -> BE      single implication, from var to expression
-    - BV <- BE      single implication, from expression to var
-    - BE == BV      full reification / double implication (e.g. BV <-> BE)
+
+    +--------------+------------------------------------------------------------+
+    | ``BV -> BE`` | single implication, from var to expression                 |
+    +--------------+------------------------------------------------------------+
+    | ``BV <- BE`` | single implication, from expression to var                 |
+    +--------------+------------------------------------------------------------+
+    | ``BE == BV`` | full reification / double implication (e.g. ``BV <-> BE``) |
+    +--------------+------------------------------------------------------------+
 
   Using logical operations, they can be decomposed and rewritten to each other.
 
   This file implements:
-    - only_bv_reifies():    transforms all reifications to BV -> BE or BV == BE
-    - only_implies():       transforms all reifications to BV -> BE form
-    - reify_rewrite():      rewrites reifications not supported by a solver to ones that are
+
+    +---------------------------+------------------------------------------------------------------+
+    | :func:`only_bv_reifies()` | transforms all reifications to ``BV -> BE`` or ``BV == BE``      |
+    +---------------------------+------------------------------------------------------------------+
+    | :func:`only_implies()`    | transforms all reifications to ``BV -> BE`` form                 |
+    +---------------------------+------------------------------------------------------------------+
+    | :func:`reify_rewrite()`   | rewrites reifications not supported by a solver to ones that are |
+    +---------------------------+------------------------------------------------------------------+
 """
 import copy
 from ..expressions.core import Operator, Comparison, Expression

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -112,7 +112,7 @@ def reify_rewrite(constraints, supported=frozenset()):
         (actually currently all comparisons <op> in {'==', '!=', '<=', '<', '>=', '>'},
          IV1 <op> IV2 are assumed to support reification BV -> (IV1 <op> IV2))
 
-        :param supported  a (frozen)set of expression names that support reification in the solver, including
+        :param supported: a (frozen)set of expression names that support reification in the solver, including
                           supported 'Left Hand Side (LHS)' expressions in reified comparisons, e.g. BV -> (LHS == V)
     """
     if not is_any_list(constraints):

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -108,12 +108,12 @@ def reify_rewrite(constraints, supported=frozenset()):
         (so after `flatten_constraint()` and 'decompose_global()')
         Output will also be in Flat Normal Form
 
-        Boolean expressions 'and', 'or', and '->' and comparison expression 'IV1==IV2' are assumed to support reification
+        Boolean expressions ``and``, ``or``, and ``->`` and comparison expression ``IV1==IV2`` are assumed to support reification
         (actually currently all comparisons <op> in {'==', '!=', '<=', '<', '>=', '>'},
-         IV1 <op> IV2 are assumed to support reification BV -> (IV1 <op> IV2))
+        ``IV1 <op> IV2`` are assumed to support reification ``BV -> (IV1 <op> IV2)``)
 
         :param supported: a (frozen)set of expression names that support reification in the solver, including
-                          supported 'Left Hand Side (LHS)' expressions in reified comparisons, e.g. BV -> (LHS == V)
+                          supported 'Left Hand Side (LHS)' expressions in reified comparisons, e.g. ``BV -> (LHS == V)``
     """
     if not is_any_list(constraints):
         # assume list, so make list

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -1,7 +1,7 @@
 """
-  Transformations regarding reification constraints.
+    Transformations regarding reification constraints.
 
-  There are three types of reification (BV=BoolVar, BE=BoolExpr):
+    There are three types of reification (BV=BoolVar, BE=BoolExpr):
 
     +--------------+------------------------------------------------------------+
     | ``BV -> BE`` | single implication, from var to expression                 |
@@ -11,9 +11,9 @@
     | ``BE == BV`` | full reification / double implication (e.g. ``BV <-> BE``) |
     +--------------+------------------------------------------------------------+
 
-  Using logical operations, they can be decomposed and rewritten to each other.
+    Using logical operations, they can be decomposed and rewritten to each other.
 
-  This file implements:
+    This file implements:
 
     +---------------------------+------------------------------------------------------------------+
     | :func:`only_bv_reifies()` | transforms all reifications to ``BV -> BE`` or ``BV == BE``      |

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -50,6 +50,9 @@ def only_implies(constraints):
         Transforms all reifications to BV -> BE form
 
         More specifically:
+
+        .. code-block:: text
+
             BV0 -> BV2 == BV3 :: BV0 -> (BV2->BV3 & BV3->BV2)
                               :: BV0 -> (BV2->BV3) & BV0 -> (BV3->BV2)
                               :: BV0 -> (~BV2|BV3) & BV0 -> (~BV3|BV2)

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -1,3 +1,6 @@
+"""
+"""
+
 from copy import copy
 
 from ..expressions.variables import _NumVarImpl, boolvar, intvar, NDVarArray, cpm_array

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -52,10 +52,10 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
         to know the specifics of the partial function being made total.
 
 
-        :param: list_of_expr: list of CPMpy expressions
-        :param: _toplevel: list of new expressions to put toplevel (used internally)
-        :param: _nbc: list of new expressions to put in nearest Boolean context (used internally)
-        :param: safen toplevel: list of expression types that need to be safened, even when toplevel. Used when
+        :param list_of_expr: list of CPMpy expressions
+        :param _toplevel: list of new expressions to put toplevel (used internally)
+        :param _nbc: list of new expressions to put in nearest Boolean context (used internally)
+        :param safen toplevel: list of expression types that need to be safened, even when toplevel. Used when
                                  a solver does not support unsafe values in it's API (e.g., OR-Tools for `div`).
     """
 

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -26,7 +26,7 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
         following the **relational semantics** as discussed in:
             Frisch, Alan M., and Peter J. Stuckey. "The proper treatment of undefinedness in
             constraint languages." International Conference on Principles and Practice of Constraint
-             Programming. Berlin, Heidelberg: Springer Berlin Heidelberg, 2009.
+            Programming. Berlin, Heidelberg: Springer Berlin Heidelberg, 2009.
 
         Under the relational semantic, an 'undefined' output for a (numerical) expression should
         propagate to `False` in the nearest Boolean parent expression. In the above example: `idx` should
@@ -201,7 +201,7 @@ def _safen_hole(cpm_expr, exclude, idx_to_safen):
         Examples include `div` where 0 has to be removed from the denominator
 
         Constructs an expression for each interval of safe values, and
-            introduces a new `output_var` variable
+        introduces a new `output_var` variable
 
         :param cpm_expr: The numerical expression to safen
         :param exclude: The domain value to exclude

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -12,14 +12,15 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
         A partial function is a function whose output is not defined for all possible inputs.
 
         In CPMpy, this is the case for the following 3 numeric functions:
-            - (Integer) division 'x // y': undefined when y=0
-            - Modulo 'x mod y': undefined when y=0
-            - Element 'Arr[idx]': undefined when idx is not in the range of Arr
+
+        - (Integer) division ``x // y``: undefined when y=0
+        - Modulo ``x mod y``: undefined when y=0
+        - Element ``Arr[idx]``: undefined when idx is not in the range of Arr
 
         A toplevel constraint must always be true, so constraint solvers simply propagate the 'unsafe'
         value(s) away. However, CPMpy allows arbitrary nesting and reification of constraints, so an
-        expression like `b <-> (Arr[idx] == 5)` is allowed, even when variable `idx` goes outside the bounds of `Arr`.
-        Should idx be restricted to be in-bounds? and what value should 'b' take if it is out-of-bounds?
+        expression like ``b <-> (Arr[idx] == 5)`` is allowed, even when variable `idx` goes outside the bounds of `Arr`.
+        Should `idx` be restricted to be in-bounds? and what value should 'b' take if it is out-of-bounds?
 
         This transformation will transform a partial function (e.g. Arr[idx]) into a total function
         following the **relational semantics** as discussed in:
@@ -31,8 +32,8 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
         propagate to `False` in the nearest Boolean parent expression. In the above example: `idx` should
         be allowed to take a value outside the bounds of `Arr`, and `b` should be False in that case.
 
-        To enable this, we want to rewrite an expression like `b <-> (partial == 5)` to something like
-        `b <-> (is_defined & (total == 5))`. The key idea is to create a copy of the potentially unsafe
+        To enable this, we want to rewrite an expression like ``b <-> (partial == 5)`` to something like
+        ``b <-> (is_defined & (total == 5))``. The key idea is to create a copy of the potentially unsafe
         argument, that can only take 'safe' values. Using this new argument in the original expression results
         in a total function. We now have the original argument variable, which is decoupled from the expression,
         and a new 'safe' argument variable which is used in the expression. The `is_defined` flag serves two
@@ -40,9 +41,9 @@ def no_partial_functions(lst_of_expr, _toplevel=None, _nbc=None, safen_toplevel=
         argument must equal the original argument so the two are coupled again. If `is_defined` is false, the new
         argument remains decoupled (can take any value, as will the function's output).
 
-        WARNING! Under the relational semantics, `b <-> ~(partial==5)` and `b <-> (partial!=5) mean
-        different things! The second is `b <-> (is_defined & (total!=5))` the first is
-        `b <-> (~is_defined | (total!=5)).
+        WARNING! Under the relational semantics, ``b <-> ~(partial==5)`` and ``b <-> (partial!=5)`` mean
+        different things! The second is ``b <-> (is_defined & (total!=5))`` the first is
+        ``b <-> (~is_defined | (total!=5))``.
 
 
         A clever observation of the implementation below is that for the above 3 expressions, the 'safe'

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -28,8 +28,9 @@ def to_cnf(constraints):
     """
         Converts all logical constraints into Conjunctive Normal Form
 
-        :param constraints: list[Expression] or Operator
-        :param supported: (frozen)set of global constraint names that do not need to be decomposed
+        Arguments:
+            constraints:    list[Expression] or Operator
+            supported:      (frozen)set of global constraint names that do not need to be decomposed
     """
     fnf = flatten_constraint(constraints)
     fnf = only_implies(fnf)
@@ -53,8 +54,8 @@ def flat2cnf(constraints):
         We do it in a principled way for each of the cases. (in)equalities
         get transformed into implications, everything is modular.
 
-        
-        :param constraints: list[Expression] or Operator
+        Arguments:
+            constraints: list[Expression] or Operator
     """
     cnf = []
     for expr in constraints:

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -10,13 +10,14 @@
   auxiliary variables.
 
   What is then left to do is to tseitin encode the following into CNF:
-  - BV with BV a BoolVar (or NegBoolView)
-  - or([BV]) constraint
-  - and([BV]) constraint
-  - BE != BV  with BE :: BV|or()|and()|BV!=BV|BV==BV|BV->BV
-  - BE == BV
-  - BE -> BV
-  - BV -> BE
+
+  - ``BV`` with BV a ``BoolVar`` (or ``NegBoolView``)
+  - ``or([BV])`` constraint
+  - ``and([BV])`` constraint
+  - ``BE != BV``  with ``BE :: BV|or()|and()|BV!=BV|BV==BV|BV->BV``
+  - ``BE == BV``
+  - ``BE -> BV``
+  - ``BV -> BE``
 """
 from ..expressions.core import Operator
 from ..expressions.variables import _BoolVarImpl
@@ -41,13 +42,13 @@ def flat2cnf(constraints):
 
         What is now left to do is to tseitin encode:
 
-  - BV with BV a BoolVar (or NegBoolView)
-  - or([BV]) constraint
-  - and([BV]) constraint
-  - BE != BV  with BE :: BV|or()|and()|BV!=BV|BV==BV|BV->BV
-  - BE == BV
-  - BE -> BV
-  - BV -> BE
+        - ``BV`` with BV a ``BoolVar`` (or ``NegBoolView``)
+        - ``or([BV])`` constraint
+        - ``and([BV])`` constraint
+        - ``BE != BV``  with ``BE :: BV|or()|and()|BV!=BV|BV==BV|BV->BV``
+        - ``BE == BV``
+        - ``BE -> BV``
+        - ``BV -> BE``
 
         We do it in a principled way for each of the cases. (in)equalities
         get transformed into implications, everything is modular.

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -1,6 +1,6 @@
 """
   Converts the logical constraints into disjuctions using the tseitin transform,
-        including flattening global constraints that are is_bool() and not in `supported`.
+        including flattening global constraints that are :func:`~cpmpy.expressions.core.Expression.is_bool()` and not in `supported`.
   
   Other constraints are copied verbatim so this transformation
   can also be used in non-pure CNF settings
@@ -37,7 +37,7 @@ def to_cnf(constraints):
 def flat2cnf(constraints):
     """
         Converts from 'flat normal form' all logical constraints into Conjunctive Normal Form,
-        including flattening global constraints that are is_bool() and not in `supported`.
+        including flattening global constraints that are :func:`~cpmpy.expressions.core.Expression.is_bool()` and not in `supported`.
 
         What is now left to do is to tseitin encode:
 

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -27,9 +27,8 @@ def to_cnf(constraints):
     """
         Converts all logical constraints into Conjunctive Normal Form
 
-        Arguments:
-        - constraints: list[Expression] or Operator
-        - supported: (frozen)set of global constraint names that do not need to be decomposed
+        :param constraints: list[Expression] or Operator
+        :param supported: (frozen)set of global constraint names that do not need to be decomposed
     """
     fnf = flatten_constraint(constraints)
     fnf = only_implies(fnf)

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -53,8 +53,8 @@ def flat2cnf(constraints):
         We do it in a principled way for each of the cases. (in)equalities
         get transformed into implications, everything is modular.
 
-        Arguments:
-        - constraints: list[Expression] or Operator
+        
+        :param constraints: list[Expression] or Operator
     """
     cnf = []
     for expr in constraints:

--- a/docs/adding_solver.md
+++ b/docs/adding_solver.md
@@ -15,6 +15,8 @@ Implementing the template consists of the following parts:
   * `__add__()` where you call transform and map the resulting CPMpy expressions, that the solver supports, to API function calls on the underlying solver
   * `solveAll()` optionally, if the solver natively supports solution enumeration
 
+For your new solver to appear in CPMpy's [API documentation](./api/solvers.rst), add a `.rst` file in ``/docs/api/solvers`` (copy one of the other solvers' file and make the necessary changes) and add your solver to the *"List of submodules"* and the *"List of classes"* in the file ``/cpmpy/solvers/__init__.py``.
+
 ## Transformations and posting constraints
 
 CPMpy solver interfaces are *eager*, meaning that any CPMpy expression given to it (through `__add__()`) is immediately transformed (throught `transform()`) and then posted to the solver.

--- a/docs/api/expressions/globalconstraints.rst
+++ b/docs/api/expressions/globalconstraints.rst
@@ -1,5 +1,5 @@
 Global Constraints (:mod:`cpmpy.expressions.globalconstraints`)
-===================================================
+===============================================================
 
 .. automodule:: cpmpy.expressions.globalconstraints
     :members:

--- a/docs/api/expressions/variables.rst
+++ b/docs/api/expressions/variables.rst
@@ -1,5 +1,5 @@
 Decision Variables (:mod:`cpmpy.expressions.variables`)
-===================================================
+=======================================================
 
 .. automodule:: cpmpy.expressions.variables
     :members:

--- a/docs/api/solvers.rst
+++ b/docs/api/solvers.rst
@@ -1,3 +1,5 @@
+.. _solver-interfaces:
+
 Solver interfaces (:mod:`cpmpy.solvers`)
 ========================================
 

--- a/docs/api/solvers/cpo.rst
+++ b/docs/api/solvers/cpo.rst
@@ -1,0 +1,7 @@
+CPMpy cpo interface (:mod:`cpmpy.solvers.cpo`)
+=====================================================
+
+.. automodule:: cpmpy.solvers.cpo
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/solvers/gcs.rst
+++ b/docs/api/solvers/gcs.rst
@@ -1,0 +1,7 @@
+CPMpy gcs interface (:mod:`cpmpy.solvers.gcs`)
+=====================================================
+
+.. automodule:: cpmpy.solvers.gcs
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/solvers/minizinc.rst
+++ b/docs/api/solvers/minizinc.rst
@@ -1,5 +1,5 @@
 CPMpy minizinc interface (:mod:`cpmpy.solvers.minizinc`)
-=====================================================
+========================================================
 
 .. automodule:: cpmpy.solvers.minizinc
     :members:

--- a/docs/api/solvers/ortools.rst
+++ b/docs/api/solvers/ortools.rst
@@ -1,5 +1,5 @@
 CPMpy ortools interface (:mod:`cpmpy.solvers.ortools`)
-=====================================================
+======================================================
 
 .. automodule:: cpmpy.solvers.ortools
     :members:

--- a/docs/api/tools/explain.rst
+++ b/docs/api/tools/explain.rst
@@ -9,6 +9,7 @@ Explanation tools (:mod:`cpmpy.tools.explain`)
 .. include:: ./explain/mus.rst
 .. include:: ./explain/mss.rst
 .. include:: ./explain/mcs.rst
+.. include:: ./explain/marco.rst
 .. include:: ./explain/utils.rst
 
 .. .. automodule:: cpmpy.tools.explain.mcs
@@ -23,6 +24,11 @@ Explanation tools (:mod:`cpmpy.tools.explain`)
 ..     :inherited-members:
 
 .. .. automodule:: cpmpy.tools.explain.mus
+..     :members:
+..     :undoc-members:
+..     :inherited-members:
+
+.. .. automodule:: cpmpy.tools.explain.marco
 ..     :members:
 ..     :undoc-members:
 ..     :inherited-members:

--- a/docs/api/tools/explain/marco.rst
+++ b/docs/api/tools/explain/marco.rst
@@ -1,0 +1,7 @@
+MARCO (:mod:`cpmpy.tools.explain.marco`)
+=====================================================
+
+.. automodule:: cpmpy.tools.explain.marco
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/tools/tune_solver.rst
+++ b/docs/api/tools/tune_solver.rst
@@ -1,5 +1,5 @@
 Solver Parameter Tuning (:mod:`cpmpy.tools.tune_solver`)
-=====================================================
+========================================================
 
 .. automodule:: cpmpy.tools.tune_solver
     :members:

--- a/docs/api/transformations.rst
+++ b/docs/api/transformations.rst
@@ -14,4 +14,5 @@ Expression transformations (:mod:`cpmpy.transformations`)
 .. .. include:: ./transformations/negation.rst
 .. .. include:: ./transformations/normalize.rst
 .. .. include:: ./transformations/reification.rst
+.. .. include:: ./transformations/safening.rst
 .. .. include:: ./transformations/to_cnf.rst

--- a/docs/api/transformations/linearize.rst
+++ b/docs/api/transformations/linearize.rst
@@ -1,5 +1,5 @@
 Convert constraints to linear form (:mod:`cpmpy.transformations.linearize`)
-=====================================================
+===========================================================================
 
 .. automodule:: cpmpy.transformations.linearize
     :members:

--- a/docs/api/transformations/reification.rst
+++ b/docs/api/transformations/reification.rst
@@ -1,5 +1,5 @@
 Convert reification constraints (:mod:`cpmpy.transformations.reification`)
-=====================================================
+==========================================================================
 
 .. automodule:: cpmpy.transformations.reification
     :members:

--- a/docs/api/transformations/safening.rst
+++ b/docs/api/transformations/safening.rst
@@ -1,0 +1,7 @@
+Safening (:mod:`cpmpy.transformations.safening`)
+================================================
+
+.. automodule:: cpmpy.transformations.safening
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/transformations/to_cnf.rst
+++ b/docs/api/transformations/to_cnf.rst
@@ -1,5 +1,5 @@
 Convert boolean expressions to cnf (:mod:`cpmpy.transformations.to_cnf`)
-=====================================================
+========================================================================
 
 .. automodule:: cpmpy.transformations.to_cnf
     :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,10 @@ extensions = [
     'myst_parser',
     'sphinx_rtd_theme',
     'sphinx_automodapi.automodapi',
-    'sphinx_automodapi.smart_resolver'
+    'sphinx_automodapi.smart_resolver',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.todo',
+    'sphinx.ext.autosectionlabel'
 ]
 
 myst_enable_extensions = [
@@ -66,6 +69,11 @@ myst_enable_extensions = [
 
 numpydoc_show_class_members = False
 numpydoc_show_inherited_class_members = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+
+todo_include_todos = True
 
 source_suffix =  ['.rst', '.md']
 # source_suffix =  '.rst'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,8 @@ CPMpy is a Constraint Programming and Modeling library in Python, based on numpy
 
    modeling
 
+.. _supported-solvers:
+
 Supported solvers
 -----------------
 

--- a/docs/installation_instructions.rst
+++ b/docs/installation_instructions.rst
@@ -5,7 +5,7 @@ CPMpy requires Python ``3.6`` or newer. The package is available on `PyPI <https
 
 The easiest way is to install using the 'pip' command line package manager. In a terminal, run:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ pip install cpmpy
 
@@ -13,13 +13,13 @@ This will automatically also install the default 'ortools' solver.
 
 If the previous command fails to execute, it may be due to the permission to install the package globally Python packages. If so, you can install it for your user only with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ pip install cpmpy --user
 
 CPMpy has regular small releases with updates and improvements, so it is a good habbit to regularly update, as follows:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ pip install -U cpmpy
 
@@ -28,7 +28,7 @@ Installing from a git repository
 --------------------------------
 If you want the very latest, or perhaps from an in-development branch, you can install directly from github as follows:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ pip install git+https://github.com/cpmpy/cpmpy@master
 
@@ -41,7 +41,7 @@ If you are developing CPMpy locally, you can run scripts from in the repository 
 
 However, if you want to test some local changes to CPMpy that can only be tested by installing CPMpy, you can do that as follows from the repository folder:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ pip install .
 

--- a/docs/installation_instructions.rst
+++ b/docs/installation_instructions.rst
@@ -1,7 +1,7 @@
 Installation instructions
 =========================
 
-CPMpy requires Python ``3.6`` or newer. The package is available on `PyPI <https://pypi.org/>`_.
+CPMpy requires Python ``3.8`` or newer. The package is available on `PyPI <https://pypi.org/>`_.
 
 The easiest way is to install using the 'pip' command line package manager. In a terminal, run:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,88 +9,109 @@ Subdirectories:
 
 ## Notebook examples:
 
-You can run these in google colab, on binder or view them on github.
+You can run these in Google Colab, on Binder or view them on GitHub.
+
+---
 
 ### `quickstart_sudoku.ipynb` 
+
+A quickstart guido to constraint solving, using the venerable sudoku problem.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/quickstart_sudoku.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-A quickstart guido to constraint solving, using the venerable sudoku problem.
+---
 
 ### `nqueens_1000.ipynb`
+
+Another classic constraint satisfaction problem, N-queens (with visualisation and parameter tuning for larger N).
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/nqueens.py">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-Another classic constraint satisfaction problem, N-queens (with visualisation and parameter tuning for larger N).
+---
 
 ### `vehicle_routing.ipynb`
+
+Exact vehicle routing model, with nice visualisation on real world map.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/vehicle_routing.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-Exact vehicle routing model, with nice visualisation on real world map.
+---
 
 ### `scheduling.ipynb`
+
+A makespan minimising jobshop problem, with nice Gantt visualisation.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/scheduling.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-
-A makespan minimising jobshop problem, with nice Gantt visualisation.
+---
 
 ### `room_assignment.ipynb`
+
+A real-life room assignment problem, do the room requests fit in the hotel?
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/room_assignment.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-A real-life room assignment problem, do the room requests fit in the hotel?
+---
 
 ### `car_sequencing.ipynb`
+
+CSPlib problem number 1, nicely demonstrates the complex expressions CP can handle.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/car_sequencing.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-CSPlib problem number 1, nicely demonstrates the complex expressions CP can handle.
+---
 
 ### `packing_rectangles.ipynb`
+
+A 2D rectangular packing problem, with visualisation.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/packing_rectangles.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-A 2D rectangular packing problem, with visualisation.
+---
 
 ### `tsp.ipynb`
+
+The Traveling Salesman Problem, just a simple `circuit` global constraint for CP.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/tsp.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-The Traveling Salesman Problem, just a simple `circuit` global constraint for CP.
+---
 
 ### `graph_coloring.ipynb`
+
+The graph coloring problem, while actually coloring a graph.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/graph_coloring.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-The graph coloring problem, while actually coloring a graph.
+---
 
 ### `map_coloring_oz_ipynb`
+
+Is also a graph coloring problem, while actually coloring the map of australia.
 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/map_coloring_oz.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-Is also a graph coloring problem, while actually coloring the map of australia.
+---
 
 ### `nonagram_ortools.ipynb`
 
@@ -100,6 +121,8 @@ The nonagram puzzle problem, implemented using OR-Tools' version of the `Regular
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
+---
+
 ### `set_game.ipynb`
 
 Set is a popular card game in which the players have to find a set in a deck of cards.
@@ -107,3 +130,5 @@ Set is a popular card game in which the players have to find a set in a deck of 
 <a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/set_game.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
+
+---

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,31 +11,99 @@ Subdirectories:
 
 You can run these in google colab, on binder or view them on github.
 
-### `quickstart_sudoku.ipynb`
+### `quickstart_sudoku.ipynb` 
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/quickstart_sudoku.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 A quickstart guido to constraint solving, using the venerable sudoku problem.
 
 ### `nqueens_1000.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/nqueens.py">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 Another classic constraint satisfaction problem, N-queens (with visualisation and parameter tuning for larger N).
 
 ### `vehicle_routing.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/vehicle_routing.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 Exact vehicle routing model, with nice visualisation on real world map.
 
 ### `scheduling.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/scheduling.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
+
 A makespan minimising jobshop problem, with nice Gantt visualisation.
 
 ### `room_assignment.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/room_assignment.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 A real-life room assignment problem, do the room requests fit in the hotel?
 
 ### `car_sequencing.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/car_sequencing.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 CSPlib problem number 1, nicely demonstrates the complex expressions CP can handle.
 
 ### `packing_rectangles.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/packing_rectangles.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 A 2D rectangular packing problem, with visualisation.
 
 ### `tsp.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/tsp.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 The Traveling Salesman Problem, just a simple `circuit` global constraint for CP.
 
 ### `graph_coloring.ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/graph_coloring.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
 The graph coloring problem, while actually coloring a graph.
 
-`map_coloring_oz.ipynb` is also a graph coloring problem, while actually coloring the map of australia.
+### `map_coloring_oz_ipynb`
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/map_coloring_oz.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
+Is also a graph coloring problem, while actually coloring the map of australia.
+
+### `nonagram_ortools.ipynb`
+
+The nonagram puzzle problem, implemented using OR-Tools' version of the `Regular` global constraint. 
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/nonogram_ortools.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+
+### `set_game.ipynb`
+
+Set is a popular card game in which the players have to find a set in a deck of cards.
+
+<a target="_blank" href="https://colab.research.google.com/github/CPMpy/cpmpy/blob/master/examples/set_game.ipynb">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>


### PR DESCRIPTION
Large collection of non-content-related changes to the documentation. A lot of the formatting used was incompatible with sphinx, resulting in scrambled documentation pages. This includes:
- large tables of expressions which weren't in a table format
- wrong use of arguments and returns for autodoc
- bad indenting
- missing `.rst` files
- ...

In general, certain pieces of the docs were only ever structured for reading within the source code, not through the static docs website. I tried to improve the formatting, improving its accessibility through the web version.  Also added a lot of cross-references in the API documentation.

Tried to separate the changes per topic in separate commits as much as possible.