### PR TITLE
Read integers with `round` i/o `int` for Gurobi

### DIFF
--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -245,6 +245,7 @@ class CPM_template(SolverInterface):
             # fill in variable values
             for cpm_var in self.user_vars:
                 sol_var = self.solver_var(cpm_var)
+                # [GUIDELINE] for ILP-solvers, ensure the value is integer and use `round()`
                 cpm_var._value = self.TPL_solver.value(sol_var)
                 raise NotImplementedError("TEMPLATE: back-translating the solution values")
 

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -252,7 +252,7 @@ class CPM_cplex(SolverInterface):
             if self.has_objective():
                 obj_val = self.cplex_model.get_objective_expr().solution_value
                 if round(obj_val) == obj_val: # it is an integer?:
-                    self.objective_value_ = int(obj_val)
+                    self.objective_value_ = round(obj_val)
                 else: #  can happen with DirectVar or when using floats as coefficients
                     self.objective_value_ = float(obj_val)
 
@@ -612,7 +612,7 @@ class CPM_cplex(SolverInterface):
                     if cpm_var.is_bool():
                         cpm_var._value = solver_val >= 0.5
                     else:
-                        cpm_var._value = int(solver_val)
+                        cpm_var._value = round(solver_val)
 
                 # Translate objective
                 if self.has_objective():

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -232,12 +232,12 @@ class CPM_gurobi(SolverInterface):
                 if cpm_var.is_bool():
                     cpm_var._value = solver_val >= 0.5
                 else:
-                    cpm_var._value = int(solver_val)
+                    cpm_var._value = round(solver_val)
             # set _objective_value
             if self.has_objective():
                 grb_obj_val = grb_objective.getValue()
                 if round(grb_obj_val) == grb_obj_val: # it is an integer?:
-                    self.objective_value_ = int(grb_obj_val)
+                    self.objective_value_ = round(grb_obj_val)
                 else: #  can happen with DirectVar or when using floats as coefficients
                     self.objective_value_ =  float(grb_obj_val)
 
@@ -580,7 +580,7 @@ class CPM_gurobi(SolverInterface):
                 if cpm_var.is_bool():
                     cpm_var._value = solver_val >= 0.5
                 else:
-                    cpm_var._value = int(solver_val)
+                    cpm_var._value = round(solver_val)
 
             # Translate objective
             if self.has_objective():

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -225,7 +225,7 @@ class CPM_hexaly(SolverInterface):
                 if cpm_var.is_bool():
                     cpm_var._value = bool(self.hex_sol.get_value(sol_var))
                 else:
-                    cpm_var._value = int(self.hex_sol.get_value(sol_var))
+                    cpm_var._value = round(self.hex_sol.get_value(sol_var))
 
             # translate objective, for optimisation problems only
             if not self.is_satisfaction:
@@ -559,12 +559,12 @@ class HexSolutionPrinter:
                         cpm_var._value = bool(hex_sol.get_value(hex_var))
                     elif isinstance(cpm_var, _IntVarImpl):
                         hex_var = self._solver.solver_var(cpm_var)
-                        cpm_var._value = int(hex_sol.get_value(hex_var))
+                        cpm_var._value = round(hex_sol.get_value(hex_var))
                     else:
                         raise NotImplementedError(f"Unexpected variable type {type(cpm_var)}")
                 # populate objective value
                 if self._solver.has_objective():
-                    self._solver.objective_value_ = int(hex_sol.get_objective_bound(0))
+                    self._solver.objective_value_ = round(hex_sol.get_objective_bound(0))
 
                 self._solver.print_display(self._display)
                 

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -417,7 +417,7 @@ class CPM_highs(SolverInterface):
                 if cpm_var.is_bool():
                     cpm_var._value = val >= 0.5
                 else:
-                    cpm_var._value = int(round(val))
+                    cpm_var._value = round(val)
 
             if self.has_objective():
                 self.objective_value_ = info.objective_function_value

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -279,7 +279,7 @@ class CPM_ortools(SolverInterface):
             if self.has_objective():
                 ort_obj_val = self.ort_solver.objective_value
                 if round(ort_obj_val) == ort_obj_val: # it is an integer?
-                    self.objective_value_ = int(ort_obj_val)  # ensure it is an integer
+                    self.objective_value_ = round(ort_obj_val)  # ensure it is an integer
                 else: # can happen when using floats as coeff in objective
                     self.objective_value_ = float(ort_obj_val)
         else: # clear values of variables
@@ -967,7 +967,7 @@ try:
                     if isinstance(cpm_var, _BoolVarImpl):
                         cpm_var._value = bool(self.Value(self._varmap[cpm_var.name]))
                     elif isinstance(cpm_var, _IntVarImpl):
-                        cpm_var._value = int(self.Value(self._varmap[cpm_var.name]))
+                        cpm_var._value = self.Value(self._varmap[cpm_var.name])
                     else:
                         raise NotImplementedError(f"Unexpected variable type {type(cpm_var)}")
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1251,3 +1251,22 @@ def test_objective_numexprs(solver, constraint):
         assert constraint.value() > constraint.get_bounds()[0] # bounds are not always tight, but should be larger than lb for sure
     except NotSupportedError:
         pytest.skip(reason=f"{solver} does not support optimisation")
+
+@pytest.mark.requires_solver("gurobi")
+class TestGurobi:
+    def test_gurobi_read_integers_issue_858(self):
+        x = cp.intvar(1, 3, shape=2, name="x")
+        p = cp.intvar(0, 1, shape=3, name="p")
+        q = cp.intvar(0, 1, shape=3, name="q")
+        m = cp.Model()
+        m += x[0] == 1  # TODO without this, x[0] is assigned None because it does not occur in any constraint. This is a separate issue
+        m += cp.sum([p[0], p[1], p[2]]) == 1
+        m += cp.sum([3, 3, 1, -1] * cp.cpm_array([q[0], q[1], q[2], x[1]])) == 0
+        m += cp.sum([q[0], q[1], q[2]]) == 1
+
+        def check():
+            print(x, x.value())
+            assert (x[1].value() >= 1), f"{x[1]}={x.value()}"
+
+        m.solveAll(solver="gurobi", solution_limit=1000, display=check)
+

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1255,9 +1255,9 @@ def test_highs_basic_ilp():
     assert s.objective_value_ == 5
 
 
-@pytest.mark.skipif(not CPM_gurobi.supported(), reason="Gurobi (gurobipy) not installed")
-class TestGurobi:
-    def test_gurobi_read_integers_issue_858(self):
+@pytest.mark.requires_solver("gurobi", "cplex", "scip", "highs", "hexaly")
+class TestRound:
+    def test_gurobi_read_integers_issue_858(self, solver):
         x = cp.intvar(1, 3, name="x")
         p = cp.intvar(0, 1, shape=3, name="p")
         q = cp.intvar(0, 1, shape=3, name="q")
@@ -1270,5 +1270,5 @@ class TestGurobi:
             print(x, x.value())
             assert (x.value() >= 1), f"{x}={x.value()}"
 
-        m.solveAll(solver="gurobi", solution_limit=1000, display=check)
+        m.solveAll(solver=solver, solution_limit=1000, display=check)
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1255,7 +1255,7 @@ def test_highs_basic_ilp():
     assert s.objective_value_ == 5
 
 
-@pytest.mark.requires_solver("gurobi")
+@pytest.mark.skipif(not CPM_gurobi.supported(), reason="Gurobi (gurobipy) not installed")
 class TestGurobi:
     def test_gurobi_read_integers_issue_858(self):
         x = cp.intvar(1, 3, name="x")
@@ -1268,7 +1268,7 @@ class TestGurobi:
 
         def check():
             print(x, x.value())
-            assert (x[1].value() >= 1), f"{x[1]}={x.value()}"
+            assert (x.value() >= 1), f"{x}={x.value()}"
 
         m.solveAll(solver="gurobi", solution_limit=1000, display=check)
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1255,13 +1255,12 @@ def test_objective_numexprs(solver, constraint):
 @pytest.mark.requires_solver("gurobi")
 class TestGurobi:
     def test_gurobi_read_integers_issue_858(self):
-        x = cp.intvar(1, 3, shape=2, name="x")
+        x = cp.intvar(1, 3, name="x")
         p = cp.intvar(0, 1, shape=3, name="p")
         q = cp.intvar(0, 1, shape=3, name="q")
         m = cp.Model()
-        m += x[0] == 1  # TODO without this, x[0] is assigned None because it does not occur in any constraint. This is a separate issue
         m += cp.sum([p[0], p[1], p[2]]) == 1
-        m += cp.sum([3, 3, 1, -1] * cp.cpm_array([q[0], q[1], q[2], x[1]])) == 0
+        m += cp.sum([3, 3, 1, -1] * cp.cpm_array([q[0], q[1], q[2], x])) == 0
         m += cp.sum([q[0], q[1], q[2]]) == 1
 
         def check():


### PR DESCRIPTION
Fixes #858 

We should at least use `round` to read integers, because now whenever Gurobi decides to slightly assign an integer variables to a value below rather than above the integer (e.g 0.99999 v. 1.000001), we'll floor/truncate to the (likely) wrong assignment. However, to be even safer, we'll have to look into IntegralityFocus.

