### PR TITLE
Not contiguous array handling in cpm_array

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -256,7 +256,7 @@ def cpm_array(arr):
     """
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)
-    elif not arr.flags['C_CONTIGUOUS'] and not arr.flags['F_CONTIGUOUS']:   # Ensure the array is contiguous before creating NDVarArray
+    elif not arr.flags['C_CONTIGUOUS'] and not arr.flags['F_CONTIGUOUS']:   # Ensure the array is contiguous
         arr = np.ascontiguousarray(arr)
     
     order = 'F' if arr.flags['F_CONTIGUOUS'] else 'C'

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -256,9 +256,7 @@ def cpm_array(arr):
     """
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)
-    
-    # Ensure the array is contiguous before creating NDVarArray
-    if not arr.flags['C_CONTIGUOUS'] and not arr.flags['F_CONTIGUOUS']:
+    elif not arr.flags['C_CONTIGUOUS'] and not arr.flags['F_CONTIGUOUS']:   # Ensure the array is contiguous before creating NDVarArray
         arr = np.ascontiguousarray(arr)
     
     order = 'F' if arr.flags['F_CONTIGUOUS'] else 'C'

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -256,6 +256,11 @@ def cpm_array(arr):
     """
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)
+    
+    # Ensure the array is contiguous before creating NDVarArray
+    if not arr.flags['C_CONTIGUOUS'] and not arr.flags['F_CONTIGUOUS']:
+        arr = np.ascontiguousarray(arr)
+    
     order = 'F' if arr.flags['F_CONTIGUOUS'] else 'C'
     return NDVarArray(shape=arr.shape, dtype=arr.dtype, buffer=arr, order=order)
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -717,6 +717,14 @@ class TestContainer(unittest.TestCase):
         
 class TestUtils(unittest.TestCase):
 
+    def test_cpm_array(self):
+        x = cp.intvar(0,10, shape=(3, 3))
+        self.assertIsInstance(cpm_array(x), NDVarArray)
+        self.assertEqual(cpm_array(x).shape, (3, 3))
+
+        self.assertIsInstance(cpm_array(x.T), NDVarArray)
+        self.assertEqual(cpm_array(x.T).shape, (3, 3))
+
     def test_eval_comparison(self):
         x = intvar(0,10, name="x")
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -983,6 +983,10 @@ class TestGlobal(unittest.TestCase):
             self.assertTrue(cons.value())
         cp.Model(cons).solveAll(display=check_true)
 
+        # test not contiguous
+        iv = cp.intvar(0, 10, shape=(3, 3))
+        self.assertTrue(cp.Model([cp.NValue(i) == 3 for i in iv.T]).solve())
+        
     def test_nvalue_except(self):
 
         iv = cp.intvar(-8, 8, shape=3)
@@ -1010,6 +1014,11 @@ class TestGlobal(unittest.TestCase):
             self.assertTrue(cons.value())
 
         cp.Model(cons).solveAll(display=check_true)
+
+        # test not contiguous
+        iv = cp.intvar(0, 10, shape=(3, 3))
+        self.assertTrue(cp.Model([cp.NValueExcept(i, val) == 3 for i in iv.T]).solve())
+
 
     @pytest.mark.skipif(not CPM_minizinc.supported(),
                         reason="Minizinc not installed")


### PR DESCRIPTION
Issue #737 revealed that our cpm_array function does not handle non-contiguous arrays, which can happen easily even with just a transpose.

In this PR, I just add a check for that, and if it is not contiguous, we make it.

Also added tests both with the nvalue constraint, where it was originally found, and a separate one for cpm_array alone.