### PR TITLE
Simplify nested wsum boolexpr

### DIFF
--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -107,6 +107,9 @@ def simplify_boolean(lst_of_expr, num_context=False):
                 else:
                     newlist.append(~args[0])
 
+            elif expr.name == "wsum":
+                newlist.append(Operator(expr.name, (args[0], simplify_boolean(args[1]))))
+
             else: # numerical expressions
                 newlist.append(Operator(expr.name, args))
 

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -108,7 +108,7 @@ def simplify_boolean(lst_of_expr, num_context=False):
                     newlist.append(~args[0])
 
             elif expr.name == "wsum":
-                newlist.append(Operator(expr.name, (args[0], simplify_boolean(args[1]))))
+                newlist.append(Operator(expr.name, [args[0], simplify_boolean(args[1])]))
 
             else: # numerical expressions
                 newlist.append(Operator(expr.name, args))

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -107,9 +107,6 @@ def simplify_boolean(lst_of_expr, num_context=False):
                 else:
                     newlist.append(~args[0])
 
-            elif expr.name == "wsum":
-                newlist.append(Operator(expr.name, [args[0], simplify_boolean(args[1])]))
-
             else: # numerical expressions
                 newlist.append(Operator(expr.name, args))
 
@@ -175,6 +172,10 @@ def simplify_boolean(lst_of_expr, num_context=False):
             expr = copy.copy(expr)
             expr.update_args(simplify_boolean(expr.args)) # TODO: how to determine boolean or numerical context? also i this even needed?
             newlist.append(expr)
+        
+        elif isinstance(expr, list): # nested list of args
+            newlist.append(simplify_boolean(expr))
+
         else: # variables/constants/direct constraints
             newlist.append(expr)
     return newlist

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -108,3 +108,11 @@ class TransSimplify(unittest.TestCase):
         self.assertEqual(str(self.transform(cons)), "[x != 2]")
         self.assertTrue(cp.Model(cons).solve())
 
+        # Simplify boolean expressions nested within a weighted sum
+        #   wsum([1, 2], [bv[0] != 0, bv[1] != 1]) ----> wsum([1, 2], [bv[0], ~bv[1]])
+        bv = cp.boolvar(name="bv", shape=2)
+        weights = cp.cpm_array([1, 2])
+        bool_as_ints = cp.cpm_array([0, 1])
+        cons = sum( weights * (bv != bool_as_ints) ) == 1
+        self.assertEqual(str(self.transform(cons)), "[sum([1, 2] * [bv[0], ~bv[1]]) == 1]")
+        self.assertTrue(cp.Model(cons).solve())


### PR DESCRIPTION
The variables argument of `wsum` was not recursively send through `simplify_boolean`, causing exceptions in downstream transformations. Bug identified by @ElFosco.

Example expression:
```python
bv = cp.boolvar(name="bv", shape=2)
weights = cp.cpm_array([1, 2])
bool_as_ints = cp.cpm_array([0, 1])
cons = sum( weights * (bv != bool_as_ints) ) == 1
```
this will look something like:
```python
sum([1, 2], [bv[0] != 0, bv[1] != 1]) == 1 # wsum
```
which after `simplify_boolean` should become:
```python
sum([1, 2], [bv[0], ~bv[1]]) == 1 # wsum
```

Otherwise causes `normalized_boolexpr` to fail, since it does not expect a `int` to still be present in the right hand side of a `!=` (assumes a var to be present, see #315) 