### PR TITLE
remove unnecessary set operations from deletion-based MUS

### DIFF
--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -52,11 +52,9 @@ def mus(soft, hard=[], solver="ortools"):
     for c in sorted(core, key=lambda c : -len(get_variables(dmap[c]))):
         if c not in core:
             continue # already removed
-        core.remove(c)
-        if s.solve(assumptions=list(core)) is True:
-            core.add(c)
-        else: # UNSAT, use new solver core (clause set refinement)
-            core = set(s.get_core())
+
+        if not s.solve(assumptions=list(core)):
+            core = set(s.get_core()) # UNSAT, use new solver core (clause set refinement)
 
     return [dmap[avar] for avar in core]
 


### PR DESCRIPTION
Small change to MUS computation where assumptions are removed and added back to the to the core set unnecessarily. Seems to matter quite a bit when testing om some toy problems