### PR TITLE
Missing user vars

### DIFF
--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -350,6 +350,10 @@ class CPM_minizinc(SolverInterface):
 
     async def _solveAll(self, display=None, time_limit=None, solution_limit=None, **kwargs):
         """ Special 'async' function because mzn.solutions() is async """
+
+        # ensure all vars are known to solver
+        self.solver_vars(list(self.user_vars))
+        
         # make mzn_inst
         (kwargs, mzn_inst) = self._pre_solve(time_limit=time_limit, **kwargs)
         kwargs['all_solutions'] = True

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -318,6 +318,7 @@ class CPM_z3(SolverInterface):
         :return: self
         """
         # all variables are user variables, handled in `solver_var()`
+        # but this misses variables which are part of constraints that don't get posted
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -35,6 +35,7 @@
     Module details
     ==============
 """
+from cpmpy.transformations.get_variables import get_variables
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
@@ -317,6 +318,7 @@ class CPM_z3(SolverInterface):
         :return: self
         """
         # all variables are user variables, handled in `solver_var()`
+        get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
         for cpm_con in self.transform(cpm_expr):

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -795,6 +795,9 @@ class TestSupportedSolvers:
         Tests whether decision variables which are part of a constraint that never gets posted to the underlying solver
         still get correctly captured and posted.
         """
+        if solver == 'pysdd' or solver == 'pysat':  # pysat and pysdd don't support integer decision variables
+            return
+        
         x = cp.intvar(1, 4, shape=1)
         # Dubious constraint which enforces nothing, gets decomposed to empty list
         # -> resulting CP model is empty

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -789,3 +789,16 @@ class TestSupportedSolvers:
             assert dv * yv + rv == xv
             assert (Operator('div', [xv, yv])).value() == dv
             assert (Operator('mod', [xv, yv])).value() == rv
+
+    def test_hidden_user_vars(self, solver):
+        """
+        Tests whether decision variables which are part of a constraint that never gets posted to the underlying solver
+        still get correctly captured and posted.
+        """
+        x = cp.intvar(1, 4, shape=1)
+        # Dubious constraint which enforces nothing, gets decomposed to empty list
+        # -> resulting CP model is empty
+        m = cp.Model([cp.AllDifferentExceptN([x], 1)])
+        s = cp.SolverLookup().get(solver, m)
+        assert len(s.user_vars) == 1 # check if var captured as a user_var
+        assert s.solveAll() == 4     # check if still correct number of solutions, even though empty model


### PR DESCRIPTION
Not all solvers correctly collected all decision variables across all constraints. 

Z3 does not call `get_variables` upon adding a constraint. Comment mentions that z3 uses `solver_var()` via `_z3_expr` to collect the variables during the transformation process, But this misses variables from constraints which decomposed to nothing (see #608).

Minizinc didn't post the collected user vars on `solveAll()`. Regular `solve()` worked perfectly. 

I added the missing lines to ensure all user decision variables are collected and posted to the solver. 
But current implementation posts decision variables twice for Z3 (not sure if this could be an issue).