### PR TITLE
Linearize sub

### DIFF
--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -152,7 +152,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum"}, reified=False):
 
             if lhs.name == "sub":
                 # convert to wsum
-                lhs = sum([1 * lhs.args[0] + -1 * lhs.args[1]])
+                lhs = Operator("wsum", [[1, -1], [lhs.args[0], lhs.args[1]]])
                 cpm_expr = eval_comparison(cpm_expr.name, lhs, rhs)
 
             if lhs.name == "-":

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -209,6 +209,22 @@ class TestTransLinearize(unittest.TestCase):
             model = cp.Model(c)
             model.solve(solver="exact")
 
+    def test_sub(self):
+        x = cp.intvar(0,10, name="x")
+        y = cp.intvar(0,10, name="y")
+
+        cons = Operator("sub", [3, x]) == y
+        [lin_cons] = linearize_constraint([cons])
+        self.assertEqual(str(lin_cons), "sum([-1, -1] * [x, y]) == -3")
+
+        cons = Operator("sub", [x, 3]) == y
+        [lin_cons] = linearize_constraint([cons])
+        self.assertEqual(str(lin_cons), "sum([1, -1] * [x, y]) == 3")
+
+        cons = Operator("sub", [x,y]) == 3
+        [lin_cons] = linearize_constraint([cons])
+        self.assertEqual(str(lin_cons), "sum([1, -1] * [x, y]) == 3")
+
 
 
 class TestConstRhs(unittest.TestCase):


### PR DESCRIPTION
Linearization of constraints such as `2 - x == y` went wrong when explcitely posted to the transformation.
Normally, we rewrite this directly as ` 2 + (-x) == y` so it stayed under the radar for some time.