### PR TITLE
SolverLookup: add installed() and status()

### DIFF
--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -102,8 +102,7 @@ class CPM_gurobi(SolverInterface):
             global GRB_ENV
             if GRB_ENV is None:
                 # initialise the native gurobi model object
-                GRB_ENV = gp.Env()
-                GRB_ENV.setParam("OutputFlag", 0)
+                GRB_ENV = gp.Env(params={"OutputFlag": 0})
                 GRB_ENV.start()
             return True
         except Exception as e:

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -97,9 +97,9 @@ class SolverLookup():
         """
             Return the list of names of all solvers (and subsolvers) supported on this system.
 
-            If a solver name is returned, it means that both the Python package is installed and the
-            solver's `.supported()` function returns True and is hence ready for immediate use
-            (e.g. any separate binaries are installed if necessary, and licenses are active if needed).
+            If a solver name is returned, it means that the solver's `.supported()` function returns True
+            and it is hence ready for immediate use
+            (e.g. any separate binaries are also installed if necessary, and licenses are active if needed).
 
             Typical use case is to use these names in `SolverLookup.get(name)`.
         """

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -82,7 +82,24 @@ class SolverLookup():
                ]
 
     @classmethod
-    def solvernames(cls):
+    def status(cls):
+        """
+            Print all CPMpy solvers and their installation status.
+        """
+        for (basename, CPM_slv) in cls.base_solvers():
+            if CPM_slv.supported():
+                print(f"{basename}: Ready to use")
+            else:
+                print(f"{basename}: Not installed")
+
+    @classmethod
+    def installed(cls):
+        """
+            Return the list of all solvers and subsolvers that are supported on this system.
+
+            Installed means that both the Python package is installed, and the solver is ready-to-use.
+            (e.g. any separate binaries are installed if necessary, and licenses are active if needed).
+        """
         names = []
         for (basename, CPM_slv) in cls.base_solvers():
             if CPM_slv.supported():
@@ -92,6 +109,12 @@ class SolverLookup():
                     for subn in subnames:
                         names.append(basename+":"+subn)
         return names
+
+    @classmethod
+    def solvernames(cls):
+        # The older (more cryptically named) way to get the list of installed solvers.
+        # Will be deprecated at some point.
+        return cls.installed()
 
     @classmethod
     def get(cls, name=None, model=None, **init_kwargs):

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -82,7 +82,7 @@ class SolverLookup():
                ]
 
     @classmethod
-    def status(cls):
+    def print_status(cls):
         """
             Print all CPMpy solvers and their installation status.
         """
@@ -93,11 +93,12 @@ class SolverLookup():
                 print(f"{basename}: Not installed")
 
     @classmethod
-    def installed(cls):
+    def available(cls):
         """
-            Return the list of all solvers and subsolvers that are supported on this system.
+            Return the list of names of all solvers and subsolvers available on this system (for use in `SolverLookup.get(name)`)
 
-            Installed means that both the Python package is installed, and the solver is ready-to-use.
+            If a solver name is returned, it means that both the Python package is installed and the
+            solver is available for immediate use: the solver's `.supported()` function returns True.
             (e.g. any separate binaries are installed if necessary, and licenses are active if needed).
         """
         names = []
@@ -114,7 +115,7 @@ class SolverLookup():
     def solvernames(cls):
         # The older (more cryptically named) way to get the list of installed solvers.
         # Will be deprecated at some point.
-        return cls.installed()
+        return cls.available()
 
     @classmethod
     def get(cls, name=None, model=None, **init_kwargs):

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -84,13 +84,13 @@ class SolverLookup():
     @classmethod
     def print_status(cls):
         """
-            Print all CPMpy solvers and their installation status.
+            Print all CPMpy solvers and their installation status on this system.
         """
         for (basename, CPM_slv) in cls.base_solvers():
             if CPM_slv.supported():
-                print(f"{basename}: Ready to use")
+                print(f"{basename}: Supported, ready to use.")
             else:
-                print(f"{basename}: Not installed")
+                print(f"{basename}: Not supported (missing Python package, binary or license).")
 
     @classmethod
     def supported(cls):

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -93,13 +93,15 @@ class SolverLookup():
                 print(f"{basename}: Not installed")
 
     @classmethod
-    def available(cls):
+    def supported(cls):
         """
-            Return the list of names of all solvers and subsolvers available on this system (for use in `SolverLookup.get(name)`)
+            Return the list of names of all solvers (and subsolvers) supported on this system.
 
             If a solver name is returned, it means that both the Python package is installed and the
-            solver is available for immediate use: the solver's `.supported()` function returns True.
+            solver's `.supported()` function returns True and is hence ready for immediate use
             (e.g. any separate binaries are installed if necessary, and licenses are active if needed).
+
+            Typical use case is to use these names in `SolverLookup.get(name)`.
         """
         names = []
         for (basename, CPM_slv) in cls.base_solvers():
@@ -113,9 +115,9 @@ class SolverLookup():
 
     @classmethod
     def solvernames(cls):
-        # The older (more cryptically named) way to get the list of installed solvers.
+        # The older (more indirectly named) way to get the list of names of *supported* solvers.
         # Will be deprecated at some point.
-        return cls.available()
+        return cls.supported()
 
     @classmethod
     def get(cls, name=None, model=None, **init_kwargs):


### PR DESCRIPTION
Inspired by #628 but not going as far, I added two functions to solver lookup. After the release, the docs will then be something like

"""
Accessing solvers always happens through the cp.SolverLookup() static class.

To see which solvers CPMpy supports, and which of those are installed and available on your system, run
`cp.SolverLookup().status()`
which will print a human-readable overview.

To loop over all systems installed and available on your machine, do:
```python
for name in cp.SolverLookup.installed():
    s = cp.SolverLookup.get(name)
    s.add(...)
    s.solve()
```
"""

I've been hesitating about the names...

* For me, `status()` is fine to just print it, rather than the longer print_status(), but I'm open to other opinions

* For `installed()` other alternatives are `list()`, `supported()`, `available()`. I want something short but where the meaning is immediately clear, so both supported and binary/license ready to use... maybe `cp.SolverLookup.available()' then? not sure


I'd like this minimal version in the upcoming release, and then how to actually populate a nice `status()` is for in #628 