### PR TITLE
Fix non-iterable + index range and add constraint nr 1

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -774,11 +774,14 @@ class Precedence(GlobalConstraint):
         args, precedence = self.args
         constraints = []
         for s,t in zip(precedence[:-1], precedence[1:]):
-            for j in range(len(args)):
+            # constraint 1 from paper
+            constraints.append(args[0] != t) 
+            # constraint 2 from paper
+            for j in range(1,len(args)):
                 lhs = args[j] == t
                 if is_bool(lhs):  # args[j] and t could both be constants
                     lhs = BoolVal(lhs)
-                constraints += [lhs.implies(cp.any(args[:j] == s))]
+                constraints += [lhs.implies(cp.any(cp.cpm_array(args[:j]) == s))] # wrap with cpm_array to capture non-iterable when j=1
         return constraints, []
 
     def value(self):


### PR DESCRIPTION
The fuzz-tester detected an issue with the decomposition for the `Precedence` global.

When j is 0 or 1, `args[:j]) == s` can result in a single bool or boolvar, which is not iterable. Wrapping it with `cpm_array` fixes it. 

Two other issues I noticed when going through the code:
1) j should start from 1, as `args[:j]` will otherwise be empty
2) constraint nr 1 from the paper was missing? `constraints.append(args[0] != t)`