### PR TITLE
Non-strict var name check

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -799,7 +799,7 @@ def _is_invalid_name(name):
     and the variables' counter is greater than the index, i.e. the name is already in use.
 
     Toggle the strict mode with `_enable_strict_variable_name_check()` and `_disable_strict_variable_name_check()`,
-    or use the context manager `ignore_strict_variable_name_check()`.
+    or use the context manager `_ignore_strict_variable_name_check()`.
     """
     if name.startswith(_IV_PREFIX):
         if _VAR_STRICT_NAME_CHECK:
@@ -833,7 +833,7 @@ def _disable_strict_variable_name_check():
     _VAR_STRICT_NAME_CHECK = False
 
 
-def ignore_strict_variable_name_check():
+def _ignore_strict_variable_name_check():
     """
     Context manager to temporarily disable strict variable name check.
     """

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -842,7 +842,7 @@ def ignore_strict_variable_name_check():
             _disable_strict_variable_name_check()
         def __exit__(self, exc_type, exc_value, traceback):
             _enable_strict_variable_name_check()
-            _update_variable_counters()
+            # _update_variable_counters() # TODO: add automatic support for this later (different PR)
             return False  # propagate exceptions
 
     return IgnoreStrictVariableNameCheck()

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable
+import threading
 import warnings # for deprecation warning
 from functools import reduce
 from typing import Any, Literal, Optional, overload
@@ -71,7 +72,7 @@ from .utils import is_num, is_int, is_boolexpr, get_bounds
 _BV_PREFIX = "BV"
 _IV_PREFIX = "IV"
 _VAR_ERR  = f"Variable names starting with {_IV_PREFIX} or {_BV_PREFIX} are reserved for internal use only, chose a different name"
-_VAR_STRICT_NAME_CHECK = True
+_VAR_NAME_CHECK_STATE = threading.local()
 
 def BoolVar(shape=1, name=None):
     """
@@ -843,7 +844,7 @@ def _is_invalid_name(name: Any) -> bool:
     or use the context manager `_ignore_strict_variable_name_check()`.
     """
     if name.startswith(_IV_PREFIX):
-        if _VAR_STRICT_NAME_CHECK:
+        if _get_strict_variable_name_check():
             return True
         else:
             id = int(name[len(_IV_PREFIX):])
@@ -853,7 +854,7 @@ def _is_invalid_name(name: Any) -> bool:
                 return False
     
     elif name.startswith(_BV_PREFIX):
-        if _VAR_STRICT_NAME_CHECK:
+        if _get_strict_variable_name_check():
             return True
         else:
             id = int(name[len(_BV_PREFIX):])
@@ -865,13 +866,14 @@ def _is_invalid_name(name: Any) -> bool:
     else:
         return False
 
+def _get_strict_variable_name_check():
+    return getattr(_VAR_NAME_CHECK_STATE, "strict", True)
+
 def _enable_strict_variable_name_check():
-    global _VAR_STRICT_NAME_CHECK
-    _VAR_STRICT_NAME_CHECK = True
+    _VAR_NAME_CHECK_STATE.strict = True
 
 def _disable_strict_variable_name_check():
-    global _VAR_STRICT_NAME_CHECK
-    _VAR_STRICT_NAME_CHECK = False
+    _VAR_NAME_CHECK_STATE.strict = False
 
 
 def _ignore_strict_variable_name_check():
@@ -880,9 +882,10 @@ def _ignore_strict_variable_name_check():
     """
     class IgnoreStrictVariableNameCheck:
         def __enter__(self):
+            self._previous = _get_strict_variable_name_check()
             _disable_strict_variable_name_check()
         def __exit__(self, exc_type, exc_value, traceback):
-            _enable_strict_variable_name_check()
+            _VAR_NAME_CHECK_STATE.strict = self._previous
             # _update_variable_counters() # TODO: add automatic support for this later (different PR)
             return False  # propagate exceptions
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -73,6 +73,7 @@ _BV_PREFIX = "BV"
 _IV_PREFIX = "IV"
 _VAR_ERR  = f"Variable names starting with {_IV_PREFIX} or {_BV_PREFIX} are reserved for internal use only, chose a different name"
 _VAR_NAME_CHECK_STATE = threading.local()
+_VAR_NAME_CHECK_STATE.strict = True # default to strict mode
 
 def BoolVar(shape=1, name=None):
     """
@@ -867,7 +868,7 @@ def _is_invalid_name(name: Any) -> bool:
         return False
 
 def _get_strict_variable_name_check():
-    return getattr(_VAR_NAME_CHECK_STATE, "strict", True)
+    return _VAR_NAME_CHECK_STATE.strict
 
 def _enable_strict_variable_name_check():
     _VAR_NAME_CHECK_STATE.strict = True

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -879,9 +879,14 @@ def _disable_strict_variable_name_check():
 
 class _IgnoreStrictVariableNameCheck:
     def __enter__(self):
+        depth = getattr(_VAR_NAME_CHECK_STATE, "ignore_check_depth", 0)
+        if depth > 0:
+            raise RuntimeError("_ignore_strict_variable_name_check() cannot be nested")
+        _VAR_NAME_CHECK_STATE.ignore_check_depth = depth + 1
         _disable_strict_variable_name_check()
 
     def __exit__(self, exc_type, exc_value, traceback):
+        _VAR_NAME_CHECK_STATE.ignore_check_depth = 0
         _enable_strict_variable_name_check()
         # _update_variable_counters() # TODO: add automatic support for this later (different PR)
         return False  # propagate exceptions

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -849,7 +849,7 @@ def _is_invalid_name(name: Any) -> bool:
         else:
             id = int(name[len(_IV_PREFIX):])
             if _IntVarImpl.counter > id:
-                return True # TODO: better error message
+                return True
             else:
                 return False
     
@@ -859,7 +859,7 @@ def _is_invalid_name(name: Any) -> bool:
         else:
             id = int(name[len(_BV_PREFIX):])
             if _BoolVarImpl.counter > id:
-                return True # TODO: better error message
+                return True
             else:
                 return False
     
@@ -890,5 +890,12 @@ class _IgnoreStrictVariableNameCheck:
 def _ignore_strict_variable_name_check():
     """
     Context manager to temporarily disable strict variable name check.
+
+    Example:
+
+        .. code-block:: python
+        
+            with _ignore_strict_variable_name_check():
+                ... create CPMpy model based on file contents here ...
     """
     return _IgnoreStrictVariableNameCheck()

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -876,17 +876,19 @@ def _disable_strict_variable_name_check():
     _VAR_NAME_CHECK_STATE.strict = False
 
 
+class _IgnoreStrictVariableNameCheck:
+    def __enter__(self):
+        self._previous = _get_strict_variable_name_check()
+        _disable_strict_variable_name_check()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        _VAR_NAME_CHECK_STATE.strict = self._previous
+        # _update_variable_counters() # TODO: add automatic support for this later (different PR)
+        return False  # propagate exceptions
+
+
 def _ignore_strict_variable_name_check():
     """
     Context manager to temporarily disable strict variable name check.
     """
-    class IgnoreStrictVariableNameCheck:
-        def __enter__(self):
-            self._previous = _get_strict_variable_name_check()
-            _disable_strict_variable_name_check()
-        def __exit__(self, exc_type, exc_value, traceback):
-            _VAR_NAME_CHECK_STATE.strict = self._previous
-            # _update_variable_counters() # TODO: add automatic support for this later (different PR)
-            return False  # propagate exceptions
-
-    return IgnoreStrictVariableNameCheck()
+    return _IgnoreStrictVariableNameCheck()

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -879,11 +879,10 @@ def _disable_strict_variable_name_check():
 
 class _IgnoreStrictVariableNameCheck:
     def __enter__(self):
-        self._previous = _get_strict_variable_name_check()
         _disable_strict_variable_name_check()
 
     def __exit__(self, exc_type, exc_value, traceback):
-        _VAR_NAME_CHECK_STATE.strict = self._previous
+        _enable_strict_variable_name_check()
         # _update_variable_counters() # TODO: add automatic support for this later (different PR)
         return False  # propagate exceptions
 

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -53,12 +53,12 @@ def _update_variable_counters(model: Model):
         if v.name.startswith(_BV_PREFIX):
             try:
                 bv_counter = max(bv_counter, int(v.name[2:])+1)
-            except:
+            except: # When name starts with _BV_PREFIX but is not a valid integer (user created name), ignore
                 pass
         elif v.name.startswith(_IV_PREFIX):
             try:
                 iv_counter = max(iv_counter, int(v.name[2:])+1)
-            except:
+            except: # When name starts with _IV_PREFIX but is not a valid integer (user created name), ignore
                 pass
 
     if (_BoolVarImpl.counter > 0 and bv_counter > 0) or \

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -38,33 +38,6 @@ from .solvers.solver_interface import SolverInterface, SolverStatus, Callback
 
 import pickle
 
-
-def _update_variable_counters(model: Model):
-    from cpmpy.transformations.get_variables import get_variables_model  # avoid circular import
-    from cpmpy.expressions.variables import _BoolVarImpl, _IntVarImpl, _BV_PREFIX, _IV_PREFIX # avoid circular import
-            
-    vs = get_variables_model(model)
-    bv_counter = 0
-    iv_counter = 0
-    for v in vs:
-        if v.name.startswith(_BV_PREFIX):
-            try:
-                bv_counter = max(bv_counter, int(v.name[2:])+1)
-            except: # When name starts with _BV_PREFIX but is not a valid integer (user created name), ignore
-                pass
-        elif v.name.startswith(_IV_PREFIX):
-            try:
-                iv_counter = max(iv_counter, int(v.name[2:])+1)
-            except: # When name starts with _IV_PREFIX but is not a valid integer (user created name), ignore
-                pass
-
-    if (_BoolVarImpl.counter > 0 and bv_counter > 0) or \
-            (_IntVarImpl.counter > 0 and iv_counter > 0):
-        warnings.warn(f"Model contains auxiliary {_IV_PREFIX}*/{_BV_PREFIX}* variables with the same name as already created. Only add expressions created AFTER loadig this model to avoid issues with duplicate variables.")
-    _BoolVarImpl.counter = max(_BoolVarImpl.counter, bv_counter)
-    _IntVarImpl.counter = max(_IntVarImpl.counter, iv_counter)
-
-
 class Model(object):
     """
     CPMpy Model object, contains the constraint and objective expressions
@@ -332,3 +305,29 @@ class Model(object):
     def deepcopy(self, memodict={}):
         warnings.warn("Deprecated, use copy.deepcopy() instead, will be removed in stable version", DeprecationWarning)
         return copy.deepcopy(self, memodict)
+
+
+def _update_variable_counters(model: Model):
+    from cpmpy.transformations.get_variables import get_variables_model  # avoid circular import
+    from cpmpy.expressions.variables import _BoolVarImpl, _IntVarImpl, _BV_PREFIX, _IV_PREFIX # avoid circular import
+            
+    vs = get_variables_model(model)
+    bv_counter = 0
+    iv_counter = 0
+    for v in vs:
+        if v.name.startswith(_BV_PREFIX):
+            try:
+                bv_counter = max(bv_counter, int(v.name[2:])+1)
+            except: # When name starts with _BV_PREFIX but is not a valid integer (user created name), ignore
+                pass
+        elif v.name.startswith(_IV_PREFIX):
+            try:
+                iv_counter = max(iv_counter, int(v.name[2:])+1)
+            except: # When name starts with _IV_PREFIX but is not a valid integer (user created name), ignore
+                pass
+
+    if (_BoolVarImpl.counter > 0 and bv_counter > 0) or (_IntVarImpl.counter > 0 and iv_counter > 0):
+        warnings.warn(f"Model contains auxiliary {_IV_PREFIX}*/{_BV_PREFIX}* variables with the same name as already created. Only add expressions created AFTER loadig this model to avoid issues with duplicate variables.")
+    # update counters for future variables
+    _BoolVarImpl.counter = max(_BoolVarImpl.counter, bv_counter)
+    _IntVarImpl.counter = max(_IntVarImpl.counter, iv_counter)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -100,6 +100,12 @@ class TestSolvers:
             cp.intvar(0, 10, name="BV123")
             cp.intvar(0, 10, name="IV123")
 
+    def test_ignore_strict_variable_name_check_nested(self):
+        with _ignore_strict_variable_name_check():
+            with pytest.raises(RuntimeError, match="cannot be nested"):
+                with _ignore_strict_variable_name_check():
+                    pass
+
     def test_clear(self):
         def n_none(v):
             val = v.value()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -2,7 +2,8 @@ import pytest
 
 import cpmpy as cp
 import numpy as np
-from cpmpy.expressions.variables import NullShapeError, _IntVarImpl, _BoolVarImpl, NegBoolView, NDVarArray, _gen_var_names
+from cpmpy.expressions.variables import NullShapeError, _IntVarImpl, _BoolVarImpl, NegBoolView, NDVarArray
+from cpmpy.expressions.variables import _gen_var_names, _ignore_strict_variable_name_check
 
 
 class TestSolvers:
@@ -69,6 +70,13 @@ class TestSolvers:
         pytest.raises(ValueError, lambda: cp.boolvar(name=("x", "IV1", "y"), shape=3))
         pytest.raises(ValueError, lambda: cp.boolvar(name=[["x","y","z"],["a", "IV1", "b"]], shape=(2,3)))
 
+        # test non-strict mode
+        _BoolVarImpl.counter = 0 # reset counters
+        _IntVarImpl.counter = 0 # reset counters, will IV123 will compare with iv counter
+        with _ignore_strict_variable_name_check(): # should not raise errors anymore
+            cp.boolvar(name="BV123")
+            cp.boolvar(name="IV123")
+
 
     def test_invalid_iv(self):
 
@@ -84,6 +92,13 @@ class TestSolvers:
         pytest.raises(ValueError, lambda: cp.intvar(0, 10, name=("BV0", "x", "y"), shape=3))
         pytest.raises(ValueError, lambda: cp.intvar(0, 10, name=("x", "BV1", "y"), shape=3))
         pytest.raises(ValueError, lambda: cp.intvar(0,10, name=[["x","y","z"],["a", "BV0", "b"]], shape=(2,3)))
+
+        # test non-strict mode
+        _BoolVarImpl.counter = 0 # reset counters, will BV123 will compare with bv counter
+        _IntVarImpl.counter = 0 # reset counters
+        with _ignore_strict_variable_name_check(): # should not raise errors anymore
+            cp.intvar(0, 10, name="BV123")
+            cp.intvar(0, 10, name="IV123")
 
     def test_clear(self):
         def n_none(v):


### PR DESCRIPTION
Added some internal tools to have greater control over variable name checks.
When working on file readers and writers, I encountered the issue that we couldn't read the model files that we ourselves have exported, due to the use of IV and BV decision variable namings. In this PR I added a couple of helper functions to allow for these variable names as long as they haven't been used before.

Now, file readers can wrap their logic in 
```python
with ignore_strict_variable_name_check():
    ... create CPMpy model based on file contents here ...
```
This will temporarily allow the use of restricted variable names (but still checks for variable name collisions).

Additionally I also extracted the "update variable counters from model" logic used when loading models from `.pickle` files to make it reusable (`_update_variable_counters`) (file readers will also need this) 

For now, readers will still have to update the counters themselves after exiting `ignore_strict_variable_name_check`, i.e. after creating the CPMpy model they should call:
```python
_update_variable_counters(model)
```

But I might have found a way to do this automatically (that could potentially also resolve the issues when copying CPMpy models across processes, but to be seen / no promises) (different approach than Ignace's). Will be for a follow-up PR.