### PR TITLE
Deletion of solver objects and use of model in test_cons

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -198,6 +198,7 @@ class Model(object):
         ret = s.solve(time_limit=time_limit, **kwargs)
         # store CPMpy status (s object has no further use)
         self.cpm_status = s.status()
+        del s  # free solver (and its memory)
         return ret
 
     def solveAll(self, solver:Optional[str]=None, display:Optional[Callback]=None, time_limit:Optional[int|float]=None, solution_limit:Optional[int]=None, **kwargs):
@@ -228,6 +229,7 @@ class Model(object):
         ret = s.solveAll(display=display,time_limit=time_limit,solution_limit=solution_limit, call_from_model=True, **kwargs)
         # store CPMpy status (s object has no further use)
         self.cpm_status = s.status()
+        del s  # free solver (and its memory)
         return ret
 
     def status(self):

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -162,6 +162,11 @@ class CPM_cplex(SolverInterface):
         """
         return self.cplex_model
 
+    def __del__(self):
+        """Release CPLEX resources by calling cplex_model.end()."""
+        if self.cplex_model is not None:
+            self.cplex_model.end()
+
     def solve(self, time_limit:Optional[float]=None, **kwargs):
         """
             Call the cplex solver

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -152,6 +152,10 @@ class CPM_gurobi(SolverInterface):
         """
         return self.grb_model
 
+    def __del__(self):
+        """Release native model memory by calling grb_model.dispose()."""
+        if self.grb_model is not None:
+            self.grb_model.dispose()
 
     def solve(self, time_limit:Optional[float]=None, solution_callback=None, **kwargs):
         """

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -208,6 +208,13 @@ class CPM_pysat(SolverInterface):
         # initialise everything else and post the constraints/objective
         super().__init__(name="pysat:"+subsolver, cpm_model=cpm_model)
 
+    def __del__(self):
+        if self.pysat_solver is not None:
+            self.pysat_solver.delete()  # requires explicit delete
+            self.pysat_solver = None
+        if self.pysat_vpool is not None:
+            self.pysat_vpool = None
+
     @property
     def native_model(self):
         """

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -307,11 +307,12 @@ def test_bool_constraints(solver, constraint):
     """
         Tests boolean constraint by posting it to the solver and checking the value after solve.
     """
+    m = Model(constraint)
     if ALL_SOLS:
-        n_sols = SolverLookup.get(solver, Model(constraint)).solveAll(display=lambda: verify(constraint))
+        n_sols = m.solveAll(solver=solver, display=lambda: verify(constraint))
         assert n_sols >= 1
     else:
-        assert SolverLookup.get(solver, Model(constraint)).solve()
+        assert m.solve(solver=solver)
         assert argval(constraint)
         assert constraint.value()
 
@@ -321,11 +322,12 @@ def test_comparison_constraints(solver, constraint):
     """
         Tests comparison constraint by posting it to the solver and checking the value after solve.
     """
+    m = Model(constraint)
     if ALL_SOLS:
-        n_sols = SolverLookup.get(solver, Model(constraint)).solveAll(display= lambda: verify(constraint))
+        n_sols = m.solveAll(solver=solver, display=lambda: verify(constraint))
         assert n_sols >= 1
     else:
-        assert SolverLookup.get(solver,Model(constraint)).solve()
+        assert m.solve(solver=solver)
         assert argval(constraint)
         assert constraint.value()
 
@@ -336,10 +338,11 @@ def test_reify_imply_constraints(solver, constraint):
     """
         Tests boolean expression by posting it to solver and checking the value after solve.
     """
+    m = Model(constraint)
     if ALL_SOLS:
-        n_sols = SolverLookup.get(solver, Model(constraint)).solveAll(display=lambda: verify(constraint))
+        n_sols = m.solveAll(solver=solver, display=lambda: verify(constraint))
         assert n_sols >= 1
     else:
-        assert SolverLookup.get(solver, Model(constraint)).solve()
+        assert m.solve(solver=solver)
         assert argval(constraint)
         assert constraint.value()


### PR DESCRIPTION
First added by @tias for #850, it has three changes:

- use `model` in test_constraints, which seems good to me
- delete solver objects after `model.solve*`, also seems good, but doesn't this happen automatically since `s` goes out of scope? 
- and added `__del__` methods for three solvers; I also think that at least for PySAT, it does have its own `__del__` methods, so these should also be called automatically?
