### PR TITLE
Fix in NValueExceptN for 1 value range

### DIFF
--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -444,6 +444,9 @@ class NValueExcept(GlobalFunction):
         lbs, ubs = get_bounds(arr)
         lb, ub = min(lbs), max(ubs)
 
+        if lb == ub: # if the domain has only one value then check if it is n or not
+            return [eval_comparison(cmp_op, int(lb != n), cpm_rhs)], []
+
         constraints = []
 
         # introduce boolvar for each possible value


### PR DESCRIPTION
Issue #624 showed that NValueExceptN decomposition crashes when the possible values just include one value. This ofc is bad usage of the constraint, but can happen I guess due to data given in a problem instance.

In the beginning I thought of fixing it by putting a __len__ in expressions, returning just 1, as the len(bv) is the first point that it crashes, and I think that this could happen in other cases too. But this did not fix the issue as then bv is not subscriptable.

So ended up in just a simple check if we end up with just one value (lb == ub) and then return the appropriate constraint, depending on whether that value is n or not.