### PR TITLE
Fix installation of pychoco on github action

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install ".[test, z3, choco, exact, pysat, pysdd, choco, minizinc, pindakaas]"
+          pip install ".[test, z3, exact, pysat, pysdd, pychoco, minizinc, pindakaas]"
           pip install pypblib  # dependency of pysat for PB constraints
           pip install pytest-xdist
           sudo snap install minizinc --classic


### PR DESCRIPTION
Previously installed "choco" but the correct package is "pychoco"