### PR TITLE
Implement constraint tagging for Pumpkin

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install ".[test, z3, exact, pysat, pysdd, pychoco, minizinc, pindakaas, pumpkin-solver]"
+          pip install ".[test, z3, exact, pysat, pysdd, pychoco, minizinc, pindakaas, pumpkin]"
           pip install pypblib  # dependency of pysat for PB constraints
           pip install pytest-xdist
           sudo snap install minizinc --classic          

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,18 +13,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install ".[test, z3, choco, exact, pysat, pysdd, choco, minizinc, pindakaas]"
+          pip install ".[test, z3, choco, exact, pysat, pysdd, choco, minizinc, pindakaas, pumpkin]"
           pip install pypblib  # dependency of pysat for PB constraints
           pip install pytest-xdist
-          sudo snap install minizinc --classic
-          
-          # install pumpkin from source
-          pip install maturin
-          git clone https://github.com/consol-lab/pumpkin pumpkin --branch pumpkin-core-v0.2.1
-          cd pumpkin/pumpkin-solver-py
-          maturin build
-          pip install ../target/wheels/*.whl # name can change based on version
-          cd ../../ # back to cpmpy
+          sudo snap install minizinc --classic          
 
       - name: Test with pytest
         run: |

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -16,11 +16,13 @@
     Installation
     ===============
 
-    The `pumpkin_solver_py` python package is currently not available on PyPI.
-    It can be installed from source using the following steps:
-     1. clone the release `v0.2.1` repository from github, e.g.: `git clone https://github.com/consol-lab/pumpkin pumpkin --branch pumpkin-core-v0.2.1`
-     2. install the "maturin" package to build the python bindings: :code:`pip install maturin`
-     3. build and install the package: :code:`cd pumpkin/pumpkin-solver-py && maturin develop`
+    Requires that the 'pumpkin-solver' python package is installed:
+
+    .. code-block:: console
+    
+        $ pip install pumpkin-solver
+
+    The rest of this documentation is for advanced users
 
     ===============
     List of classes

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -37,11 +37,8 @@
     Module details
     ==============
 """
-import warnings
-import re
 from typing import Optional
-import pkg_resources
-
+from importlib.metadata import version, PackageNotFoundError
 from os.path import join
 
 import numpy as np
@@ -86,7 +83,7 @@ class CPM_pumpkin(SolverInterface):
 
 
     @staticmethod
-    def version() -> Optional[str]:
+    def version(cls) -> Optional[str]:
         """
         Returns the installed version of the solver's Python API.
         """
@@ -94,8 +91,8 @@ class CPM_pumpkin(SolverInterface):
             # there is also a version of the solver itself in the Cargo.toml (/pumpkin-solver/Cargo.toml)
             # currently not accessible through the python api
             # dynamic = ["version"] in the pyproject.toml does not seem to get the right value?
-            return pkg_resources.get_distribution('pumpkin-solver-py').version 
-        except pkg_resources.DistributionNotFound:
+            return version('pumpkin-solver')
+        except PackageNotFoundError:
             return None
 
     def __init__(self, cpm_model=None, subsolver=None):

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -381,6 +381,8 @@ class CPM_pumpkin(SolverInterface):
         # do we already have this predicate? 
         #  (actually, cse might already catch these...)
         if (lhs, comp, rhs) not in self.predicate_map:
+            if tag is None:
+                tag = self.pum_solver.new_constraint_tag()
             pred = Predicate(self.to_pum_ivar(lhs, tag=tag), comp, rhs)
             self.predicate_map[(lhs, comp, rhs)] = pred
         

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -83,14 +83,11 @@ class CPM_pumpkin(SolverInterface):
 
 
     @staticmethod
-    def version(cls) -> Optional[str]:
+    def version() -> Optional[str]:
         """
         Returns the installed version of the solver's Python API.
         """
         try:
-            # there is also a version of the solver itself in the Cargo.toml (/pumpkin-solver/Cargo.toml)
-            # currently not accessible through the python api
-            # dynamic = ["version"] in the pyproject.toml does not seem to get the right value?
             return version('pumpkin-solver')
         except PackageNotFoundError:
             return None

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -77,7 +77,7 @@ class CPM_pumpkin(SolverInterface):
     def supported():
         # try to import the package
         try:
-            import pumpkin_solver_py as psp
+            import pumpkin_solver as psp
             return True
         except ModuleNotFoundError:
             return False
@@ -107,9 +107,9 @@ class CPM_pumpkin(SolverInterface):
             subsolver: None, not used
         """
         if not self.supported():
-            raise Exception("CPM_Pumpkin: Install the python package 'pumpkin_solver_py'")
+            raise Exception("CPM_Pumpkin: Install the python package 'pumpkin_solver'")
 
-        from pumpkin_solver_py import Model
+        from pumpkin_solver import Model
 
         assert subsolver is None 
 
@@ -147,9 +147,9 @@ class CPM_pumpkin(SolverInterface):
         """
 
         # Again, I don't know why this is necessary, but the PyO3 modules seem to be a bit wonky.
-        from pumpkin_solver_py import BoolExpression as PumpkinBool, IntExpression as PumpkinInt
-        from pumpkin_solver_py import SatisfactionResult, SatisfactionUnderAssumptionsResult
-        from pumpkin_solver_py.optimisation import OptimisationResult, Direction
+        from pumpkin_solver import BoolExpression as PumpkinBool, IntExpression as PumpkinInt
+        from pumpkin_solver import SatisfactionResult, SatisfactionUnderAssumptionsResult
+        from pumpkin_solver.optimisation import OptimisationResult, Direction
 
         # ensure all vars are known to solver
         self.solver_vars(list(self.user_vars))
@@ -348,7 +348,7 @@ class CPM_pumpkin(SolverInterface):
         """
             Convert a CPMpy expression to a Pumpkin predicate (comparison with constant)
         """
-        from pumpkin_solver_py import Comparator, Predicate
+        from pumpkin_solver import Comparator, Predicate
 
         if isinstance(cpm_expr, _BoolVarImpl):
             if isinstance(cpm_expr, NegBoolView):
@@ -459,7 +459,7 @@ class CPM_pumpkin(SolverInterface):
             Convert a CPMpy expression into a Pumpkin constraint
             Expects a transformed CPMpy expression, this logic is implemented as a separate function so we can support reification in `add()`
         """
-        from pumpkin_solver_py import constraints
+        from pumpkin_solver import constraints
         if tag is None:
             tag = self.pum_solver.new_constraint_tag()
         if isinstance(cpm_expr, _BoolVarImpl):

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ solver_dependencies = {
     "gcs": ["gcspy"],
     "cpo": ["docplex"],
     "pindakaas": ["pindakaas"],
+    "pumpkin": ["pumpkin-solver>=0.2.1"]
 }
 solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 
 


### PR DESCRIPTION
The Python interface of Pumpkin has changed, and now requires to add a consrtaint tag to each constraint while posting.
This PR updates our interface to do exactly that.

The purpose of the tags is to, while reading the proof-log, figure out which constraints were used to derive a new clause.

In this PR, the tags are chosen such that they correspond to a "transformed" constraint as supported by the solver.
Alternatively, we can also chose to make the tags correspond to the untransformed, user-level consrtaints instead.
In the MiniZinc interface, they correspond to each flatzinc constraint if I remember correcly; so tried to minic this here as well.