### PR TITLE
CPLEX unsupported quadratic equality

### DIFF
--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -417,10 +417,7 @@ class CPM_cplex(SolverInterface):
                     self.cplex_model.add_constraint(cplexlhs == cplexrhs)
 
                 elif lhs.name == 'mul':
-                    assert len(lhs.args) == 2, "CPLEX only supports multiplication with 2 variables"
-                    a, b = self.solver_vars(lhs.args)
-                    # CPLEX supports quadratic constraints
-                    self.cplex_model.add_constraint(a * b == cplexrhs)
+                    raise NotSupportedError(f'CPLEX only supports quadratic constraints that define a convex region, i.e. quadratic equalities are not supported: {cpm_expr}')
 
                 else:
                     # Global functions


### PR DESCRIPTION
Raises proper error for #760. Is still not perfect, since non-convex equality can appear after transformation (e.g. decomposition), making the error message confusing for the user.

Proper fix would be to look into the linearisation of the product of two integer decision variables.