### PR TITLE
`solution_callback` for Hexaly

### DIFF
--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -519,6 +519,9 @@ class HexSolutionPrinter:
                     else:
                         hex_var = self._solver.solver_var(cpm_var)
                         cpm_var._value = int(hex_sol.get_value(hex_var))
+                # populate objective value
+                if self._solver.has_objective():
+                    self._solver.objective_value_ = int(hex_sol.get_objective_bound(0))
 
                 # display
                 if isinstance(self._display, Expression):


### PR DESCRIPTION
Hexaly has support for intermediate solution callbacks. Added the necessary code on CPMpy's side for the `solution_callback` argument of a `.solve()` call, similar to OR-Tools.

Also very small fix for setting solver-native arguments, `setattr(self.hex_solver, arg, val)` should have been `setattr(self.hex_solver.param, arg, val)`.