### PR TITLE
Fix timeout under assumptions in Exact

### DIFF
--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -246,7 +246,7 @@ class CPM_exact(SolverInterface):
         elif my_status == "INCONSISTENT": # found inconsistency over assumptions
             self.cpm_status.exitstatus = ExitStatus.UNSATISFIABLE
         elif my_status == "TIMEOUT": # found timeout
-            if self.xct_solver.hasSolution(): # found a (sub-)optimal solution
+            if self.has_objective() and self.xct_solver.hasSolution(): # found a (sub-)optimal solution
                 self.cpm_status.exitstatus = ExitStatus.FEASIBLE
             else: # no solution found
                 self.cpm_status.exitstatus = ExitStatus.UNKNOWN


### PR DESCRIPTION
When assumptions are set, and Exact has reached a timeout, it sometimes still reports `hasSolution()` to be True.
But from my experiments, it seems that this solution does not always satisfy the assumptions...
This PR fixes that at CPMpy level, I'll open an issue on Exact itself too.