### PR TITLE
Skip psplib test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,7 +19,10 @@ import itertools
 EXAMPLES = glob(join("examples", "*.py")) + glob(join("examples", "csplib", "*.py"))
 ADVANCED_EXAMPLES = glob(join("examples", "advanced", "*.py"))
 
-SKIPPED_EXAMPLES = ["ocus_explanations.py", "psplib.py"]  # waiting for issues to be resolved
+SKIPPED_EXAMPLES = [
+                    "ocus_explanations.py", # waiting for issues to be resolved 
+                    "psplib.py" # randomly fails on github due to file creation
+                    ]  
 
 # SOLVERS = SolverLookup.supported()
 SOLVERS = [


### PR DESCRIPTION
The test randomly fails on github often, while also slows down a lot the testing. Also, it creates around 480 files each time. It does not seem needed so excluding it.