### PR TITLE
Minizinc installed subsolver

### DIFF
--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -89,7 +89,7 @@ class CPM_pysat(SolverInterface):
 
 
     @staticmethod
-    def solvernames():
+    def solvernames(*args):
         """
             Returns solvers supported by PySAT on your system
         """

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -88,7 +88,7 @@ class SolverLookup():
             if CPM_slv.supported():
                 names.append(basename)
                 if hasattr(CPM_slv, "solvernames"):
-                    subnames = CPM_slv.solvernames()
+                    subnames = CPM_slv.solvernames(installed=True)
                     for subn in subnames:
                         names.append(basename+":"+subn)
         return names

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -518,6 +518,14 @@ m = cp.Model(cp.sum(x) <= 5)
 m.solve(solver="minizinc:chuffed")
 ```
 
+You can even use the same model across different solvers to see which one you like best:
+```python
+# m = same model as above
+for solvername in cp.SolverLookup.solvernames() # all solvers (+subsolvers) installed on the system
+    m.solve(solver=solvername)
+    print(m.status())
+```
+
 Note that for solvers other than "ortools", you will need to **install additional package(s)**. You can check if a solver, e.g. "gurobi", is supported by calling `cp.SolverLookup.get("gurobi")` and it will raise a helpful error if it is not yet installed on your system. See [the API documentation](./api/solvers.rst) of the solver for detailed installation instructions.
 
 ## Model versus solver interface


### PR DESCRIPTION
Calling `cp.SolverLookup.solvernames()` returns all solver(+subsolver) names currently installed on the system, except for minizinc.
With minizinc, all subsolvers get returned, without a check if they're available. This is an issue when someone wants to easily test a model against all installed solvers:

```python
for solvername in cp.SolverLookup.solvernames():
    m.solve(solver=solvername)
    print(solvername , m.status())
```

This will fail on all minizinc subsolvers which aren't installed. 

The minizinc API does not expose the installation status. The current implementation for getting solver names in CPMpy makes use of the following:
```python
minizinc.default_driver.available_solvers()
``` 
It returns a dictionary with for each 'tag' all possible 'drivers'. It does not check if the executables for each driver are available. Additionally, it includes tags which don't represent solvers ('globalizer', 'findmus', ...) ,  tags which represent a 'family' of solvers (like 'cp', 'ilp', ...) and duplicate tags (like 'coinbc', 'cbc', 'org.minizinc.mip.coin-bc')

This alternative implementation proposes 
1) an new way of getting all minizinc solver names without some of the above issues (by directly accessing the minizinc API in the same way that the minizinc python library does
2) a (optional) filtering of minizinc solvers on those that are installed. 

The detection of installation is currently done by attempting to solve a small model with that solver and seeing whether it fails. This has a performance overhead (2.48s vs 0.19s before on my machine). An alternative would be to check if the solver's minizinc configuration file (or the executable) is available on the machine. But then we would have to check [all possible locations](https://docs.minizinc.dev/en/stable/command_line.html#configuration-files), or parse the last output line of a `minizinc --solvers` call (no guarantee that the format of this output will stay the same).

So there currently doesn't seem to be a great solution to this problem.
