### PR TITLE
Fix constants in global decomposition

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -229,7 +229,6 @@ class AllDifferentExcept0(AllDifferentExceptN):
         All nonzero arguments have a distinct value
     """
     def __init__(self, *arr):
-        flatarr = flatlist(arr)
         super().__init__(arr, 0)
 
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1368,6 +1368,13 @@ class TestTypeChecks(unittest.TestCase):
                 except (NotImplementedError, NotSupportedError):
                     pass
 
+    def test_issue_699(self):
+        x,y = cp.intvar(0,10, shape=2, name=tuple("xy"))
+        self.assertTrue(cp.Model(cp.AllDifferentExcept0([x,0,y,0]).decompose()).solve())
+        self.assertTrue(cp.Model(cp.AllDifferentExceptN([x,3,y,0], 3).decompose()).solve())
+        self.assertTrue(cp.Model(cp.AllDifferentExceptN([x,3,y,0], [3,0]).decompose()).solve())
+
+
     def test_element_index_dom_mismatched(self):
         """
             Check transform of `[0,1,2][x in -1..1] == y in 1..5`


### PR DESCRIPTION
For some globals, we use `.implies` on a comparison, which can fail when comparing two constants.
Fixes #699, and another argument to get started on some more structured testing (#650 ;) )