### PR TITLE
Setup fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=[
         'ortools>=9.9',
         'numpy>=1.5',
+        'setuptools',
     ],
     #extra dependency, only needed if minizinc is to be used.
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_version(rel_path):
     else:
         raise RuntimeError("Unable to find version string.")
 
-with open("README.md", "r") as readme_file:
+with open("README.md", "r", encoding="utf8") as readme_file:
     long_description = readme_file.read()
 
 setup(


### PR DESCRIPTION
Small fixes for the setup.py:
1) explicitly open README.md with utf8 encoding (`pip install -e .` started to fail on Windows)
2) add `setuptools` to required deps (was supposed to have happened in #568, identified missing in #652 )