### PR TITLE
Convert ints to vars in GCC first argument for Choco

### DIFF
--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -589,7 +589,7 @@ class CPM_choco(SolverInterface):
                 return self.chc_model.int_value_precede_chain(self._to_vars(cpm_expr.args[0]), cpm_expr.args[1])
             elif cpm_expr.name == "gcc":
                 vars, vals, occ = cpm_expr.args
-                return self.chc_model.global_cardinality(*self.solver_vars([vars, vals]), self._to_vars(occ), cpm_expr.closed)
+                return self.chc_model.global_cardinality(self._to_vars(vars), vals, self._to_vars(occ), cpm_expr.closed)
             else:
                 raise NotImplementedError(f"Unknown global constraint {cpm_expr}, should be decomposed! If you reach this, please report on github.")
 


### PR DESCRIPTION
Fixes issue #632 

Initial plan was to fix together with the indomain crash from #635, but that issue will be fixed outside of the choco interface.

I also checked other globals in choco if a similar fix is needed, it seems that we have covered similar cases in other globals already.

very specific bug so not sure if test is needed.