### PR TITLE
Test dependent on OR-Tools first found solution

### DIFF
--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -388,13 +388,16 @@ class TestGlobal(unittest.TestCase):
         from cpmpy.expressions.utils import argval
         self.assertTrue(sum(argval(X)) == 0)
 
-        Z = cp.intvar(0, 1, shape=(3,2))
+        Z = cp.intvar(0, 1, shape=(4,2))
         c = cp.LexChainLess(Z)
         m = cp.Model(c)
         self.assertTrue(m.solve())
         self.assertTrue(sum(argval(Z[0])) == 0)
         self.assertTrue(sum(argval(Z[1])) == 1)
-        self.assertTrue(sum(argval(Z[2])) >= 1)
+        self.assertTrue(argval(Z[1,0]) == 0)
+        self.assertTrue(sum(argval(Z[2])) == 1)
+        self.assertTrue(argval(Z[2,1]) == 0)
+        self.assertTrue(sum(argval(Z[3])) >= 1)
 
 
     def test_indomain_onearg(self):


### PR DESCRIPTION
The test for the `LexChainLess` global constraint was quite dependent on the solution order of OR-Tools (i.e. of the multiple solutions that exists, which solution would OR-Tools return first). Made the test instance more constrained such that only a single unique solution exists. 

This dependence on "which solution OR-Tools returns" is a general issue in our test set, hindering running the tests on a different default solver.