### PR TITLE
Fix gurobi objective posting

### DIFF
--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -296,7 +296,7 @@ class CPM_gurobi(SolverInterface):
             self.grb_model.setObjective(obj, sense=GRB.MINIMIZE)
         else:
             self.grb_model.setObjective(obj, sense=GRB.MAXIMIZE)
-        self.grb_model.optimize()
+        self.grb_model.update()
 
     def has_objective(self):
         return self.grb_model.getObjective().size() != 0  # TODO: check if better way to do this...


### PR DESCRIPTION
So #726 introduced a call to Gurobi when posting an objective (I believe to ensure the `.has_objective()` works properly) but this actually solves the problem... It should be `.update()` instead.