### PR TITLE
Safe variable names

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -65,9 +65,9 @@ import cpmpy as cp  # to avoid circular import
 from .core import Expression, Operator
 from .utils import is_num, is_int, flatlist, is_boolexpr, is_true_cst, is_false_cst, get_bounds
 
-_BV_NAME = "BV"
-_IV_NAME = "IV"
-_VAR_ERR  = f"Variable names starting with {_IV_NAME} or {_BV_NAME} are reserved for internal use only, chose a different name"
+_BV_PREFIX = "BV"
+_IV_PREFIX = "IV"
+_VAR_ERR  = f"Variable names starting with {_IV_PREFIX} or {_BV_PREFIX} are reserved for internal use only, chose a different name"
 
 def BoolVar(shape=1, name=None):
     """
@@ -344,7 +344,7 @@ class _IntVarImpl(_NumVarImpl):
         assert is_int(ub), "IntVar upperbound must be integer {} {}".format(type(ub), ub)
 
         if name is None:
-            name = "{}{}".format(_IV_NAME, _IntVarImpl.counter)
+            name = f"{_IV_PREFIX}{_IntVarImpl.counter}"
             _IntVarImpl.counter = _IntVarImpl.counter + 1 # static counter
 
         super().__init__(int(lb), int(ub), name=name) # explicit cast: can be numpy
@@ -371,7 +371,7 @@ class _BoolVarImpl(_IntVarImpl):
         assert(ub == 0 or ub == 1)
 
         if name is None:
-            name = "{}{}".format(_BV_NAME,_BoolVarImpl.counter)
+            name = f"{_BV_PREFIX}{_BoolVarImpl.counter}"
             _BoolVarImpl.counter = _BoolVarImpl.counter + 1 # static counter
         _IntVarImpl.__init__(self, lb, ub, name=name)
 
@@ -787,5 +787,5 @@ def _genname(basename, idxs):
     return f"{basename}[{stridxs}]" # "<name>[<idx0>,<idx1>,...]"
 
 def _is_invalid_name(name):
-    return name.startswith(_IV_NAME) or name.startswith(_BV_NAME)
+    return name.startswith(_IV_PREFIX) or name.startswith(_BV_PREFIX)
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -65,6 +65,9 @@ import cpmpy as cp  # to avoid circular import
 from .core import Expression, Operator
 from .utils import is_num, is_int, flatlist, is_boolexpr, is_true_cst, is_false_cst, get_bounds
 
+_BV_NAME = "BV"
+_IV_NAME = "IV"
+_VAR_ERR  = f"Variable names starting with {_IV_NAME} or {_BV_NAME} are reserved for internal use only, chose a different name"
 
 def BoolVar(shape=1, name=None):
     """
@@ -124,6 +127,8 @@ def boolvar(shape=1, name=None):
     if shape == 0 or shape is None:
         raise NullShapeError(shape)
     if shape == 1:
+        if name is not None and _is_invalid_name(name):
+            raise ValueError(_VAR_ERR)
         return _BoolVarImpl(name=name)
 
     # collect the `names` of each individual decision variable
@@ -206,6 +211,8 @@ def intvar(lb, ub, shape=1, name=None):
     if shape == 0 or shape is None:
         raise NullShapeError(shape)
     if shape == 1:
+        if name is not None and _is_invalid_name(name):
+            raise ValueError(_VAR_ERR)
         return _IntVarImpl(lb, ub, name=name)
 
     # collect the `names` of each individual decision variable
@@ -337,7 +344,7 @@ class _IntVarImpl(_NumVarImpl):
         assert is_int(ub), "IntVar upperbound must be integer {} {}".format(type(ub), ub)
 
         if name is None:
-            name = "IV{}".format(_IntVarImpl.counter)
+            name = "{}{}".format(_IV_NAME, _IntVarImpl.counter)
             _IntVarImpl.counter = _IntVarImpl.counter + 1 # static counter
 
         super().__init__(int(lb), int(ub), name=name) # explicit cast: can be numpy
@@ -364,7 +371,7 @@ class _BoolVarImpl(_IntVarImpl):
         assert(ub == 0 or ub == 1)
 
         if name is None:
-            name = "BV{}".format(_BoolVarImpl.counter)
+            name = "{}{}".format(_BV_NAME,_BoolVarImpl.counter)
             _BoolVarImpl.counter = _BoolVarImpl.counter + 1 # static counter
         _IntVarImpl.__init__(self, lb, ub, name=name)
 
@@ -756,6 +763,8 @@ def _gen_var_names(name, shape):
             raise ValueError(f"The shape of name sequence {name_arr.shape} does not match {shape}.")
         if len(name_arr.flat) != len(np.unique(name_arr)):
             raise ValueError(f"Duplicated names in {name_arr}.")
+        if any(_is_invalid_name(n) for n in name_arr.flat):
+            raise ValueError(_VAR_ERR)
         return [name_arr[idx] for idx in np.ndindex(shape)]
     else:
         raise TypeError(f"Unsupported type for name: {type(name)}")
@@ -772,6 +781,11 @@ def _genname(basename, idxs):
     """
     if basename == None:
         return None
+    if _is_invalid_name(basename):
+        raise ValueError(_VAR_ERR)
     stridxs = ",".join(map(str, idxs))
     return f"{basename}[{stridxs}]" # "<name>[<idx0>,<idx1>,...]"
+
+def _is_invalid_name(name):
+    return name.startswith(_IV_NAME) or name.startswith(_BV_NAME)
 

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -284,24 +284,25 @@ class Model(object):
             m = pickle.load(f)
             # bug 158, we should increase the boolvar/intvar counters to avoid duplicate names
             from cpmpy.transformations.get_variables import get_variables_model  # avoid circular import
+            from cpmpy.expressions.variables import _BoolVarImpl, _IntVarImpl, _BV_PREFIX, _IV_PREFIX # avoid circular import
             vs = get_variables_model(m)
             bv_counter = 0
             iv_counter = 0
             for v in vs:
-                if v.name.startswith("BV"):
+                if v.name.startswith(_BV_PREFIX):
                     try:
                         bv_counter = max(bv_counter, int(v.name[2:])+1)
                     except:
                         pass
-                elif v.name.startswith("IV"):
+                elif v.name.startswith(_IV_PREFIX):
                     try:
                         iv_counter = max(iv_counter, int(v.name[2:])+1)
                     except:
                         pass
-            from cpmpy.expressions.variables import _BoolVarImpl, _IntVarImpl  # avoid circular import
+
             if (_BoolVarImpl.counter > 0 and bv_counter > 0) or \
                     (_IntVarImpl.counter > 0 and iv_counter > 0):
-                warnings.warn(f"from_file '{fname}': contains auxiliary IV*/BV* variables with the same name as already created. Only add expressions created AFTER loadig this model to avoid issues with duplicate variables.")
+                warnings.warn(f"from_file '{fname}': contains auxiliary {_IV_PREFIX}*/{_BV_PREFIX}* variables with the same name as already created. Only add expressions created AFTER loadig this model to avoid issues with duplicate variables.")
             _BoolVarImpl.counter = max(_BoolVarImpl.counter, bv_counter)
             _IntVarImpl.counter = max(_IntVarImpl.counter, iv_counter)
             return m

--- a/cpmpy/tools/xcsp3/xcsp3_cpmpy.py
+++ b/cpmpy/tools/xcsp3/xcsp3_cpmpy.py
@@ -71,6 +71,7 @@ from cpmpy.solvers.solver_interface import ExitStatus as CPMStatus
 from cpmpy.tools.xcsp3 import _parse_xcsp3, _load_xcsp3
 from cpmpy.tools.xcsp3 import globals
 from cpmpy.solvers.ortools import CPM_ortools
+from cpmpy.expressions.variables import _BV_PREFIX, _IV_PREFIX
 
 # PyCSP3
 from xml.etree.ElementTree import ParseError
@@ -259,7 +260,7 @@ def solution_xml(model, useless_style="*", boolean_style="int"):
 
     # How useless variables should be handled
     #    (variables which have value `None` in the solution)
-    variables = {var.name: var for var in model.user_vars if var.name[:2] not in ["IV", "BV", "B#"]} # dirty workaround for all missed aux vars in user vars
+    variables = {var.name: var for var in model.user_vars if var.name[:2] not in [_IV_PREFIX, _BV_PREFIX, "B#"]} # dirty workaround for all missed aux vars in user vars
     if useless_style == "*":
         variables = {k:(v.value() if v.value() is not None else "*") for k,v in variables.items()}
     elif useless_style == "drop":

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -52,6 +52,38 @@ class TestSolvers(unittest.TestCase):
         c = cp.boolvar(shape=(2,3), name="c")
         self.assertEqual(str(c), "[[c[0,0] c[0,1] c[0,2]]\n [c[1,0] c[1,1] c[1,2]]]")
 
+    def test_invalid_bv(self):
+
+        self.assertRaises(ValueError, lambda: cp.boolvar(name="BV123"))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name="BV123", shape=3))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name=("BV0", "x", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name=("x", "BV1", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name=[["x","y","z"],["a", "BV1", "b"]], shape=(2,3)))
+
+
+        # this seems fine but it is not!! can still clash
+        self.assertRaises(ValueError, lambda: cp.boolvar(name="IV123"))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name="IV123", shape=3))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name=("IV0", "x", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name=("x", "IV1", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.boolvar(name=[["x","y","z"],["a", "IV1", "b"]], shape=(2,3)))
+
+
+    def test_invalid_iv(self):
+
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="IV123"))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="IV123", shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("BV0", "x", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("x", "IV1", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "BV0", "b"]], shape=(2,3)))
+
+        # this seems fine but it is not!! can still clash
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="BV123"))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="BV123", shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("BV0", "x", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("x", "BV1", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "IV0", "b"]], shape=(2,3)))
+
     def test_clear(self):
         def n_none(v):
             return sum(v.value() == None)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -73,16 +73,16 @@ class TestSolvers(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="IV123"))
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="IV123", shape=3))
-        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("BV0", "x", "y"), shape=3))
+        self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("IV0", "x", "y"), shape=3))
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("x", "IV1", "y"), shape=3))
-        self.assertRaises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "BV0", "b"]], shape=(2,3)))
+        self.assertRaises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "IV0", "b"]], shape=(2,3)))
 
         # this seems fine but it is not!! can still clash
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="BV123"))
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name="BV123", shape=3))
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("BV0", "x", "y"), shape=3))
         self.assertRaises(ValueError, lambda: cp.intvar(0, 10, name=("x", "BV1", "y"), shape=3))
-        self.assertRaises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "IV0", "b"]], shape=(2,3)))
+        self.assertRaises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "BV0", "b"]], shape=(2,3)))
 
     def test_clear(self):
         def n_none(v):


### PR DESCRIPTION
Add code to ensure a user cannot make a variable whose name can collide with auxiliary variables.