### PR TITLE
Pin Pumpkin git commit

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,7 @@ jobs:
           
           # install pumpkin from source
           pip install maturin
-          git clone https://github.com/consol-lab/pumpkin pumpkin
+          git clone https://github.com/consol-lab/pumpkin pumpkin --branch pumpkin-core-v0.2.1
           cd pumpkin/pumpkin-solver-py
           maturin build
           pip install ../target/wheels/*.whl # name can change based on version

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -18,7 +18,7 @@
 
     The `pumpkin_solver_py` python package is currently not available on PyPI.
     It can be installed from source using the following steps:
-     1. clone the repository from github: https://github.com/consol-lab/pumpkin
+     1. clone the release `v0.2.1` repository from github, e.g.: `git clone https://github.com/consol-lab/pumpkin pumpkin --branch pumpkin-core-v0.2.1`
      2. install the "maturin" package to build the python bindings: :code:`pip install maturin`
      3. build and install the package: :code:`cd pumpkin/pumpkin-solver-py && maturin develop`
 


### PR DESCRIPTION
In this tag, the `constraint_tag` argument is not yet required as it is on main (which is break CI atm). Not sure if this fixes it, as locally `maturin build` is still building the latest source for some reason.