### PR TITLE
Improve exceptions (documentations, some refactor)

### DIFF
--- a/cpmpy/exceptions.py
+++ b/cpmpy/exceptions.py
@@ -9,31 +9,37 @@ class CPMpyException(Exception):
 
 
 class MinizincPathException(CPMpyException):
+    '''Raised when `minizinc` is not added to PATH'''
     pass
 
 class MinizincNameException(CPMpyException):
+    '''Raised when a variable is a keyword or otherwise violates Minizinc naming rules'''
     pass
 
 class MinizincBoundsException(CPMpyException):
-    pass
-
-class ChocoTypeException(CPMpyException):
+    '''Raised when an integer overflows MiniZinc's bounds of (-2147483646..2147483646)'''
     pass
 
 class ChocoBoundsException(CPMpyException):
+    '''Raised when an integer overflows Choco's integer bounds of (-2147483646..2147483646)'''
     pass
 
 class NotSupportedError(CPMpyException):
+    '''Raised when a solver does not support a certain feature'''
     pass
 
 class IncompleteFunctionError(CPMpyException):
+    '''Raised when an expression's value is not defined for its sub-expressions (e.g. `x div y` where `y` is assigned 0)'''
     pass
 
 class TypeError(CPMpyException):
+    '''Raised when an expression receives sub-expressions of the wrong type'''
     pass
 
 class GCSVerificationException(CPMpyException):
+    '''Raised when GCS fails proof logging by VeriPB'''
     pass
 
 class TransformationNotImplementedError(CPMpyException):
+    '''Raised when a transformation is not implemented for a certain expression'''
     pass


### PR DESCRIPTION
This adds some documentation which was missing as pointed out in #344. I tried to understand the exceptions from the context, let me know if I misinterpreted something.

We could merge this. One refactor I'd propose is to simplify by removing solver specific errors.

- Rename `NotSupportedError` to `SolverLimitation(solver)`: whenever the solver `solver` cannot support something in the model (and is not likely to: e.g. integer out of bounds for Minizinc)
- `SolverConfigurationException(solver)`: whenever `solver` is mis-configured (dependency not installed, minizinc not in PAH, license missing, etc..), the user can usually fix this
- `ResultVerificationException` proof logging failed (eg GCSVerificationException)

If it's not worth the API change of exception, we can merge/close this now.