### PR TITLE
Discussing whether we support constants for Element decomposition

### DIFF
--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -286,14 +286,15 @@ class Element(GlobalFunction):
 
         """
         arr, idx = self.args
-        # for every  `i` in the intersection of array indices and the bounds of `idx`..
+        # Find where the array indices and the bounds of `idx` intersect
         lb, ub = get_bounds(idx)
         new_lb, new_ub = max(lb, 0), min(ub, len(arr) - 1)
-        return [  # ..we post `(idx = i) -> idx=i -> arr[i] <CMP_OP> cpm_rhs`.
-            implies(idx == i, eval_comparison(cpm_op, arr[i], cpm_rhs)) for i in range(new_lb, new_ub + 1)
-        ] + [  # also enforce the new bounds 
-            idx >= new_lb, idx <= new_ub
-        ], []  # no auxiliary variables
+        cons=[]
+        # For every `i` in that intersection, post `(idx = i) -> idx=i -> arr[i] <CMP_OP> cpm_rhs`.
+        for i in range(new_lb, new_ub+1):
+            cons.append(implies(idx == i, eval_comparison(cpm_op, arr[i], cpm_rhs)))
+        cons+=[idx >= new_lb, idx <= new_ub]  # also enforce the new bounds 
+        return cons, []  # no auxiliary variables
 
     def __repr__(self):
         return "{}[{}]".format(self.args[0], self.args[1])

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -70,7 +70,7 @@ import cpmpy as cp
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
 from .core import Expression, Operator, Comparison
 from .variables import boolvar, intvar, cpm_array
-from .utils import flatlist, argval, is_num, is_int, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, is_bool, is_true_cst, is_false_cst
+from .utils import flatlist, argval, is_num, is_int, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, is_bool, is_true_cst, is_false_cst, get_bounds
 
 
 class GlobalFunction(Expression):
@@ -290,8 +290,8 @@ class Element(GlobalFunction):
         cons = []
         # the decomposition posts `idx=i -> arr[i] <CMP_OP> cpm_rhs`
         # for every  `i` in the intersection of array indices and the bounds of `idx`
-        lb, ub = idx.get_bounds()
         new_lb, new_ub = max(lb, 0), min(ub, len(arr))
+        lb, ub = get_bounds(idx)
         for i in range(new_lb, new_ub):
             cond = idx == i
             if is_true_cst(cond):

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -68,9 +68,9 @@ import numpy as np
 import cpmpy as cp
 
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
-from .core import Expression, Operator, Comparison
+from .core import Expression, Operator
 from .variables import boolvar, intvar, cpm_array
-from .utils import flatlist, argval, is_num, is_int, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, is_bool, is_true_cst, is_false_cst, get_bounds, implies
+from .utils import flatlist, argval, is_num, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, get_bounds, implies
 
 
 class GlobalFunction(Expression):
@@ -237,6 +237,7 @@ def element(arg_list):
     warnings.warn("Deprecated, use Element(arr,idx) instead, will be removed in stable version", DeprecationWarning)
     assert (len(arg_list) == 2), "Element expression takes 2 arguments: Arr, Idx"
     return Element(arg_list[0], arg_list[1])
+
 class Element(GlobalFunction):
     """
         The 'Element' global constraint enforces that the result equals Arr[Idx]

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -70,7 +70,7 @@ import cpmpy as cp
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
 from .core import Expression, Operator, Comparison
 from .variables import boolvar, intvar, cpm_array
-from .utils import flatlist, argval, is_num, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, is_bool
+from .utils import flatlist, argval, is_num, is_int, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, is_bool
 
 
 class GlobalFunction(Expression):
@@ -256,6 +256,8 @@ class Element(GlobalFunction):
             raise TypeError("index cannot be a boolean expression: {}".format(idx))
         if is_any_list(idx):
             raise TypeError("For using multiple dimensions in the Element constraint, use comma-separated indices")
+        if is_int(idx): # prevents OR-Tools error
+            idx = cp.intvar(idx, idx)
         super().__init__("element", [arr, idx])
 
     def __getitem__(self, index):

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -285,6 +285,11 @@ class Element(GlobalFunction):
 
         """
         arr, idx = self.args
+        if is_num(idx): # index is constant, we only enforce one constraint
+            try:
+                return [eval_comparison(cpm_op, arr[idx], cpm_rhs)], []
+            except IndexError: # out-of-bounds is undefined (TODO check how to handle partial fixed result)
+                return [], [False]
         return [(idx == i).implies(eval_comparison(cpm_op, arr[i], cpm_rhs)) for i in range(len(arr))] + \
                [idx >= 0, idx < len(arr)], []
 

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -194,6 +194,15 @@ def get_bounds(expr):
             return int(expr), int(expr)
         return math.floor(expr), math.ceil(expr)
 
+def implies(expr, other):
+    """ like :func:`~cpmpy.expressions.core.Expression.implies`, but also works for non-expressions """
+    if expr is True:
+        return other
+    elif expr is False:
+        return BoolVal(True)
+    else:
+        return expr.implies(other)
+
 # Specific stuff for ShortTabel global (should this be in globalconstraints.py instead?)
 STAR = "*" # define constant here
 def is_star(arg):

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -195,10 +195,12 @@ def get_bounds(expr):
         return math.floor(expr), math.ceil(expr)
 
 def implies(expr, other):
-    """ like :func:`~cpmpy.expressions.core.Expression.implies`, but also works for non-expressions """
-    if expr is True:
+    """ like :func:`~cpmpy.expressions.core.Expression.implies`, but also safe to use for non-expressions """
+    if isinstance(expr, cp.expressions.core.Expression):
+        return expr.implies(other)
+    elif arg is True or arg is np.True_:
         return other
-    elif expr is False:
+    elif arg is False or arg is np.False_:
         return BoolVal(True)
     else:
         return expr.implies(other)

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -198,9 +198,9 @@ def implies(expr, other):
     """ like :func:`~cpmpy.expressions.core.Expression.implies`, but also safe to use for non-expressions """
     if isinstance(expr, cp.expressions.core.Expression):
         return expr.implies(other)
-    elif arg is True or arg is np.True_:
+    elif expr is True or expr is np.True_:
         return other
-    elif arg is False or arg is np.False_:
+    elif expr is False or expr is np.False_:
         return BoolVal(True)
     else:
         return expr.implies(other)

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -198,9 +198,9 @@ def implies(expr, other):
     """ like :func:`~cpmpy.expressions.core.Expression.implies`, but also safe to use for non-expressions """
     if isinstance(expr, cp.expressions.core.Expression):
         return expr.implies(other)
-    elif expr is True or expr is np.True_:
+    elif is_true_cst(expr):
         return other
-    elif expr is False or expr is np.False_:
+    elif is_false_cst(expr):
         return BoolVal(True)
     else:
         return expr.implies(other)

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -481,7 +481,7 @@ class CPM_ortools(SolverInterface):
                     return self.ort_model.AddDivisionEquality(ortrhs, *self.solver_vars(lhs.args))
                 elif lhs.name == 'element':
                     arr, idx = lhs.args
-                    if is_int(idx) and (idx < 0 or idx >= len(arr)):
+                    if is_int(idx): # OR-Tools does not handle all constant integer cases
                         idx = intvar(idx,idx)
                     # OR-Tools has slight different in argument order
                     return self.ort_model.AddElement(

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -4,6 +4,7 @@ import cpmpy
 from cpmpy import Model, SolverLookup, BoolVal
 from cpmpy.expressions.globalconstraints import *
 from cpmpy.expressions.globalfunctions import *
+from cpmpy.expressions.core import Comparison
 
 import pytest
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1336,3 +1336,12 @@ class TestTypeChecks(unittest.TestCase):
                     self.assertFalse(cp.Model([cp.boolvar() == cp.Element([0], 1)]).solve(solver=s))
                 except (NotImplementedError, NotSupportedError):
                     pass
+
+    def test_element_index_dom_mismatched(self):
+        for s, cls in cp.SolverLookup.base_solvers():
+            if cls.supported():
+                try:
+                    # the index variable has a lower bound *outside* the indexable range, and an upper bound inside AND lower than the indexable range upper bound
+                    assert str(cp.Element([0,1,2], cp.intvar(-1,1)).decompose_comparison("==", cp.intvar(1,5))) == "([(IV0 == 0) -> (IV1 == 0), IV0 >= 0, IV0 <= 1], [])"
+                except (NotImplementedError, NotSupportedError):
+                    pass

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1342,5 +1342,8 @@ class TestTypeChecks(unittest.TestCase):
             Check transform of `[0,1,2][x in -1..1] == y in 1..5`
             Note the index variable has a lower bound *outside* the indexable range, and an upper bound inside AND lower than the indexable range upper bound
         """
-        assert str(cp.Element([0,1,2], cp.intvar(-1,1, name="x")).decompose_comparison("==", cp.intvar(1,5, name="y"))) \
-                == "([(x == 0) -> (y == 0), (x == 1) -> (y == 1), x >= 0, x <= 1], [])"
+        constraint=cp.Element([0,1,2], cp.intvar(-1,1, name="x"))
+        self.assertEqual(
+            str(constraint.decompose_comparison("==", cp.intvar(1,5, name="y"))),
+            "([(x == 0) -> (y == 0), (x == 1) -> (y == 1), x >= 0, x <= 1], [])"
+        )

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1338,10 +1338,9 @@ class TestTypeChecks(unittest.TestCase):
                     pass
 
     def test_element_index_dom_mismatched(self):
-        for s, cls in cp.SolverLookup.base_solvers():
-            if cls.supported():
-                try:
-                    # the index variable has a lower bound *outside* the indexable range, and an upper bound inside AND lower than the indexable range upper bound
-                    assert str(cp.Element([0,1,2], cp.intvar(-1,1)).decompose_comparison("==", cp.intvar(1,5))) == "([(IV0 == 0) -> (IV1 == 0), IV0 >= 0, IV0 <= 1], [])"
-                except (NotImplementedError, NotSupportedError):
-                    pass
+        """
+            Check transform of `[0,1,2][x in -1..1] == y in 1..5`
+            Note the index variable has a lower bound *outside* the indexable range, and an upper bound inside AND lower than the indexable range upper bound
+        """
+        assert str(cp.Element([0,1,2], cp.intvar(-1,1, name="x")).decompose_comparison("==", cp.intvar(1,5, name="y"))) \
+                == "([(x == 0) -> (y == 0), (x == 1) -> (y == 1), x >= 0, x <= 1], [])"

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1325,3 +1325,14 @@ class TestTypeChecks(unittest.TestCase):
         self.assertRaises(TypeError, cp.Table, [iv[0], iv[1], iv[2], 5], [(5, 2, 2)])
         self.assertRaises(TypeError, cp.Table, [iv[0], iv[1], iv[2], [5]], [(5, 2, 2)])
         self.assertRaises(TypeError, cp.Table, [iv[0], iv[1], iv[2], ['a']], [(5, 2, 2)])
+
+    def test_issue627(self):
+        for s, cls in cp.SolverLookup.base_solvers():
+            if cls.supported():
+                try:
+                    # constant look-up
+                    self.assertTrue(cp.Model([cp.boolvar() == cp.Element([0], 0)]).solve(solver=s))
+                    # constant out-of-bounds look-up
+                    self.assertFalse(cp.Model([cp.boolvar() == cp.Element([0], 1)]).solve(solver=s))
+                except (NotImplementedError, NotSupportedError):
+                    pass


### PR DESCRIPTION
So the issue is the Element's decomposition does not work for integer constants as index, only integer variables. So the following test failed for z3, and after my fix still for or-tools:

```python
# constant look-up
self.assertTrue(cp.Model([cp.boolvar() == cp.Element([0], 0)]).solve(solver=s))
# constant out-of-bounds look-up
self.assertFalse(cp.Model([cp.boolvar() == cp.Element([0], 1)]).solve(solver=s))
```

However, if the user uses the overloaded Python array indexing (e.g. `[0][0]`), then we don't get this issue in the first place.

So the question is a) should the decompositions of global constraints support constants for (some) arguments, and b) do we support the use of cp.Element, or only of array indexing (e.g. should the model just have [0][0], which would just work)

Depending on these questions, the PR can just be closed, otherwise I need to still resolve an issue for OR-tools.