### PR TITLE
add hexaly to readme, name it a global opt solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Install simply with `pip install cpmpy`
 CPMpy can translate to a wide variety of constraint solving paradigms, including both commercial and open-source solvers.
 
 * **CP Solvers**: OR-Tools (default), IBM CP Optimizer (license required), Choco, Glasgow GCS, Pumpkin, MiniZinc+solvers
-* **ILP Solvers**: Gurobi (license required)
+* **ILP Solvers**: Gurobi (license required), CPLEX (license required)
+* **GO Solvers**: Hexaly (license required)
 * **SMT Solvers**: Z3
 * **PB Solvers**: Exact, Pindakaas
 * **SAT Solvers**: PySAT+solvers, PySDD

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,11 @@ Supported solvers
      - SAT ASAT ISAT - OPT IOPT
      - pip
      - 
+   * - :doc:`Hexaly <api/solvers/hexaly>`
+     - Global Opt.
+     - SAT ALLSAT - OPT IOPT
+     - pip + local + (aca.) licence
+     -
    * - :doc:`Gurobi <api/solvers/gurobi>`
      - ILP
      - SAT - OPT IOPT - PAR
@@ -90,12 +95,6 @@ Supported solvers
      - SAT ISAT ALLSAT - KC 
      - pip
      - only Boolean variables (CPMpy transformation incomplete)
-
-   * - :doc:`Hexaly <api/solvers/hexaly>`
-     - Local search
-     - SAT ALLSAT - OPT IOPT
-     - pip + local + (aca.) licence
-     -
 
 Native capability abbreviations:
     * SAT: Satisfaction, ASAT: Satisfaction under Assumptions+core extraction, ISAT: Incremental Satisfaction, ALLSAT: All solution enumeration


### PR DESCRIPTION
hexaly calls itself a global optimizer, we should do the same (so on README, new category: GO, and in docs reademe, global opt.)

Is that OK? e.g. @IgnaceBleukx 

Rest looks fine.


@hbierlee do you want to use this PR to discuss how we should categorize Pindakaas?

It accepts PB-level input, so I would consider it a PB solver... And although it uses a SAT solver, could we call it a SAT solver?