### PR TITLE
Fix inverse decomposition

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -381,7 +381,7 @@ class Inverse(GlobalConstraint):
         constraining, defining = [], []
         for i,x in enumerate(fwd):
             if is_num(x) and not 0 <= x < len(rev): 
-                return [cp.BoolVal(False)], [] # this will never work
+                return [cp.BoolVal(False)], [] # can never satisfy the Inverse constraint
            
             lb, ub = get_bounds(x)
             if lb >= 0 and ub < len(rev): # safe, index is within bounds

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -389,7 +389,7 @@ class Inverse(GlobalConstraint):
             else: # partial! need safening here
                 is_defined, total_expr, toplevel = cp.transformations.safening._safen_range(rev[x], (0, len(rev)-1), 1)
                 constraining += [is_defined, total_expr == i]
-            defining += toplevel
+                defining += toplevel
         
         return constraining, defining
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -374,7 +374,6 @@ class Inverse(GlobalConstraint):
         super().__init__("inverse", [fwd, rev])
 
     def decompose(self):
-        from cpmpy.transformations.safening import _safen_range
 
         fwd, rev = self.args
         rev = cpm_array(rev)
@@ -388,7 +387,7 @@ class Inverse(GlobalConstraint):
             if lb >= 0 and ub < len(rev): # safe, index is within bounds
                 constraining.append(rev[x] == i)
             else: # partial! need safening here
-                is_defined, total_expr, toplevel =_safen_range(rev[x], (0, len(rev)-1), 1)
+                is_defined, total_expr, toplevel = cp.transformations.safening._safen_range(rev[x], (0, len(rev)-1), 1)
                 constraining += [is_defined, total_expr == i]
             defining += toplevel
         

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -374,9 +374,25 @@ class Inverse(GlobalConstraint):
         super().__init__("inverse", [fwd, rev])
 
     def decompose(self):
+        from cpmpy.transformations.safening import _safen_range
+
         fwd, rev = self.args
         rev = cpm_array(rev)
-        return [cp.all(rev[x] == i for i, x in enumerate(fwd))], []
+
+        constraining, defining = [], []
+        for i,x in enumerate(fwd):
+            if is_num(x) and not 0 <= x < len(rev): 
+                return [cp.BoolVal(False)], [] # this will never work
+           
+            lb, ub = get_bounds(x)
+            if lb >= 0 and ub < len(rev): # safe, index is within bounds
+                constraining.append(rev[x] == i)
+            else: # partial! need safening here
+                is_defined, total_expr, toplevel =_safen_range(rev[x], (0, len(rev)-1), 1)
+                constraining += [is_defined, total_expr == i]
+            defining += toplevel
+        
+        return constraining, defining
 
     def value(self):
         fwd = argvals(self.args[0])

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -33,10 +33,10 @@ SAT_SOLVERS = {"pysat", "pysdd"}
 
 EXCLUDE_GLOBAL = {"pysat": NUM_GLOBAL,
                   "pysdd": NUM_GLOBAL | {"Xor"},
-                  "z3": {"Inverse"},
-                  "choco": {"Inverse"},
-                  "ortools":{"Inverse"},
-                  "exact": {"Inverse"},
+                  "z3": {},
+                  "choco": {},
+                  "ortools":{},
+                  "exact": {},
                   "minizinc": {"IncreasingStrict"}, # bug #813 reported on libminizinc
                   "gcs": {}
                   }


### PR DESCRIPTION
The current decomposition of `Inverse` is invalid as it does not account for the potential partiality of the Element constraints it generates.

As we do safening **before** decomposing global constraints, we need to make sure any decomposition is safe.
This PR fixes that, by re-using one one the safening helper functions.

Inverse is also re-enabled in the testsuite (previously disabled for all solvers, hence master was already fine)