### PR TITLE
Change `cp.sum(*iterable, **kwargs)` to `cp.sum(iterable, **kwargs)`

### DIFF
--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -142,15 +142,14 @@ def min(*iterable, **kwargs):
     return Minimum(iterable)
 
 
-def sum(*iterable, **kwargs):
+def sum(iterable, **kwargs):
     """
         sum() overwrites the python built-in to support decision variables.
 
         if iterable does not contain CPMpy expressions, the built-in is called
         checks if all constants and uses built-in sum() in that case
     """
-    if len(iterable) == 1:
-        iterable = tuple(iterable[0]) # Fix generator polling
+    iterable = tuple(iterable)  # convert iterable (possibly generator) to tuple
     if not builtins.any(isinstance(elem, Expression) for elem in iterable):
         return builtins.sum(iterable, **kwargs)
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -618,7 +618,8 @@ class TestBuildIns(unittest.TestCase):
         self.assertEqual(str(gt), str(cp.sum(self.x)))
         self.assertEqual(str(gt), str(cp.sum(list(self.x))))
         self.assertEqual(str(gt), str(cp.sum(v for v in self.x)))
-        self.assertEqual(str(gt), str(cp.sum(self.x[0], self.x[1], self.x[2])))
+        with self.assertRaises(TypeError):  # Python sum does not accept sum(1,2,3)
+            cp.sum(self.x[0], self.x[1], self.x[2])
 
     def test_max(self):
         gt = Maximum(self.x)


### PR DESCRIPTION
This is in line with the Python's `builtins.sum`