### PR TITLE
Test and fix `version` method for all solvers

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1047,3 +1047,5 @@ class TestSupportedSolvers:
         num_sols = cp.Model(cp.BoolVal(False)).solveAll(solver=solver, solution_limit=solution_limit)
         assert num_sols == 0
 
+    def test_version(self, solver):
+        assert SolverLookup.lookup(solver).version() is not None


### PR DESCRIPTION
This fixes `version()` for all solvers (on CI).

A small fix that can be merged quickly. Alternatively, we could try out just implementing this in `SolverInterface` class, because most `version` methods use? Avoiding this duplication for most solvers:

```py
@staticmethod
def version() -> Optional[str]:
    """
    Returns the installed version of the solver's Python API.
    """
    try:
        return pkg_resources.get_distribution('pumpkin').version
    except pkg_resources.DistributionNotFound:
        return None
```
