### PR TITLE
Missing packaging in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'ortools>=9.9',
         'numpy>=1.5',
         'setuptools',
+        'packaging', # to check solver versions
     ],
     extras_require={
         # Solvers


### PR DESCRIPTION
'packaging' was added to `requirements.txt`, but not to `setup.py`