### PR TITLE
Boolean constant in wsum

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -763,12 +763,15 @@ class Operator(Expression):
             weights, vars = self.args
             bounds = []
             #this may seem like too many lines, but avoiding np.sum avoids overflowing things at int32 bounds
-            for i, varbounds in enumerate([get_bounds(arg) for arg in vars]):
-                sortbounds = (list(weights[i] * x for x in varbounds))
-                sortbounds.sort()
-                bounds += [sortbounds]
-            lbs, ubs = (zip(*bounds))
-            lowerbound, upperbound = sum(lbs), sum(ubs) #this is builtins sum, not numpy sum
+            for w, (lb, ub) in zip(weights, [get_bounds(arg) for arg in vars]):
+                x,y = int(w) * lb, int(w) * ub
+                if x <= y: # x is the lb of this arg
+                    lowerbound += x
+                    upperbound += y
+                else:
+                    lowerbound += y
+                    upperbound += x
+
         elif self.name == 'sub':
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -762,6 +762,7 @@ class Operator(Expression):
         elif self.name == 'wsum':
             weights, vars = self.args
             bounds = []
+            lowerbound, upperbound = 0,0
             #this may seem like too many lines, but avoiding np.sum avoids overflowing things at int32 bounds
             for w, (lb, ub) in zip(weights, [get_bounds(arg) for arg in vars]):
                 x,y = int(w) * lb, int(w) * ub

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -90,7 +90,7 @@ from types import GeneratorType
 import numpy as np
 import cpmpy as cp
 
-from .utils import is_num, is_any_list, flatlist, get_bounds, is_boolexpr, is_true_cst, is_false_cst, argvals, is_bool
+from .utils import is_int, is_num, is_any_list, flatlist, get_bounds, is_boolexpr, is_true_cst, is_false_cst, argvals, is_bool
 from ..exceptions import IncompleteFunctionError, TypeError
 
 

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -633,6 +633,13 @@ class Operator(Expression):
         # we have the requirement that weighted sums are [weights, expressions]
         if name == 'wsum':
             assert all(is_num(a) for a in arg_list[0]), "wsum: arg0 has to be all constants but is: "+str(arg_list[0])
+            weights = []
+            for w in arg_list[0]:
+                if is_int(w):
+                    weights.append(int(w)) # bool or int, simplifies things later on
+                else:
+                    weights.append(w) # can be float
+            arg_list = (weights, arg_list[1])
 
         # small cleanup: nested n-ary operators are merged into the toplevel
         # (this is actually against our design principle of creating

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -80,7 +80,9 @@ def numexprs(solver):
         names = [(name, arity) for name, arity in names if name not in EXCLUDE_OPERATORS[solver]]
     for name, arity in names:
         if name == "wsum":
-            operator_args = [list(range(len(NUM_ARGS))), NUM_ARGS]
+            yield Operator("wsum", [list(range(len(NUM_ARGS))), NUM_ARGS])
+            yield Operator("wsum", [[True, BoolVal(False), np.True_], NUM_ARGS]) # bit of everything
+            continue
         elif name == "div" or name == "pow":
             operator_args = [NN_VAR,3]
         elif arity != 0:


### PR DESCRIPTION
Allows to use Boolean constants as arguments in a weighted sum, fixes #688 
Especially useful when using a Boolean array as mask during modeling.

Also includes rewrite of `get_bounds` of weighted sum, avoiding sorting of the arguments, which could go wrong previously... Not sure if it can stay in this PR