### PR TITLE
Undefault `pypblib` dependency for `pysat`

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -14,6 +14,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install ".[test, z3, choco, exact, pysat, pysdd, choco, minizinc]"
+          pip install pypblib  # dependency of pysat for PB constraints
           pip install pytest-xdist
           sudo snap install minizinc --classic
       - name: Test with pytest

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -21,7 +21,13 @@
     Installation
     ============
 
-    Requires that the 'python-sat' package is installed. If you want to also solve pseudo-Boolean and cardinality constraints, you should also install its optional dependency 'pypblib', as follows:
+    Requires that the 'python-sat' package is installed:
+
+    .. code-block:: console
+
+        $ pip install pysat
+
+    If you want to also solve pseudo-Boolean and cardinality constraints, you should also install its optional dependency 'pypblib', as follows:
 
     .. code-block:: console
 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -114,7 +114,8 @@ class CPM_pysat(SolverInterface):
         except Exception as e:
             raise e
 
-    _pb = None  # holds pysat.pb module if its dependency `pypblib` installed
+    """The `pysat.pb` module if its dependency `pypblib` installed, `None` if we have not checked it yet, or `False` if we checked and it is *not* installed"""
+    _pb = None  # 
 
     @staticmethod
     def solvernames():
@@ -446,7 +447,6 @@ class CPM_pysat(SolverInterface):
 
     def _pysat_cardinality(self, cpm_expr, reified=False):
         """ Convert CPMpy comparison of `sum` (over Boolean variables) into PySAT list of clauses """
-        assert self._card is not None, "Native module which should have been cached in init"
 
         # unpack and transform to PySAT argument
         lhs, rhs = cpm_expr.args

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -91,10 +91,11 @@ class CPM_pysat(SolverInterface):
             from pysat.formula import IDPool
             from pysat.solvers import Solver
 
+            from pysat import card
+            CPM_pysat._card = card  # native
+
             # try to import pypblib once
             if CPM_pysat._pb is None:
-                from pysat import card
-                CPM_pysat._card = card  # native
                 try:
                     from pysat import pb  # require pypblib
                     CPM_pysat._pb = pb

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -90,6 +90,17 @@ class CPM_pysat(SolverInterface):
             # while we need the 'python-sat' package, some more checks:
             from pysat.formula import IDPool
             from pysat.solvers import Solver
+
+            # try to import pypblib once
+            if CPM_pysat._pb is None:
+                from pysat import card
+                CPM_pysat._card = card  # native
+                try:
+                    from pysat import pb  # require pypblib
+                    CPM_pysat._pb = pb
+                except (ModuleNotFoundError, NameError):  # pysat returns the wrong error type (latter i/o former)
+                    CPM_pysat._pb = False  # not installed, avoid reimporting
+
             return True
         except ModuleNotFoundError:
             return False
@@ -140,16 +151,6 @@ class CPM_pysat(SolverInterface):
             subsolver = "glucose4" # something recent...
         elif subsolver.startswith('pysat:'):
             subsolver = subsolver[6:] # strip 'pysat:'
-
-        # try to import pypblib once (TODO I'd like class initialization, but can't find proper docs for it )
-        if CPM_pysat._pb is None:
-            from pysat import card
-            CPM_pysat._card = card  # native
-            try:
-                from pysat import pb  # require pypblib
-                CPM_pysat._pb = pb
-            except (ModuleNotFoundError, NameError): # pysat returns the wrong error type (latter i/o former)
-                CPM_pysat._pb = False  # not installed, avoid reimporting
 
         # initialise the native solver object
         self.pysat_vpool = IDPool()

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -148,9 +148,8 @@ class CPM_pysat(SolverInterface):
             try:
                 from pysat import pb  # require pypblib
                 CPM_pysat._pb = pb
-                # return True # now imported
             except (ModuleNotFoundError, NameError): # pysat returns the wrong error type (latter i/o former)
-                return CPM_pysat._pb is False  # not installed, avoid reimporting
+                CPM_pysat._pb = False  # not installed, avoid reimporting
 
         # initialise the native solver object
         self.pysat_vpool = IDPool()
@@ -466,8 +465,9 @@ class CPM_pysat(SolverInterface):
 
     def _pysat_pseudoboolean(self, cpm_expr):
         """Convert CPMpy comparison of `wsum` (over Boolean variables) into PySAT list of clauses."""
-        if self._pb is None:
+        if self._pb is False:
             raise ImportError("The model contains a PB constraint, for which PySAT needs an additional dependency (PBLib). To install it, run `pip install pypblib`.")
+        assert self._pb is not None, "We should have imported the `pb` module if it was installed."
 
         if cpm_expr.args[0].name != "wsum":
             raise NotSupportedError(

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -149,8 +149,8 @@ class CPM_pysat(SolverInterface):
                 from pysat import pb  # require pypblib
                 CPM_pysat._pb = pb
                 # return True # now imported
-            except ModuleNotFoundError:
-                return CPM_pysat._pblib is False # not installed, avoid reimporting
+            except (ModuleNotFoundError, NameError): # pysat returns the wrong error type (latter i/o former)
+                return CPM_pysat._pb is False  # not installed, avoid reimporting
 
         # initialise the native solver object
         self.pysat_vpool = IDPool()

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -27,7 +27,7 @@
 
         $ pip install pysat
 
-    If you want to also solve pseudo-Boolean and cardinality constraints, you should also install its optional dependency 'pypblib', as follows:
+    If you want to also solve pseudo-Boolean constraints, you should also install its optional dependency 'pypblib', as follows:
 
     .. code-block:: console
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "choco": ["pychoco>=0.2.1"],
         "exact": ["exact>=2.1.0"],
         "minizinc": ["minizinc"],
-        "pysat": ["python-sat[pblib]"],
+        "pysat": ["python-sat"],
         "gurobi": ["gurobipy"],
         "pysdd": ["pysdd"],
         "gcs": ["gcspy"],

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -15,6 +15,9 @@ def test_pypblib_error():
             lambda : CPM_pysat(cp.Model(2*cp.boolvar() + 3 * cp.boolvar() + 5 * cp.boolvar() <= 6)).solve()
         )
 
+    # this one should still work without `pypblib`
+    assert CPM_pysat(cp.Model(1*cp.boolvar() + 1 * cp.boolvar() + 1 * cp.boolvar() <= 2)).solve()
+
 @pytest.mark.skipif(not pblib_available, reason="pypblib not installed")
 class TestEncodePseudoBooleanConstraint(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -7,7 +7,7 @@ from cpmpy.solvers.pysat import CPM_pysat
 import importlib # can check for modules *without* importing them
 pblib_available = importlib.util.find_spec("pypblib") is not None
 
-@pytest.mark.skipif(pblib_available, reason="`pypblib` not installed")
+@pytest.mark.skipif(pblib_available, reason="`pypblib` is installed")
 def test_pypblib_error():
     # NOTE if you want to run this but pypblib is already installed, run `pip uninstall pypblib && pip install -e .[pysat]`
     unittest.TestCase().assertRaises(

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -1,9 +1,21 @@
 import unittest
+import pytest
 import cpmpy as cp 
 from cpmpy import *
 from cpmpy.solvers.pysat import CPM_pysat
-from cpmpy.transformations.to_cnf import to_cnf
 
+import importlib # can check for modules *without* importing them
+pblib_available = importlib.util.find_spec("pypblib") is not None
+
+@pytest.mark.skipif(pblib_available, reason="`pypblib` not installed")
+def test_pypblib_error():
+    # NOTE if you want to run this but pypblib is already installed, run `pip uninstall pypblib && pip install -e .[pysat]`
+    unittest.TestCase().assertRaises(
+            ImportError, # just solve a pb constraint with pypblib not installed
+            lambda : CPM_pysat(cp.Model(2*cp.boolvar() + 3 * cp.boolvar() + 5 * cp.boolvar() <= 6)).solve()
+        )
+
+@pytest.mark.skipif(not pblib_available, reason="pypblib not installed")
 class TestEncodePseudoBooleanConstraint(unittest.TestCase):
     def setUp(self):
         self.bv = boolvar(shape=3)


### PR DESCRIPTION
Fixes #643. To properly test it with/without installing pypblib, had to refactor the import caching a bit too (what we're actually trying to do is class initialization, but can't find the proper docs). Anyway, now it should only be imported once.