### PR TITLE
Choco shorttable STAR int

### DIFF
--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -596,7 +596,7 @@ class CPM_choco(SolverInterface):
                 table = table.astype(float) # nan's require float dtype
                 # Choco requires a wildcard value not present in dom of args,
                 # take value lower than anything else
-                chc_star = min(np.nanmin(table), *get_bounds(array)[0]) -1
+                chc_star = int(min(np.nanmin(table), *get_bounds(array)[0]) -1) # should be an int
                 chc_table = np.nan_to_num(table, nan=chc_star).astype(int).tolist()
                 return self.chc_model.table(self.solver_vars(array), chc_table, universal_value=chc_star, algo="STR2+")
             elif cpm_expr.name == "regular":


### PR DESCRIPTION
Ensure that the star symbol used for choco's shorttable is an integer. Some tricks have been used to detect star locations by turning the table data type to float and representing the stars as `np.nan`. The smallest non-nan value then gets found and STAR will take the value of 1 less (min - 1). But when posting to the solver, choco expects a int star-symbol, which is currently still a float. Simply fixed by casting to int (the min - 1 is already is an int but represented with the float datatype).
