### PR TITLE
Remove version upper limits

### DIFF
--- a/docs/api/cpmpy.model.Model.rst
+++ b/docs/api/cpmpy.model.Model.rst
@@ -1,0 +1,35 @@
+﻿cpmpy.model.Model
+=================
+
+.. currentmodule:: cpmpy.model
+
+.. autoclass:: Model
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Model.__init__
+      ~Model.add
+      ~Model.copy
+      ~Model.deepcopy
+      ~Model.from_file
+      ~Model.has_objective
+      ~Model.maximize
+      ~Model.minimize
+      ~Model.objective
+      ~Model.objective_value
+      ~Model.solve
+      ~Model.solveAll
+      ~Model.status
+      ~Model.to_file
+   
+   
+
+   
+   
+   

--- a/docs/installation_instructions.rst
+++ b/docs/installation_instructions.rst
@@ -1,7 +1,7 @@
 Installation instructions
 =========================
 
-CPMpy requires Python ``3.8`` or newer. The package is available on `PyPI <https://pypi.org/>`_.
+CPMpy requires Python ``3.10`` or newer. The package is available on `PyPI <https://pypi.org/>`_.
 
 The easiest way is to install using the 'pip' command line package manager. In a terminal, run:
 
@@ -24,6 +24,20 @@ CPMpy has regular small releases with updates and improvements, so it is a good 
     $ pip install -U cpmpy
 
 
+If you would like to install a specific (previous) version of CPMpy, you can add a constraint to the command:
+
+.. code-block:: console
+
+    $ pip install -U cpmpy==0.10.0
+
+For reproducability reasons, you might want to pin CPMpy and all its dependencies to the versions available on a specific data (e.g. when your experiments were run).
+Using the [uv package manager](https://docs.astral.sh/uv/), this can be achieved with the [--exclude-newer](https://docs.astral.sh/uv/reference/settings/#exclude-newer):
+
+.. code-block:: console
+
+    $ uv pip install cpmpy --exclude-newer 2026-01-01T00:00:00Z
+
+
 CPMpy supports a multitude of solvers of different technologies to be used as backend. Easy installation is provided through optional dependencies:
 
 .. code-block:: bash
@@ -31,7 +45,15 @@ CPMpy supports a multitude of solvers of different technologies to be used as ba
     # Choose any subset of solvers to install
     $ pip install cpmpy[choco, cpo, exact, gcs, gurobi, minizinc, pysat, pysdd, z3] 
 
-Some solver require additional steps (like acquiring a (aca.) license). Have a look at :ref:`this <supported-solvers>` overview.
+Some solvers require additional steps (like acquiring a (aca.) license). Have a look at :ref:`this <supported-solvers>` overview.
+
+
+.. warning::
+    As proposed in this nice `writeup <https://iscinumpy.dev/post/bound-version-constraints/>`_, CPMpy does not enforce upper version limits on its dependencies.
+    This means that two runs of ``pip install cpmpy==<version>`` can lead to different results depending on when the command was run. Additionally, when a solver 
+    backend does a braking change to its interface, the CPMpy wrapper might temporarily not work correctly. We strive to release a fix a soon as possible, 
+    but there will always a small delay. So for settings where robustness and reproducability are of great importance, we highly recommend using `uv` to pin 
+    CPMpy to a specific date.
 
 
 Installing from a git repository

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -18,9 +18,13 @@ pip install cpmpy[gurobi, choco, exact] # installs 3 additional solving backends
 
 An overview of the available backends can be found [here](index.rst#supported-solvers).
 
-CPMpy requires python version  3.8 or higher.
+CPMpy requires python version  3.10 or higher.
 
 See [installation instructions](./installation_instructions.rst) for more details. 
+
+```{warning}
+CPMpy does not enforce hard version upper limits on its dependencies. For settings where robustness and reproducability are of great importance, have a look at the above detailed installation instructions.
+```
 
 ## Using the library
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy >= 1.5
-ortools >=9.3.10497,<=9.15.6755,!=9.9.*,!=9.10.*,!=9.11.*
+ortools >=9.3.10497,!=9.9.*,!=9.10.*,!=9.11.*
 packaging # to check solver versions

--- a/setup.py
+++ b/setup.py
@@ -20,19 +20,19 @@ with open("README.md", "r", encoding="utf8") as readme_file:
 
 
 solver_dependencies = {
-    "ortools": ["ortools>=9.3.10497,<=9.15.6755,!=9.9.*,!=9.10.*,!=9.11.*"], # exclusion due to bug #191
-    "z3": ["z3-solver>=4.8.15.0,<=4.15.4.0"],
-    "choco": ["pychoco>=0.2.1,<=0.2.4"],
-    "exact": ["exact>=2.1.0,<=2.2.1"], # older versions (<2.2.1) are bugged on py3.13
-    "minizinc": ["minizinc>=0.7.0,<=0.10.0"],
-    "pysat": ["python-sat>=1.8.dev4,<=1.9.dev26"],
-    "gurobi": ["gurobipy>=11.0.0,<=13.0.0"],
-    "pysdd": ["pysdd>=0.2.11,<=1.0.6"],
-    "gcs": ["gcspy==0.1.9"], # first version to pass all tests
-    "cpo": ["docplex>=2.28.240,<=2.31.254"],
-    "pumpkin": ["pumpkin-solver==0.2.2"], # CPMpy requires features only available from Pumpkin version >=0.2.2
-    "pindakaas": ["pindakaas>=0.2.1,<=0.3.0"],
-    "cplex": ["docplex>=2.28.240,<=2.31.254", "cplex>=20.1.0.4,<=22.1.2.0"],
+    "ortools": ["ortools>=9.3.10497,!=9.9.*,!=9.10.*,!=9.11.*"], # exclusion due to bug #191
+    "z3": ["z3-solver>=4.8.15.0"],
+    "choco": ["pychoco>=0.2.1"],
+    "exact": ["exact>=2.1.0"], # older versions (<2.2.1) are bugged on py3.13
+    "minizinc": ["minizinc>=0.7.0"],
+    "pysat": ["python-sat>=1.8.dev4"],
+    "gurobi": ["gurobipy>=11.0.0"],
+    "pysdd": ["pysdd>=0.2.11"],
+    "gcs": ["gcspy>=0.1.9"], # first version to pass all tests
+    "cpo": ["docplex>=2.28.240"],
+    "pumpkin": ["pumpkin-solver>=0.2.2"], # CPMpy requires features only available from Pumpkin version >=0.2.2
+    "pindakaas": ["pindakaas>=0.2.1"],
+    "cplex": ["docplex>=2.28.240", "cplex>=20.1.0.4"],
 }
 solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 
 
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'ortools>=9.3.10497,<=9.15.6755,!=9.9.*,!=9.10.*,!=9.11.*',
+        'ortools>=9.3.10497,!=9.9.*,!=9.10.*,!=9.11.*',
         'numpy>=1.5',
         'setuptools',
         'packaging', # to check solver versions


### PR DESCRIPTION
Removes hard dependency version upper limits, as discussed in #844. Added a bit of documentation, hinting towards the use of `uv` when an exactly reproducible install is required.