### PR TITLE
Remove 3.9 syntax from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,15 +51,15 @@ setup(
         'numpy>=1.5',
         'setuptools',
     ],
-    extras_require=(
+    extras_require={
         # Solvers
-        solver_dependencies | {
+        **solver_dependencies,
         # Tools
         # "xcsp3": ["pycsp3"], <- for when xcsp3 is merged
         # Other
         "test": ["pytest"],
         "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2"],
-    }),
+    },
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
One of the changes I made to the `setup.py` to support the "all" optional dependency breaks support for python 3.8. 
`a = dict | dict` is apparently syntax only introduced since 3.9, should have done `a = {**dict, **dict}` instead.

Luckily, our GitHub workflow responsible for the release to pip builds the wheels using python 3.9, so the version on pip is not affected.

Came across this issue whilst cleaning up my "dev-tooling", adding the ability to easily run our testsuite against all supported python versions. Will make a pull request with this tooling so that we can catch such issues in the future.