### PR TITLE
Optional dependency 'all' solvers

### DIFF
--- a/docs/adding_solver.md
+++ b/docs/adding_solver.md
@@ -17,6 +17,8 @@ Implementing the template consists of the following parts:
 
 For your new solver to appear in CPMpy's [API documentation](./api/solvers.rst), add a `.rst` file in ``/docs/api/solvers`` (copy one of the other solvers' file and make the necessary changes) and add your solver to the *"List of submodules"* and the *"List of classes"* in the file ``/cpmpy/solvers/__init__.py``.
 
+To ease the installation process of your solver, be sure to add it to CPMpy's `setup.py`. Simply add an entry to `solver_dependencies`, mapping the cpmpy-native name for your solver (the same one used when calling `model.solve(solver=<SOLVER_NAME>)`) to the name of your pip-installable Python package and all its required dependencies.
+
 ## Transformations and posting constraints
 
 CPMpy solver interfaces are *eager*, meaning that any CPMpy expression given to it (through `__add__()`) is immediately transformed (throught `transform()`) and then posted to the solver.

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,21 @@ def get_version(rel_path):
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()
 
+
+solver_dependencies = {
+    "ortools": ["ortools"],
+    "z3": ["z3-solver"],
+    "choco": ["pychoco>=0.2.1"],
+    "exact": ["exact>=2.1.0"],
+    "minizinc": ["minizinc"],
+    "pysat": ["python-sat"],
+    "gurobi": ["gurobipy"],
+    "pysdd": ["pysdd"],
+    "gcs": ["gcspy"],
+    "cpo": ["docplex"],
+}
+solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 
+
 setup(
     name='cpmpy',
     version=get_version("cpmpy/__init__.py"),
@@ -35,26 +50,15 @@ setup(
         'ortools>=9.9',
         'numpy>=1.5',
     ],
-    #extra dependency, only needed if minizinc is to be used.
-    extras_require={
-        "FULL":  ["minizinc"],
+    extras_require=(
         # Solvers
-        "ortools": ["ortools"],
-        "z3": ["z3-solver"],
-        "choco": ["pychoco>=0.2.1"],
-        "exact": ["exact>=2.1.0"],
-        "minizinc": ["minizinc"],
-        "pysat": ["python-sat"],
-        "gurobi": ["gurobipy"],
-        "pysdd": ["pysdd"],
-        "gcs": ["gcspy"],
-        "cpo": ["docplex"],
+        solver_dependencies | {
         # Tools
         # "xcsp3": ["pycsp3"], <- for when xcsp3 is merged
         # Other
         "test": ["pytest"],
         "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2"],
-    },
+    }),
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Remove the outdated "FULL" optional dependency and add "all", which results in installing all solvers:
```console
pip install -e .[all]
pip install cpmpy[all] # same as : pip install cpmpy[ortools,z3,choco,exact,minizinc,pysat,gurobi,pysdd,gcs,cpo]
```