### PR TITLE
Template docstrings

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -12,7 +12,7 @@
     the constraints or objective stored in the model.
 
     A model can be solved multiple times, and constraints can be added inbetween solve calls.
-    Note that constraints are added using the ``+=`` operator (implemented by :meth:`__add__() <cpmpy.model.Model.__add__>`).
+    Note that constraints are added using :meth:`.add(...) <cpmpy.model.Model.add>` or using the ``+=`` operator (implemented by :meth:`__add__() <cpmpy.model.Model.__add__>`).
 
     See the full list of functions below.
 
@@ -49,9 +49,9 @@ class Model(object):
             Arguments of constructor:
 
             Arguments:
-                `*args`: Expression object(s) or list(s) of Expression objects
-                `minimize`: Expression object representing the objective to minimize
-                `maximize`: Expression object representing the objective to maximize
+                *args (Expression or list[Expression]): The constraints of the model
+                minimize (Expression): The objective to minimize
+                maximize (Expression): The objective to maximize
 
             At most one of minimize/maximize can be set, if none are set, it is assumed to be a satisfaction problem
         """
@@ -85,16 +85,16 @@ class Model(object):
         Add one or more constraints to the model.
 
         Arguments:
-            con (Expression or list): Expression object(s) or list(s) of Expression objects representing constraints
+            con (Expression or list[Expression]): Expression object(s) or list(s) of Expression objects representing constraints
 
         Returns:
-            Model: Returns self to allow for method chaining
+            Model: Returns ``self`` to allow for method chaining
 
         Example:
             .. code-block:: python
 
                 m = Model()
-                m += [x > 0]
+                m.add([x > 0])
         """
         if is_any_list(con):
             # catch some beginner mistakes: check that top-level Expressions in the list have Boolean return type
@@ -122,7 +122,7 @@ class Model(object):
         """
             Minimize the given objective function
 
-            `minimize()` can be called multiple times, only the last one is stored
+            ``minimize()`` can be called multiple times, only the last one is stored
         """
         self.objective(expr, minimize=True)
 
@@ -130,7 +130,7 @@ class Model(object):
         """
             Maximize the given objective function
 
-            `maximize()` can be called multiple times, only the last one is stored
+            ``maximize()`` can be called multiple times, only the last one is stored
         """
         self.objective(expr, minimize=False)
 
@@ -141,9 +141,9 @@ class Model(object):
 
             Arguments:
                 expr (Expression):      the CPMpy expression that represents the objective function
-                minimize (bool):        whether it is a minimization problem (True) or maximization problem (False)
+                minimize (bool):        whether it is a minimization problem (``True``) or maximization problem (``False``)
 
-            'objective()' can be called multiple times, only the last one is stored
+            ``objective()`` can be called multiple times, only the last one is stored
         """
         self.objective_ = expr
         self.objective_is_min = minimize
@@ -153,7 +153,7 @@ class Model(object):
             Check if the model has an objective function
 
             Returns:
-                bool: True if the model has an objective function, False otherwise
+                bool: ``True`` if the model has an objective function, ``False`` otherwise
         """
         return self.objective_ is not None
 
@@ -162,14 +162,15 @@ class Model(object):
             Returns the value of the objective function of the last solver run on this model
 
             Returns:
-                an integer or 'None' if it is not run or is a satisfaction problem
+                int, optional:  The objective value as an integer or ``None`` if it is not run or is a satisfaction problem
         """
         return self.objective_.value()
 
     def solve(self, solver=None, time_limit=None, **kwargs):
-        """ Send the model to a solver and get the result.
+        """ 
+        Send the model to a solver and get the result.
 
-            Run :func:`SolverLookup.solvernames() <cpmpy.solvers.SolverLookup.solvernames>` to find out the valid solver names on your system. (default: None = first available solver)
+        Run :func:`SolverLookup.solvernames() <cpmpy.solvers.utils.SolverLookup.solvernames>` to find out the valid solver names on your system. (default: None = first available solver)
 
         Arguments:
             solver (string or a name in SolverLookup.solvernames() or a SolverInterface class (Class, not object!), optional): 
@@ -180,8 +181,8 @@ class Model(object):
         Returns:
             bool: the computed output:
 
-            - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)
-            - False     if no solution is found
+            - ``True``      if a solution is found (not necessarily optimal, e.g. could be after timeout)
+            - ``False``     if no solution is found
         """
         if kwargs and solver is None:
             raise NotSupportedError("Specify the solver when using kwargs, since they are solver-specific!")
@@ -206,9 +207,9 @@ class Model(object):
             If at least one solution was found and the solver exhausted all possible solutions, the solver status will be 'Optimal', otherwise 'Feasible'.
 
             Arguments:
-                display:            either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
-                                    default/None: nothing displayed
-                solution_limit:     stop after this many solutions (default: None)
+                display:                            either a list of CPMpy expressions, OR a callback function, called with the variables after value-mapping
+                                                    default/None: nothing displayed
+                solution_limit (int, optional):     stop after this many solutions (default: None)
 
             Returns:
                 int: number of solutions found (within the time and solution limit)
@@ -235,7 +236,7 @@ class Model(object):
             Status information includes exit status (optimality) and runtime.
 
             Returns:
-                an object of :class:`SolverStatus`
+                an object of :class:`SolverStatus <cpmpy.solvers.solver_interface.SolverStatus>`
         """
         return self.cpm_status
 
@@ -263,7 +264,7 @@ class Model(object):
 
     def to_file(self, fname):
         """
-            Serializes this model to a ``.pickle`` format
+            Serializes this model to a `.pickle` format
 
             Arguments:
                 fname (FileDescriptorOrPath): Filename of the resulting serialized model
@@ -278,7 +279,7 @@ class Model(object):
             Reads a Model instance from a binary pickled file
 
             Returns:
-                an object of :class: `Model`
+                an object of :class:`Model`
         """
         with open(fname, "rb") as f:
             m = pickle.load(f)


### PR DESCRIPTION
A proposal reference on the docstring style.

I tried cleaning up the `model.py` docstrings a bit, following the [google docstring style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html), to use this file as a reference (`model.py` seemed to have the most consistent docstrings already).

Alternative docstring styles are 
- numpydoc 
- reST style
- javadoc style

(see [here](https://stackoverflow.com/questions/3898572/what-are-the-most-common-python-docstring-formats) for some examples)
In my opinion, the google style is the most readable. But open to other proposals.

A decision which still needs to be made, regards the use of backticks. Single backticks render as italic text, double render as inline code. In some of our docstrings we use single where double would actually be more appropriate. There is an option in sphinx to render both as inline code, fixing the rendering without needing to change all out backtick use. But as included in this example template, it can still be useful to be able to make a distinction between the two. E.g. `.pickle` file format is referenced somewhere. We want to highlight it, but not make it an inline code. So single backtick makes it italic.

---

So a proposal:

- use google-style docstrings
- use backlinks whenever possible (e.g. ``:func:`SolverLookup.solvernames() <cpmpy.solvers.utils.SolverLookup.solvernames>``
- if possible include type hints for the arguments and the return value
- single backticks to highlight a piece of text (e.g. a concept like a file type), use double backticks for inline code snippets (use codeblocks `.. code-block:: python` when not inline)
- for default values, it seems like adding `(default: ...)` at the end of the argument description has already been used quite consistently, so we could stick with that style

Will add these guidelines to the wiki (and update them with any feedback provided here)