### PR TITLE
Fix tests when `pysat` is installed but `pypblib` is not

### DIFF
--- a/tests/test_pysat_cardinality.py
+++ b/tests/test_pysat_cardinality.py
@@ -3,11 +3,7 @@ import unittest
 import pytest
 import cpmpy as cp 
 from cpmpy.expressions import *
-from cpmpy.expressions.core import Operator
 from cpmpy.solvers.pysat import CPM_pysat
-from cpmpy.transformations.linearize import only_positive_coefficients
-
-pblib_available = importlib.util.find_spec("pypblib") is not None
 
 SOLVER = "pysat"
 
@@ -136,7 +132,7 @@ class TestCardinality(unittest.TestCase):
         self.assertTrue(ps.solve())
         self.assertGreaterEqual(sum(self.bvs.value()), 2)
 
-    @pytest.mark.skipif(not pblib_available, reason="`pypblib` not installed")
+    @pytest.mark.skipif(importlib.util.find_spec("pypblib") is None, reason="While cardinality constraints are natively supported by PySAT, the dependency `pypblib` is additionally required to support PB constraints for PySAT, which are generated for this test")
     def test_pysat_card_implied(self):
         b = cp.boolvar()
         x = cp.boolvar(shape=5)

--- a/tests/test_pysat_cardinality.py
+++ b/tests/test_pysat_cardinality.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest
 import pytest
 import cpmpy as cp 
@@ -6,6 +7,7 @@ from cpmpy.expressions.core import Operator
 from cpmpy.solvers.pysat import CPM_pysat
 from cpmpy.transformations.linearize import only_positive_coefficients
 
+pblib_available = importlib.util.find_spec("pypblib") is not None
 
 SOLVER = "pysat"
 
@@ -134,6 +136,7 @@ class TestCardinality(unittest.TestCase):
         self.assertTrue(ps.solve())
         self.assertGreaterEqual(sum(self.bvs.value()), 2)
 
+    @pytest.mark.skipif(not pblib_available, reason="`pypblib` not installed")
     def test_pysat_card_implied(self):
         b = cp.boolvar()
         x = cp.boolvar(shape=5)

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -1,11 +1,13 @@
 import unittest
 import pytest
-import cpmpy as cp 
+import cpmpy as cp
 from cpmpy import *
 from cpmpy.solvers.pysat import CPM_pysat
 
 import importlib # can check for modules *without* importing them
 pysat_available = CPM_pysat.supported()
+
+# pypblib is additionally required to support PB constraints for PySAT. We can skip these tests if it is not installed.
 pblib_available = importlib.util.find_spec("pypblib") is not None
 
 @pytest.mark.skipif(not (pysat_available and not pblib_available), reason="`pysat` is not installed" if not pysat_available else "`pypblib` is installed")

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -8,7 +8,7 @@ import importlib # can check for modules *without* importing them
 pysat_available = importlib.util.find_spec("pysat") is not None
 pblib_available = importlib.util.find_spec("pypblib") is not None
 
-@pytest.mark.skipif(not (pysat_available and not pblib_available), reason="`pypblib` is installed")
+@pytest.mark.skipif(not (pysat_available and not pblib_available), reason="`pysat` is not installed" if not pysat_available else "`pypblib` is installed")
 def test_pypblib_error():
     # NOTE if you want to run this but pypblib is already installed, run `pip uninstall pypblib && pip install -e .[pysat]`
     unittest.TestCase().assertRaises(
@@ -19,7 +19,7 @@ def test_pypblib_error():
     # this one should still work without `pypblib`
     assert CPM_pysat(cp.Model(1*cp.boolvar() + 1 * cp.boolvar() + 1 * cp.boolvar() <= 2)).solve()
 
-@pytest.mark.skipif(not (pysat_available and pblib_available), reason="pypblib not installed")
+@pytest.mark.skipif(not (pysat_available and pblib_available), reason="`pysat` is not installed" if not pysat_available else "`pypblib` not installed")
 class TestEncodePseudoBooleanConstraint(unittest.TestCase):
     def setUp(self):
         self.bv = boolvar(shape=3)

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -5,7 +5,7 @@ from cpmpy import *
 from cpmpy.solvers.pysat import CPM_pysat
 
 import importlib # can check for modules *without* importing them
-pysat_available = importlib.util.find_spec("pysat") is not None
+pysat_available = CPM_pysat.supported()
 pblib_available = importlib.util.find_spec("pypblib") is not None
 
 @pytest.mark.skipif(not (pysat_available and not pblib_available), reason="`pysat` is not installed" if not pysat_available else "`pypblib` is installed")

--- a/tests/test_pysat_wsum.py
+++ b/tests/test_pysat_wsum.py
@@ -5,9 +5,10 @@ from cpmpy import *
 from cpmpy.solvers.pysat import CPM_pysat
 
 import importlib # can check for modules *without* importing them
+pysat_available = importlib.util.find_spec("pysat") is not None
 pblib_available = importlib.util.find_spec("pypblib") is not None
 
-@pytest.mark.skipif(pblib_available, reason="`pypblib` is installed")
+@pytest.mark.skipif(not (pysat_available and not pblib_available), reason="`pypblib` is installed")
 def test_pypblib_error():
     # NOTE if you want to run this but pypblib is already installed, run `pip uninstall pypblib && pip install -e .[pysat]`
     unittest.TestCase().assertRaises(
@@ -18,7 +19,7 @@ def test_pypblib_error():
     # this one should still work without `pypblib`
     assert CPM_pysat(cp.Model(1*cp.boolvar() + 1 * cp.boolvar() + 1 * cp.boolvar() <= 2)).solve()
 
-@pytest.mark.skipif(not pblib_available, reason="pypblib not installed")
+@pytest.mark.skipif(not (pysat_available and pblib_available), reason="pypblib not installed")
 class TestEncodePseudoBooleanConstraint(unittest.TestCase):
     def setUp(self):
         self.bv = boolvar(shape=3)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest
 import tempfile
 import pytest

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -15,6 +15,9 @@ from cpmpy.solvers.choco import CPM_choco
 from cpmpy import SolverLookup
 from cpmpy.exceptions import MinizincNameException, NotSupportedError
 
+pysat_available = CPM_pysat.supported()
+pblib_available = importlib.util.find_spec("pypblib") is not None
+
 class TestSolvers(unittest.TestCase):
 
     # should move this test elsewhere later
@@ -313,8 +316,7 @@ class TestSolvers(unittest.TestCase):
         self.assertFalse(ps2.solve(assumptions=[mayo]+[v for v in inds]))
         self.assertEqual(ps2.get_core(), [mayo,inds[6],inds[9]])
 
-    @pytest.mark.skipif(not CPM_pysat.supported(),
-                        reason="PySAT not installed")
+    @pytest.mark.skipif(not (pysat_available and pblib_available), reason="`pysat` is not installed" if not pysat_available else "`pypblib` not installed")
     def test_pysat_card(self):
         b = cp.boolvar()
         x = cp.boolvar(shape=5)


### PR DESCRIPTION
After a fresh install with `pip install -e .[test]`, running `pytest` still fails because of two issues:

- `setuptools` not being installed (which I thought was fixed in #564; should we be able to run the tests without explicitly running `pip install setuptools`?)
- Some small issue with the changed pysat import

This PR fixes that.