### PR TITLE
Fix eval comparison

### DIFF
--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -157,6 +157,11 @@ def eval_comparison(str_op, lhs, rhs):
 
         Especially useful in decomposition and transformation functions that already involve a comparison.
     """
+    if isinstance(lhs, np.integer):
+        lhs = int(lhs)
+    if isinstance(rhs, np.integer):
+        rhs = int(rhs)
+
     if str_op == '==':
         return lhs == rhs
     elif str_op == '!=':

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -5,8 +5,8 @@ import numpy as np
 from cpmpy.exceptions import IncompleteFunctionError
 from cpmpy.expressions import *
 from cpmpy.expressions.variables import NDVarArray
-from cpmpy.expressions.core import Operator, Expression
-from cpmpy.expressions.utils import get_bounds, argval
+from cpmpy.expressions.core import Comparison, Operator, Expression
+from cpmpy.expressions.utils import eval_comparison, get_bounds, argval
 
 class TestComparison(unittest.TestCase):
     def test_comps(self):
@@ -649,6 +649,35 @@ class TestContainer(unittest.TestCase):
         assert d[self.x] == "x"
         assert d[self.y] == "y"
         assert d[self.z] == "z"
+
+        
+class TestUtils(unittest.TestCase):
+
+    def test_eval_comparison(self):
+        x = intvar(0,10, name="x")
+
+        for comp in ["==", "!=", "<", "<=", ">", ">="]:
+            expr = eval_comparison(comp, x, 5)
+            self.assertIsInstance(expr, Comparison)
+            self.assertEqual(str(expr.args[0]), "x")
+            self.assertEqual(expr.args[1], 5) # should always put the constant on the right
+
+            expr = eval_comparison(comp, 5, x)
+            self.assertIsInstance(expr, Comparison)
+            self.assertEqual(str(expr.args[0]), "x")
+            self.assertEqual(expr.args[1], 5) # should always put the constant on the right
+
+            # now, also check with numpy
+            expr = eval_comparison(comp, x, np.int64(5))
+            self.assertIsInstance(expr, Comparison)
+            self.assertEqual(str(expr.args[0]), "x")
+            self.assertEqual(expr.args[1], 5) # should always put the constant on the right
+
+            expr = eval_comparison(comp, np.int64(5), x)
+            self.assertIsInstance(expr, Comparison)
+            self.assertEqual(str(expr.args[0]), "x")
+            self.assertEqual(expr.args[1], 5) # should always put the constant on the right
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `__bool__` optimization opened up a new rabbit hole.

The root cause was the following snippet:"
```python
import cpmpy as cp

idx = cp.intvar(0,1, name="idx")
arr = cp.cpm_array([100,200])
y = cp.intvar(0,1000)

lookup = arr[idx]
decomp = lookup.decompose_comparison("==", y)
print(decomp)
>> ([not([idx == 0]), not([idx == 1]), idx >= 0, idx <= 1], [])
```

Interenally, we rely on `eval_comparison` but this goes wrong when comparing with numpy integer.
E.g., `np.int64(100) == x` returns `False`.

I patched it in this PR, but we should have a look at how to do this more properly (e.g., in #625 ?)

Should be merged quite soon (tutorial currently fails to run)