### PR TITLE
Changelog recovery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,8 @@
 - **Standardize solver version checks**: Unified approach to checking solver version compatibility. [#568](https://github.com/CPMpy/cpmpy/pull/568)  
 - **Update requirements**: Upped our minimal python requirement from 3.6 to 3.7. [#573](https://github.com/CPMpy/cpmpy/pull/573)
 
+**Full Changelog**: https://github.com/CPMpy/cpmpy/compare/v0.9.23...v0.9.24
+
 <!-- ---------------------------------- - ---------------------------------- -->
 
 ## 0.9.23
@@ -51,6 +53,8 @@ Quick release, because we want the updated tools to be available.
 * Extension to tools: MARCO and SMUS 
 * Added tests for incremental solving and fixed incemental solving with objective in Exact
 * Cumulative decomposition fix when capacity was numpy integer.
+
+**Full Changelog**: https://github.com/CPMpy/cpmpy/compare/v0.9.22...v0.9.23
 
 <!-- ---------------------------------- - ---------------------------------- -->
 
@@ -79,6 +83,8 @@ Quick release, because we want the updated tools to be available.
 Thanks to 2 new contributors!
 * [@ThomSerg](https://github.com/ThomSerg) and [@sin3000x](https://github.com/sin3000x)
 
+**Full Changelog**: https://github.com/CPMpy/cpmpy/compare/v0.9.21...v0.9.22
+
 <!-- ---------------------------------- - ---------------------------------- -->
 
 ## 0.9.21
@@ -104,6 +110,8 @@ Thanks to 2 new contributors!
 * Extending automatic testsuite
 * Check if minizinc executable is installed
 
+**Full Changelog**: https://github.com/CPMpy/cpmpy/compare/v0.9.20...v0.9.21
+
 <!-- ---------------------------------- - ---------------------------------- -->
 
 ## 0.9.20
@@ -116,6 +124,8 @@ Thanks to 2 new contributors!
 * Added a warning when expressions have non-integer bounds, as these will be rounded
 * Fixed a bug in our helper function is_bool, now also recognises our BoolVal objects
 * Updated our ortools and minizinc version requirements.
+
+**Full Changelog**: https://github.com/CPMpy/cpmpy/compare/v0.9.19..v0.9.20
 
 <!-- ---------------------------------- - ---------------------------------- -->
 
@@ -139,6 +149,8 @@ Thanks to 2 new contributors!
 * Correctly handle global constraints with list-arguments of length 1
 * Add missing edge case in flatten
 * Type check table constraint first argument, cannot be a constant.
+
+**Full Changelog**: https://github.com/CPMpy/cpmpy/compare/v0.9.18...v0.9.19
 
 <!-- ---------------------------------- - ---------------------------------- -->
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,168 @@
 # Change log
 
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.24
+
+### Release Notes
+
+#### Enhancements and Features
+- **Safening of partial functions**: New transformation to safen partial function. [#515](https://github.com/CPMpy/cpmpy/pull/515)
+- **Update Choco interface with native reification**: Improved the Choco solver interface with native reification support. [#526](https://github.com/CPMpy/cpmpy/pull/526)  
+- **Reals in objective function**: Added support for real numbers in the objective function. [#529](https://github.com/CPMpy/cpmpy/pull/529)  
+- **Better naive grow**: Enhanced the "naive grow" strategy for better performance. [#528](https://github.com/CPMpy/cpmpy/pull/528)  
+- **Blocks world**: Introduced a "blocks world" example for demonstration purposes. [#533](https://github.com/CPMpy/cpmpy/pull/533)  
+- **Examples Colab links**: Added direct Colab links to examples for easier experimentation. [#553](https://github.com/CPMpy/cpmpy/pull/553)  
+- **Circuit decomposition for all ranges**: Extended circuit decomposition to handle all ranges. [#424](https://github.com/CPMpy/cpmpy/pull/424)  
+- **Global function in Z3 objective**: Introduced global functions in Z3 solver objectives. [#560](https://github.com/CPMpy/cpmpy/pull/560)  
+- **Z3 auto subsolver**: Implemented automatic subsolver selection for Z3 when solving optimization problems. [#567](https://github.com/CPMpy/cpmpy/pull/567)  
+- **Parametrize solver tests**: Streamlined solver test cases using parameterization. [#572](https://github.com/CPMpy/cpmpy/pull/572)  
+- **Linearize power**: Added linearization for power operations. [#538](https://github.com/CPMpy/cpmpy/pull/538)  
+- **Improve Boolean normalization for PySAT**: Enhanced normalization of Boolean terms for PySAT. [#569](https://github.com/CPMpy/cpmpy/pull/569)  
+
+#### Performance Improvements
+- **Has subexpr optimization**: Skip transformations of leaf expressions for improved efficiency. [#532](https://github.com/CPMpy/cpmpy/pull/532)  
+- **Only implied speedup**: Optimized "only implied" handling for significant speedups. [#541](https://github.com/CPMpy/cpmpy/pull/541)  
+- **Distribute tests over CPUs**: Distributed tests over 4 CPUs, reducing runtime from `21m30s` to `8m45s`. [#571](https://github.com/CPMpy/cpmpy/pull/571)  
+- **ndvar_getitem optimization**: Improved `ndvar_getitem` by moving fetch casts to initialization. [#550](https://github.com/CPMpy/cpmpy/pull/550) 
+- **Remove inline imports**: Instead use `import as x` at top of file. [#542](https://github.com/CPMpy/cpmpy/pull/542)  
+
+#### Bug Fixes
+- **Remove broadcast in min/max**: Fixed issues when forwarding to built-in min/max functions. [#536](https://github.com/CPMpy/cpmpy/pull/536)  
+- **Convert numpy array in Table constraint**: Ensured proper conversion of NumPy arrays to lists in Table constraints. [#540](https://github.com/CPMpy/cpmpy/pull/540)  
+- **Clear values on UNSAT**: Added functionality to clear variable values when UNSAT is detected. [#523](https://github.com/CPMpy/cpmpy/pull/523)  
+- **Fix cpm_array with order='F'**: Resolved issues with `cpm_array()` when using column-major order. [#555](https://github.com/CPMpy/cpmpy/pull/555)  
+- **Car sequencing index fix**: Corrected indexing issues in the car sequencing problem. [#565](https://github.com/CPMpy/cpmpy/pull/565)  
+
+#### Code Quality and Maintenance
+- **Improve exception messages**: Enhanced clarity of exception messages and removed unused imports. [#539](https://github.com/CPMpy/cpmpy/pull/539)  
+- **Edits to the docs**: Updated documentation for clarity and completeness. [#530](https://github.com/CPMpy/cpmpy/pull/530)    
+- **Gurobi license check**: Separated Gurobi license checks into a distinct process. [#566](https://github.com/CPMpy/cpmpy/pull/566)  
+- **Standardize solver version checks**: Unified approach to checking solver version compatibility. [#568](https://github.com/CPMpy/cpmpy/pull/568)  
+- **Update requirements**: Upped our minimal python requirement from 3.6 to 3.7. [#573](https://github.com/CPMpy/cpmpy/pull/573)
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.23
+
+Quick release, because we want the updated tools to be available.
+
+### What's Changed
+* Extension to tools: MARCO and SMUS 
+* Added tests for incremental solving and fixed incemental solving with objective in Exact
+* Cumulative decomposition fix when capacity was numpy integer.
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.22
+
+### What's New
+* New solver: GlasgowConstraintSolver (GCS)
+* Upgraded to Exact 2
+* Minizinc print: easily extract MiniZinc and FlatZinc text from CPMpy model.
+* Update TEMPLATE.py to make it clearer how to add new solvers.
+* SolverLookup gives clear error message in stead of returning None
+* allow kwargs in Model.solve()
+* call python builtins for sum, abs, min and max without expressions in the arguments.
+* All solvers now have a native_model() function, to allow native solver access.
+* It's now possible to name multiple new variables at once, by providing the names in a list.
+* Linearize transformation can now rewrite modulo (if multiplication is supported)
+* Fix behaviour of "all", "any", "max", "min", "sum", "prod" on higher dimensional NDVarArrays (maintain dimensionality)
+* Value function of expressions now always returns a python integer, where it could sometimes be a numpy integer.
+* Fixed performance issue where all solver vars where seen as user vars when solving with MiniZinc
+
+### Documentation
+* Overall improvement of documentation
+* update documentation of 'comparison' transformation
+
+### New Contributors
+Thanks to 2 new contributors!
+* [@ThomSerg](https://github.com/ThomSerg) and [@sin3000x](https://github.com/sin3000x)
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.21
+
+### New Global constraints:
+* Increasing, Decreasing, IncreasingStrict, DecreasingStrict
+* Lexicographical ordering constraints: LexLess, LexLessEq, LexChainLess, LexChainLessEq
+* Scheduling constraints Precedence and NoOverlap
+* Closed version of GCC
+* AllDiffExceptN, AllEqualExceptN 
+* Nvalues except n
+* Negative table
+* Among
+
+### Bug Fixes:
+* count nested in a wsum crashed MiniZinc [#461](https://github.com/CPMpy/cpmpy/issues/461)
+* AllDifferentExcept0 now correctly works with MiniZinc
+* User variables that get simplified away during transformation steps are now saved.
+* Add missing case in simplify bool transformation.
+
+### Quality of life
+* Removed type restriction for InDomain
+* Extending automatic testsuite
+* Check if minizinc executable is installed
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.20
+
+### What's Changed
+* Choco is now a tier 2 solver, available to use after installing the pychoco package! 
+* new DIMACS parser and writer
+* SolverLookup is now a classmethod for easier use of custom solvers.
+* Fixed a bug where expression bounds didn't get rounded to integers when creating an intvar
+* Added a warning when expressions have non-integer bounds, as these will be rounded
+* Fixed a bug in our helper function is_bool, now also recognises our BoolVal objects
+* Updated our ortools and minizinc version requirements.
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.19
+
+### What's Changed
+* Update on tools/subsets, add mcs and mss tools with grow-variants.
+* Full propagation with exact
+* Adding NValue global constraint
+* Minizinc result now saved in solver object, this allows to access the solver statistics.
+
+### Documentation
+* Update docs for tools.
+* Docs on solver statistics
+* Format solver api, and add missing links in docs
+* Update version and copyright date
+* Remove bug where python comment (#) got interpreted as a header.
+
+### Bug Fixes
+* Properly handle reified global constraints for Minizinc
+* Correctly handle global constraints with list-arguments of length 1
+* Add missing edge case in flatten
+* Type check table constraint first argument, cannot be a constant.
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
+## 0.9.18
+Minor release with some bugfixes, we are trying to do monthly releases now, so they will be more concise.
+
+### What's new?
+* get_bounds() helper function now works on arrays and lists, returning arrays (lists) of bounds
+* Pysdd added to our automated GitHub tests
+* Pysdd does not support Xor anymore.
+
+### Bugfixes
+* Fixed Cumulative bug when capacity was a numpy int.
+* Cumulative now works in Minizinc with only one task.
+* Docs look good again
+* Corrected default parameter value in docs
+* Fixed visualisations in Nonogram and Room assignment notebook examples
+* Adopted the new ORtools 9.8 names of tuneable parameters.
+
+## New Contributors
+* [@KennyVDV](https://github.com/KennyVDV) made their first contribution by adding a new example: chess_position
+
+<!-- ---------------------------------- - ---------------------------------- -->
+
 ## 0.9.17
 Some new solvers supported at tier 3, update to our transformations and bugfixes.
 


### PR DESCRIPTION
Bring the changelog back to a file-centric workflow, i.e. update the `changelog.md` and then call
```console
gh release create vX.Y.Z -F changelog.md
```
(see release wiki for more info)

The last few releases have been done though the GitHub interface, resulting in an outdated changelog file. This pull request brings the file back up-to-date.