### PR TITLE
Fix all-solution `ortools` edge cases

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -88,6 +88,23 @@ class TestSolvers(unittest.TestCase):
         self.assertEqual(list(rev.value()), expected_inverse)
 
 
+    def test_ortools_solve_empty(self):
+        user_vars = []
+        sols = []
+        cp.Model().solveAll(display=lambda: sols.append(tuple(argvals(user_vars))))
+        assert len(sols) == 1, "An empty CSP (with 0 user variables) should have one solution (with an empty assignment)"
+        assert sols == [tuple()]
+
+    def test_ortools_solve_all(self):
+        x,y,z = cp.intvar(0, 2, shape=3,name="xyz")
+        p = cp.boolvar(name="p")
+        user_vars = [x, y, z, p]
+        sols = []
+        cp.Model(p.implies(
+            2 * x + 3 * y + 5 * z == 12
+        )).solveAll(display=lambda: sols.append(tuple(argvals(user_vars))))
+        assert len(sols) == len(set(sols)), "There should be no duplicate solutions"
+
     def test_ortools_direct_solver(self):
         """
         Test direct solver access.


### PR DESCRIPTION
Two edge cases to fix for `solveAll` on OR-tools:

```python

self = <test_solvers.TestSolvers testMethod=test_ortools_solve_all>

    def test_ortools_solve_all(self):
        x,y,z = cp.intvar(0, 2, shape=3,name="xyz")
        p = cp.boolvar(name="p")
        user_vars = [x, y, z, p]
        sols = []
        cp.Model(p.implies(
            2 * x + 3 * y + 5 * z == 12
        )).solveAll(display=lambda: sols.append(tuple(argvals(user_vars))))
>       assert len(sols) == len(set(sols)), "There should be no duplicate solutions"
E       AssertionError: There should be no duplicate solutions
E       assert 56 == 29
E        +  where 56 = len([(0, 0, 0, False), (0, 0, 0, False), (1, 0, 0, False), (1, 0, 0, False), (1, 1, 0, False), (1, 2, 0, False), ...])
E        +  and   29 = len({(0, 0, 0, False), (0, 0, 1, False), (0, 0, 2, False), (0, 1, 0, False), (0, 1, 1, False), (0, 1, 2, False), ...})
E        +    where {(0, 0, 0, False), (0, 0, 1, False), (0, 0, 2, False), (0, 1, 0, False), (0, 1, 1, False), (0, 1, 2, False), ...} = set([(0, 0, 0, False), (0, 0, 0, False), (1, 0, 0, False), (1, 0, 0, False), (1, 1, 0, False), (1, 2, 0, False), ...])

tests/test_solvers.py:106: AssertionError
____________________________________________________________________________________________ TestSolvers.test_ortools_solve_empty _____________________________________________________________________________________________
[gw5] linux -- Python 3.12.9 /home/hbierlee/Projects/cpmpy/.direnv/python-3.12.9/bin/python

self = <test_solvers.TestSolvers testMethod=test_ortools_solve_empty>

    def test_ortools_solve_empty(self):
        user_vars = []
        sols = []
        cp.Model().solveAll(display=lambda: sols.append(tuple(argvals(user_vars))))
>       assert len(sols) == 1, "An empty CSP (with 0 user variables) should have one solution (with an empty assignment)"
E       AssertionError: An empty CSP (with 0 user variables) should have one solution (with an empty assignment)
E       assert 0 == 1
E        +  where 0 = len([])

tests/test_solvers.py:95: AssertionError
```
