### PR TITLE
Skip slow examples

### DIFF
--- a/examples/csplib/prob001_car_sequence.py
+++ b/examples/csplib/prob001_car_sequence.py
@@ -74,7 +74,6 @@ if __name__ == "__main__":
     # argument parsing
     url = "https://raw.githubusercontent.com/CPMpy/cpmpy/master/examples/csplib/prob001_car_sequence.json"
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    #parser.add_argument('-instance', nargs='?', default="Problem 4/72  (Regin & Puget #1)", help="Name of the problem instance found in file 'filename'")
     parser.add_argument('-instance', nargs='?', default="Problem 60-04", help="Name of the problem instance found in file 'filename'")
     parser.add_argument('-filename', nargs='?', default=url, help="File containing problem instances, can be local file or url")
     parser.add_argument('--list-instances', help='List all problem instances', action='store_true')

--- a/examples/csplib/prob005_auto_correlation.py
+++ b/examples/csplib/prob005_auto_correlation.py
@@ -38,7 +38,7 @@ def PAF(arr, s):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-length", nargs='?', type=int, default=16, help="Length of bitarray")
+    parser.add_argument("-length", nargs='?', type=int, default=12, help="Length of bitarray")
 
     length = parser.parse_args().length
 

--- a/examples/csplib/prob009_perfect_squares.py
+++ b/examples/csplib/prob009_perfect_squares.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # argument parsing
     url = "https://raw.githubusercontent.com/CPMpy/cpmpy/csplib/examples/csplib/prob009_perfect_squares.json"
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('-instance', nargs='?', default="problem7", help="Name of the problem instance found in file 'filename'")
+    parser.add_argument('-instance', nargs='?', default="problem2", help="Name of the problem instance found in file 'filename'")
     parser.add_argument('-filename', nargs='?', default=url, help="File containing problem instances, can be local file or url")
     parser.add_argument('--list-instances', help='List all problem instances', action='store_true')
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,8 +19,8 @@ import itertools
 EXAMPLES = glob(join("examples", "*.py")) + glob(join("examples", "csplib", "*.py"))
 ADVANCED_EXAMPLES = glob(join("examples", "advanced", "*.py"))
 
-EXAMPLES = sorted(EXAMPLES, key=str)
-ADVANCED_EXAMPLES = sorted(ADVANCED_EXAMPLES, key=str)
+EXAMPLES = sorted(EXAMPLES)
+ADVANCED_EXAMPLES = sorted(ADVANCED_EXAMPLES)
 
 SKIPPED_EXAMPLES = [
                     "ocus_explanations.py", # waiting for issues to be resolved 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,6 +19,9 @@ import itertools
 EXAMPLES = glob(join("examples", "*.py")) + glob(join("examples", "csplib", "*.py"))
 ADVANCED_EXAMPLES = glob(join("examples", "advanced", "*.py"))
 
+EXAMPLES = sorted(EXAMPLES, key=str)
+ADVANCED_EXAMPLES = sorted(ADVANCED_EXAMPLES, key=str)
+
 SKIPPED_EXAMPLES = [
                     "ocus_explanations.py", # waiting for issues to be resolved 
                     "psplib.py" # randomly fails on github due to file creation

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,7 +25,15 @@ ADVANCED_EXAMPLES = sorted(ADVANCED_EXAMPLES, key=str)
 SKIPPED_EXAMPLES = [
                     "ocus_explanations.py", # waiting for issues to be resolved 
                     "psplib.py" # randomly fails on github due to file creation
-                    ]  
+                    ]
+
+SKIP_MIP = ['npuzzle.py', 'tst_likevrp.py', 'sudoku_', 'pareto_optimal.py',
+            'prob009_perfect_squares.py', 'blocks_world.py', 'flexible_jobshop.py',
+            'mario', 'pareto_optimal','prob006_golomb.py', 'tsp.py', 'prob028_bibd.py', 'prob001_car_sequence.py'
+            ]
+
+SKIP_MZN = ['blocks_world.py', 'flexible_jobshop.py', 'pareto_optimal.py', 'npuzzle.py', 'sudoku_']
+
 
 # SOLVERS = SolverLookup.supported()
 SOLVERS = [
@@ -47,10 +55,9 @@ def test_example(solver, example):
     """
     if any(skip_name in example for skip_name in SKIPPED_EXAMPLES):
         pytest.skip(f"Skipped {example}, waiting for issues to be resolved")
-    if solver in ('gurobi', 'minizinc') and any(x in example for x in
-                                                ["npuzzle.py", "tst_likevrp.py", 'sudoku_', 'pareto_optimal.py',
-                                                 'prob009_perfect_squares.py', 'blocks_world.py',
-                                                 'flexible_jobshop.py']):
+    if solver in ('gurobi',) and any(x in example for x in SKIP_MIP):
+        return pytest.skip(reason=f"exclude {example} for {solver}, too slow or solver-specific")
+    if solver == 'minizinc' and any(x in example for x in SKIP_MZN):
         return pytest.skip(reason=f"exclude {example} for {solver}, too slow or solver-specific")
 
     base_solvers = SolverLookup.base_solvers


### PR DESCRIPTION
Some of the examples we have are very slow for certain solvers.
This PR ensures to exclude any examples which ran for more than 5s on my machine.

The pytest-timeout library apparently does not kill a sub-process (i.e., the solver) after the time-limit has been reached.