### PR TITLE
Fix CSE edge-case in only_numexpr_equality

### DIFF
--- a/cpmpy/transformations/comparison.py
+++ b/cpmpy/transformations/comparison.py
@@ -38,7 +38,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
             if not isinstance(cond, _BoolVarImpl): # expr -> bv
                 res = only_numexpr_equality([cond], supported, csemap=csemap)
                 if len(res) == 1 and cond is not res[0]: # changed, but no new cons due to CSE
-                    newcons[i] = res[0]
+                    newcons[i] = res[0].implies(subexpr)
                 if len(res) > 1:
                     newcons[i] = res[1].implies(subexpr)
                     newcons.insert(i, res[0])
@@ -46,7 +46,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
             elif not isinstance(subexpr, _BoolVarImpl):  # bv -> expr
                 res = only_numexpr_equality([subexpr], supported, csemap=csemap)
                 if len(res) == 1 and subexpr is not res[0]: # changed, but no new cons due to CSE
-                    newcons[i] = res[0]
+                    newcons[i] = cond.implies(res[0])
                 if len(res) > 1:
                     newcons[i] = cond.implies(res[1])
                     newcons.insert(i, res[0]) # can still be changted because of CSE
@@ -62,7 +62,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
                 if not isinstance(lhs, _BoolVarImpl):  # expr == bv
                     res = only_numexpr_equality([lhs], supported, csemap=csemap)
                     if len(res) == 1 and lhs is not res[0]: # changed, but no new cons due to CSE
-                        newcons[i] = res[0]
+                        newcons[i] = res[0] == rhs
                     if len(res) > 1:
                         newcons[i] = res[1] == rhs
                         newcons.insert(i, res[0])
@@ -70,7 +70,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
                 elif not isinstance(rhs, _BoolVarImpl):  # bv == expr
                     res = only_numexpr_equality([rhs], supported, csemap=csemap)
                     if len(res) == 1 and rhs is not res[0]: # changed, but no new cons due to CSE
-                        newcons[i] = res[0]
+                        newcons[i] = lhs == res[0]
                     if len(res) > 1:
                         newcons[i] = lhs == res[1]
                         newcons.insert(i, res[0])

--- a/cpmpy/transformations/comparison.py
+++ b/cpmpy/transformations/comparison.py
@@ -49,7 +49,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
                     newcons[i] = cond.implies(res[0])
                 if len(res) > 1:
                     newcons[i] = cond.implies(res[1])
-                    newcons.insert(i, res[0]) # can still be changted because of CSE
+                    newcons.insert(i, res[0]) 
             else: #bv -> bv
                 pass
 


### PR DESCRIPTION
Because of CSE, only_numexpr_equality can return a single expression to transform a constraint.

E.g, if `csemap = {max(x,y,z) : IV0}`, then calling `only_numexpr_equality([`max(x,y,z) < 42`]) will return `IV0 < 42`.
The old code assumed that if there was only 1 constraint returned, nothing changed.

This cause some tests to fail for Pumpkin, and probably a failing test in #583 is also linked to this (yet to test).