### PR TITLE
Special case xor in solver interfaces

### DIFF
--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -54,7 +54,8 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.globalconstraints import DirectConstraint
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, boolvar, intvar
 from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.utils import is_num, is_int, eval_comparison, flatlist, argval, argvals, get_bounds
+from ..expressions.utils import is_num, is_int, eval_comparison, flatlist, argval, argvals, get_bounds, is_true_cst, \
+    is_false_cst
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
@@ -593,7 +594,17 @@ class CPM_ortools(SolverInterface):
                 fwd, rev = self.solver_vars(cpm_expr.args)
                 return self.ort_model.AddInverse(fwd, rev)
             elif cpm_expr.name == 'xor':
-                return self.ort_model.AddBoolXOr(self.solver_vars(cpm_expr.args))
+                args = cpm_expr.args
+                if any(is_true_cst(a) for a in cpm_expr.args):
+                    # replace with constant variable instead
+                    if not hasattr(self, "_true_var"):
+                        self._true_var = boolvar()
+                        self.add(self._true_var)
+                    args = [a if not is_true_cst(a) else self._true_var for a in cpm_expr.args]
+
+                # remove false constants
+                args = [a for a in args if not is_false_cst(a)]
+                return self.ort_model.AddBoolXOr(self.solver_vars(args))
             else:
                 raise NotImplementedError(f"Unknown global constraint {cpm_expr}, should be decomposed! "
                                           f"If you reach this, please report on github.")

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -501,6 +501,8 @@ class CPM_z3(SolverInterface):
                 return z3.Distinct(self._z3_expr(cpm_con.args))
             elif cpm_con.name == 'xor':
                 z3_args = self._z3_expr(cpm_con.args)
+                if len(z3_args) == 1: # just the arg
+                    return z3_args[0]
                 z3_cons = z3.Xor(z3_args[0], z3_args[1])
                 for a in z3_args[2:]:
                     z3_cons = z3.Xor(z3_cons, a)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -59,7 +59,7 @@ from cpmpy.transformations.reification import only_implies, only_bv_reifies
 from .decompose_global import decompose_in_tree
 
 from .flatten_model import flatten_constraint, get_or_make_var
-from .normalize import toplevel_list
+from .normalize import toplevel_list, simplify_boolean
 from .. import Abs
 from ..exceptions import TransformationNotImplementedError
 
@@ -297,6 +297,15 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum"}, reified=False, c
 
             [cpm_expr] = canonical_comparison([cpm_expr])  # just transforms the constraint, not introducing new ones
             lhs, rhs = cpm_expr.args
+
+            if lhs.name == "sum" and len(lhs.args) == 1 and isinstance(lhs.args[0], _BoolVarImpl) and "or" in supported:
+                # very special case, avoid writing as sum of 1 argument
+                new_expr = simplify_boolean([eval_comparison(cpm_expr.name,lhs.args[0], rhs)])
+                assert len(new_expr) == 1
+                newlist.append(Operator("or", new_expr))
+                continue
+
+
 
             # check trivially true/false (not allowed by PySAT Card/PB)
             if cpm_expr.name in ('<', '<=', '>', '>=') and is_num(rhs):

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -51,8 +51,10 @@ def toplevel_list(cpm_expr, merge_and=True):
 
 def simplify_boolean(lst_of_expr, num_context=False):
     """
-    Removes boolean constants from all CPMpy expressions.
-    Only resulting boolean constant is literal 'false'.
+    Removes boolean constants from all CPMpy expressions, except for constants in global constraints/functions.
+    Solver interfaces are expected to implement special cases of typing for global constraints themselves.
+
+    Only resulting Boolean constant is literal 'false'.
     Boolean constants are promoted to `int` if in a numerical context,
     `ints` are never converted to `bool`.
     

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -193,7 +193,10 @@ def global_constraints(solver):
             continue
 
         if name == "Xor":
-            expr = cls(BOOL_ARGS)
+            yield Xor(BOOL_ARGS)
+            yield Xor(BOOL_ARGS + [True,False])
+            yield Xor([True])
+            continue
         elif name == "Inverse":
             expr = cls(NUM_ARGS, [1,0,2])
         elif name == "Table":

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -195,7 +195,6 @@ def global_constraints(solver):
         if name == "Xor":
             yield Xor(BOOL_ARGS)
             yield Xor(BOOL_ARGS + [True,False])
-            yield Xor([True])
             continue
         elif name == "Inverse":
             expr = cls(NUM_ARGS, [1,0,2])

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -709,6 +709,20 @@ class TestGlobal(unittest.TestCase):
         self.assertFalse(cp.Model(cp.Xor([False, False])).solve())
         self.assertFalse(cp.Model(cp.Xor([False, False, False])).solve())
 
+    def test_ite_with_constants(self):
+        x,y,z = cp.boolvar(shape=3)
+        expr = cp.IfThenElse(True, y, z)
+        self.assertTrue(cp.Model(expr).solve())
+        self.assertTrue(expr.value())
+        expr = cp.IfThenElse(False, y, z)
+        self.assertTrue(cp.Model(expr).solve())
+
+        expr = cp.IfThenElse(x, y, z)
+        self.assertTrue(cp.Model(~expr).solve())
+        self.assertFalse(expr.value())
+        x,y, z = x.value(), y.value(), z.value()
+        self.assertTrue((x and z) or (not x and y))
+
 
 
     def test_not_xor(self):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -686,28 +686,30 @@ class TestGlobal(unittest.TestCase):
 
         bvs = cp.boolvar(shape=3)
 
-        cases = [(bvs.tolist() + [True],              True),
-                 (bvs.tolist() + [True, True],        True),
-                 (bvs.tolist() + [True, True, True],  True),
-                 (bvs.tolist() + [False],             True),
-                 (bvs.tolist() + [False, True],       True),
-                 ([True], False),
-                 ([False], True)
-               ]
-        for arg, res in cases:
-            expr = cp.Xor(arg)
+        cases =[bvs.tolist() + [True],
+                bvs.tolist() + [True, True],
+                bvs.tolist() + [True, True, True],
+                bvs.tolist() + [False],
+                bvs.tolist() + [False, True],
+                [True]]
 
+        for args in cases:
+            expr = cp.Xor(args)
             model = cp.Model(expr)
-            print(model)
-            self.assertEqual(model.solve(), res)
-            if res:
-                self.assertTrue(expr.value())
 
-            d_model = cp.Model(expr.decompose())
-            self.assertEqual(d_model.solve(), res)
-            if res:
-                self.assertTrue(expr.value())
-            
+            self.assertTrue(model.solve())
+            self.assertTrue(expr.value())
+
+            # also check with decomposition
+            model = cp.Model(expr.decompose())
+            self.assertTrue(model.solve())
+            self.assertTrue(expr.value())
+
+        # edge case with False constants
+        self.assertFalse(cp.Model(cp.Xor([False, False])).solve())
+        self.assertFalse(cp.Model(cp.Xor([False, False, False])).solve())
+
+
 
     def test_not_xor(self):
         bv = cp.boolvar(5)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -682,6 +682,33 @@ class TestGlobal(unittest.TestCase):
         self.assertTrue(cp.Model(cp.Xor(bv)).solve())
         self.assertTrue(cp.Xor(bv).value())
 
+    def test_xor_with_constants(self):
+
+        bvs = cp.boolvar(shape=3)
+
+        cases = [(bvs.tolist() + [True],              True),
+                 (bvs.tolist() + [True, True],        True),
+                 (bvs.tolist() + [True, True, True],  True),
+                 (bvs.tolist() + [False],             True),
+                 (bvs.tolist() + [False, True],       True),
+                 ([True], False),
+                 ([False], True)
+               ]
+        for arg, res in cases:
+            expr = cp.Xor(arg)
+
+            model = cp.Model(expr)
+            print(model)
+            self.assertEqual(model.solve(), res)
+            if res:
+                self.assertTrue(expr.value())
+
+            d_model = cp.Model(expr.decompose())
+            self.assertEqual(d_model.solve(), res)
+            if res:
+                self.assertTrue(expr.value())
+            
+
     def test_not_xor(self):
         bv = cp.boolvar(5)
         self.assertTrue(cp.Model(~cp.Xor(bv)).solve())


### PR DESCRIPTION
Cherry pick relevant commits from #703

Only implements special casing for XOR constraint with constants in the solver interfaces.
Affected solvers are:
- OR-Tools
- Z3
- Pysat (through linearize changes, resulting from combination of decomposing and int2bool transformation)

Allows to leave some more time to think about changes in #703 which will now just be about the negation of globals.