### PR TITLE
Add missing "version" to pumpkin

### DIFF
--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -37,6 +37,8 @@
 """
 import warnings
 import re
+from typing import Optional
+import pkg_resources
 
 from os.path import join
 
@@ -80,6 +82,19 @@ class CPM_pumpkin(SolverInterface):
         except Exception as e:
             raise e
 
+
+    @staticmethod
+    def version() -> Optional[str]:
+        """
+        Returns the installed version of the solver's Python API.
+        """
+        try:
+            # there is also a version of the solver itself in the Cargo.toml (/pumpkin-solver/Cargo.toml)
+            # currently not accessible through the python api
+            # dynamic = ["version"] in the pyproject.toml does not seem to get the right value?
+            return pkg_resources.get_distribution('pumpkin-solver-py').version 
+        except pkg_resources.DistributionNotFound:
+            return None
 
     def __init__(self, cpm_model=None, subsolver=None):
         """


### PR DESCRIPTION
Pumpkin was missing an implementation for "version". Added a simple implementation getting the version of the python library.
This "version" is currently not in sync with the one from the rust codebase (defined in `/pumpkin-solver/Cargo.toml`)
Would be nice to be also able to return the version of the solver itself, not just the python API.