### PR TITLE
Typechecking GlobalConstraint arguments

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -450,8 +450,13 @@ class NegativeTable(GlobalConstraint):
     def __init__(self, array, table):
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
-            raise TypeError(f"the first argument of a Table constraint should only contain variables/expressions: "
+            raise TypeError(f"The first argument of NegativeTable constraint should only contain variables/expressions: "
                             f"{array}")
+        if isinstance(table, np.ndarray): # Ensure table is a list
+            table = table.tolist()
+        if not all(is_int(x) for row in table for x in row):
+            raise TypeError(f"the second argument of NegativeTable constraint should only contain integers: "
+                            f"{table}")
         super().__init__("negative_table", [array, table])
 
     def decompose(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -794,6 +794,8 @@ class Decreasing(GlobalConstraint):
     """
 
     def __init__(self, *args):
+        if not is_any_list(args):
+            raise TypeError("Decreasing expects a list, but got", args)
         super().__init__("decreasing", flatlist(args))
 
     def decompose(self):
@@ -816,6 +818,8 @@ class IncreasingStrict(GlobalConstraint):
     """
 
     def __init__(self, *args):
+        if not is_any_list(args):
+            raise TypeError("IncreasingStrict expects a list, but got", args)
         super().__init__("strictly_increasing", flatlist(args))
 
     def decompose(self):
@@ -838,6 +842,8 @@ class DecreasingStrict(GlobalConstraint):
     """
 
     def __init__(self, *args):
+        if not is_any_list(args):
+            raise TypeError("DecreasingStrict expects a list, but got", args)
         super().__init__("strictly_decreasing", flatlist(args))
 
     def decompose(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -670,7 +670,7 @@ class Precedence(GlobalConstraint):
     """
     def __init__(self, vars, precedence):
         if not is_any_list(vars):
-            raise TypeError("Precedence expects a list of variables, but got", vars)
+            raise TypeError("Precedence expects a list as first argument, but got", vars)
         if not is_any_list(precedence) or any(isinstance(x, Expression) for x in precedence):
             raise TypeError("Precedence expects a list of values as precedence, but got", precedence)
         super().__init__("precedence", [cpm_array(vars), precedence])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -511,6 +511,8 @@ class InDomain(GlobalConstraint):
     """
 
     def __init__(self, expr, arr):
+        if not isinstance(expr, Expression):
+            raise TypeError(f"The first argument of InDomain should be an expression")
         if not all(is_int(x) for x in arr):
             raise TypeError(f"The second argument of InDomain should contain only integers")
         super().__init__("InDomain", [expr, arr])

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -501,6 +501,8 @@ class InDomain(GlobalConstraint):
     """
 
     def __init__(self, expr, arr):
+        if not all(is_int(x) for x in arr):
+            raise TypeError(f"The second argument of InDomain should contain only integers")
         super().__init__("InDomain", [expr, arr])
 
     def decompose(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -420,11 +420,13 @@ class ShortTable(GlobalConstraint):
     def __init__(self, array, table):
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
-            raise TypeError("The first argument of a Table constraint should only contain variables/expressions")
-        if not all(is_int(x) or x == STAR for row in table for x in row):
-            raise TypeError(f"elements in argument `table` should be integer or {STAR}")
-        if isinstance(table, np.ndarray): # Ensure it is a list
+            raise TypeError(f"The first argument of a Table constraint should only contain variables/expressions: "
+                            f"{array}")
+        if isinstance(table, np.ndarray): # Ensure table is a list
             table = table.tolist()
+        if not all(is_int(x) or x == STAR for row in table for x in row):
+            raise TypeError(f"elements in argument `table` should be integer or {STAR}: "
+                            f"{table}")
         super().__init__("short_table", [array, table])
 
     def decompose(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -393,11 +393,14 @@ class Table(GlobalConstraint):
     """
     def __init__(self, array, table):
         array = flatlist(array)
-        if isinstance(table, np.ndarray): # Ensure it is a list
-            table = table.tolist()
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError(f"the first argument of a Table constraint should only contain variables/expressions: "
                             f"{array}")
+        if isinstance(table, np.ndarray): # Ensure table is a list
+            table = table.tolist()
+        if not all(is_int(x) for row in table for x in row):
+            raise TypeError(f"the second argument of a Table constraint should only contain integers: "
+                            f"{table}")
         super().__init__("table", [array, table])
 
     def decompose(self):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -770,6 +770,8 @@ class Increasing(GlobalConstraint):
     """
 
     def __init__(self, *args):
+        if not is_any_list(args):
+            raise TypeError("Increasing expects a list, but got", args)
         super().__init__("increasing", flatlist(args))
 
     def decompose(self):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -278,10 +278,6 @@ class TestGlobal(unittest.TestCase):
     def test_InDomain(self):
         iv = cp.intvar(-8, 8)
         iv_arr = cp.intvar(-8, 8, shape=5)
-        cons = [cp.InDomain(iv, iv_arr)]
-        model = cp.Model(cons)
-        self.assertTrue(model.solve())
-        self.assertIn(iv.value(), iv_arr.value())
         vals = [1, 5, 8, -4]
         cons = [cp.InDomain(iv, vals)]
         model = cp.Model(cons)
@@ -297,30 +293,13 @@ class TestGlobal(unittest.TestCase):
         cons = cp.InDomain(min(iv_arr), vals)
         model = cp.Model(cons)
         self.assertTrue(model.solve())
-        iv2 = cp.intvar(-8, 8)
-        vals = [1, 5, 8, -4, iv2]
-        cons = [cp.InDomain(iv, vals)]
-        model = cp.Model(cons)
-        self.assertTrue(model.solve())
-        self.assertIn(iv.value(), vals)
         vals = [1, 5, 8, -4]
         bv = cp.boolvar()
         cons = [cp.InDomain(bv, vals)]
         model = cp.Model(cons)
         self.assertTrue(model.solve())
         self.assertIn(bv.value(), vals)
-        vals = [iv2, 5, 8, -4]
-        bv = cp.boolvar()
-        cons = [cp.InDomain(bv, vals)]
-        model = cp.Model(cons)
-        self.assertTrue(model.solve())
-        self.assertIn(bv.value(), vals)
-        vals = [bv & bv, 5, 8, -4]
-        bv = cp.boolvar()
-        cons = [cp.InDomain(bv, vals)]
-        model = cp.Model(cons)
-        self.assertTrue(model.solve())
-        self.assertIn(bv.value(), vals)
+
 
     def test_lex_lesseq(self):
         from cpmpy import BoolVal


### PR DESCRIPTION
Issue #635 revealed that giving unexpected arguments in global constraints can lead to crashes. Sometimes they are not even straightforward to understand where the crashes come from. Similar issues may appear for other globals as some tests revealed more globals failing.

In this PR, arguments of global constraints are typechecked for expected use. We were a bit inconsistent with that, as some global constraints had checks, while others had no checks. Even on the same constraint sometimes some arguments were checked and some not (e.g. Table-like constraints).

I went through the list of global constraints and functions and added the most straightforward ones. 