### PR TITLE
Simplify bool fix

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -437,7 +437,7 @@ class BoolVal(Expression):
     """
 
     def __init__(self, arg):
-        assert is_true_cst(arg) or is_false_cst(arg)
+        assert is_true_cst(arg) or is_false_cst(arg), f"BoolVal must be initialized with a boolean constant, got {arg} of type {type(arg)}"
         super(BoolVal, self).__init__("boolval", [bool(arg)])
 
     def value(self):

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -221,7 +221,11 @@ def simplify_boolean(lst_of_expr, num_context=False):
                 elif rhs > 1:
                     newlist.append(BoolVal(name in {"!=", "<", "<="})) # all other operators evaluate to False
             else:
-                newlist.append(eval_comparison(name, lhs, rhs))
+                res = eval_comparison(name, lhs, rhs)
+                if is_bool(res):
+                    newlist.append(int(res) if num_context else BoolVal(res))
+                else:
+                    newlist.append(res)                    
         elif isinstance(expr, (GlobalConstraint, GlobalFunction)):
             newargs = simplify_boolean(expr.args) # TODO: how to determine which are Bool/int?
             if any(a1 is not a2 for a1,a2 in zip(expr.args, newargs)):

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -222,9 +222,9 @@ def simplify_boolean(lst_of_expr, num_context=False):
                     newlist.append(BoolVal(name in {"!=", "<", "<="})) # all other operators evaluate to False
             else:
                 res = eval_comparison(name, lhs, rhs)
-                if is_bool(res):
+                if is_bool(res): # Result is a Boolean constant
                     newlist.append(int(res) if num_context else BoolVal(res))
-                else:
+                else: # Result is an expression
                     newlist.append(res)                    
         elif isinstance(expr, (GlobalConstraint, GlobalFunction)):
             newargs = simplify_boolean(expr.args) # TODO: how to determine which are Bool/int?


### PR DESCRIPTION
fix of issue #613 

Specifically, simplify_bool did not handle the case where a comparison ended up being True or False in eval_comparison.