### PR TITLE
MDD decomposition for Table constraint 

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -143,7 +143,7 @@ from .core import Expression, BoolVal, ExprLike, ListLike
 from .variables import cpm_array, intvar, boolvar, _BoolVarImpl
 from .utils import all_pairs, is_int, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies
 from .globalfunctions import * # XXX make this file backwards compatible
-
+from .mdd_encoding import filter_table, dom_size, construct_mdd, mdd_to_flow
 if TYPE_CHECKING:
     from cpmpy.solvers.solver_interface import SolverInterface
 
@@ -597,6 +597,33 @@ class Table(GlobalConstraint):
         """
         arr, tab = self.args
         return [cp.any(cp.all(ai == ri for ai, ri in zip(arr, row)) for row in tab)], []
+
+    def decompose_positive(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Linear decomposition of the Table global constraint. First, a table is converted to an MDD,
+        then this MDD is converted to flow constraints that ensure that exactly one row of the table is assigned to the array.
+        "
+        Returns:
+            tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        """
+        arr, tab = self.args
+
+        if len(tab) == 0:
+            return [BoolVal(False)], []
+        elif len(tab) == 1:
+            cons = []
+            for i,x in enumerate(arr):
+                cons += [(x == tab[0][i])]
+            return cons, []
+
+        tab = filter_table(arr, np.array(tab))
+        ordering = np.argsort([dom_size(x) for x in arr])
+        reordered_tab = tab[:, ordering]
+        reordered_arr = [arr[i] for i in ordering]
+        mdd_cache = construct_mdd(reordered_tab)
+        flow_cons = mdd_to_flow(mdd_cache, reordered_arr)
+
+        return flow_cons, []
 
     def value(self) -> Optional[bool]:
         """

--- a/cpmpy/expressions/mdd_encoding.py
+++ b/cpmpy/expressions/mdd_encoding.py
@@ -1,0 +1,321 @@
+"""
+
+Internal auxiliary functions to implement the linear decomposition of Table constraints. This happens as follows:
+Step 1: The table T in the Table constraint is converted to a Multivalued Decision Diagram (MDD).
+    - Step 1.1: The MDD is constructed by adding every row in T iteratively.
+    - Step 1.2: The MDD is reduced by merging every equivalent node in the MDD (having the same set of completing suffixes).
+Step 2: Using this MDD, the Table constraint is converted to flow constraints, with a total flow of 1, thereby enforcing that the variable corresponds to exactly one row in T.
+
+
+"""
+
+from collections import defaultdict
+import enum
+import numpy as np
+import cpmpy as cp
+
+class MDD:
+    """
+    Class identifying the MDD constructed during Step 1 of the decomposition algorithm.
+    """
+    def __init__(self):
+        self.MDD_cache = {}
+        self.MDD_cache_reverse = defaultdict(set)
+        self.repeated_keys = set()
+
+class TerminatingState(enum.Enum):
+    """
+        Class identifying a terminal state in the MDD.
+    """
+    SNK = 'snk'
+
+class Prefix:
+    """
+        Class for prefixes (of rows in the table), which are used to uniquely identify nodes in the MDD.
+    """
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def __eq__(self, other):
+        if not isinstance(other, Prefix):
+            return False
+        else:
+            return self.prefix == other.prefix
+
+    def __hash__(self):
+        return hash(self.prefix)
+
+    def __deepcopy__(self):
+        return Prefix(self.prefix)
+
+class MDD_node:
+    """
+        Class for nodes in the MDD, which are characterized by a prefix identifying them, a level (depth from the source node),
+        and a transition function that points to other prefixes / nodes depending on the next value.
+
+    """
+    def __init__(self, prefix, level, transition):
+        self.prefix = prefix
+        self.level = level
+        self.transition = transition
+
+    def __eq__(self, other):
+        if not isinstance(other, MDD_node):
+            return False
+
+        if self.level != other.level:
+            return False
+
+        if self.transition.keys() != other.transition.keys():
+            return False
+
+        for key in self.transition:
+            if self.transition[key] != other.transition[key]:
+                return False
+
+        return True
+
+    __hash__ = object.__hash__
+
+class MDD_node_key:
+    """
+        Wrapper class supporting a hashable canonical representation of an MDD node.
+    """
+
+    def __init__(self, node: "MDD_node"):
+        self.level = node.level
+
+        def key_value_repr(v):
+            if isinstance(v, Prefix):
+                return (v.prefix)
+            elif isinstance(v, TerminatingState):
+                return ("TerminatingState")
+            else:
+                raise TypeError(f"Unsupported transition value type: {type(v)}")
+
+        self.transition = tuple(
+            sorted((k, key_value_repr(v)) for k, v in node.transition.items())
+        )
+
+        self._hash = hash((self.level, self.transition))
+
+    def __eq__(self, other):
+        if not isinstance(other, MDD_node_key):
+            return False
+
+        return (self.level == other.level) and (self.transition == other.transition)
+
+    def __hash__(self):
+        return self._hash
+
+def lookup_mdd(mdd_node, cache):
+    if isinstance(mdd_node, Prefix):
+        mdd_node = cache[mdd_node]
+    return mdd_node
+
+def add_row_to_mdd(row, mdd_node, mdd, level=0):
+    """
+    Auxiliary function performing the construction step of the MDD (step 1.1)
+    :param row: the current row being added
+    :param mdd_node: the current MDD node the algorithm is operating on
+    :param mdd: the current MDD
+    :param level: at which level of the MDD construction is happening
+    :return: A prefix identifying the new MDD node after construction
+    """
+    mdd_node = lookup_mdd(mdd_node, mdd.MDD_cache)
+
+    if len(row) == level:
+        return TerminatingState.SNK
+
+    prefix = Prefix(tuple(row[:level]))
+    value = row[level]
+
+    if value not in mdd_node.transition:
+        mdd_node.transition[value] = add_row_to_mdd(row, MDD_node(tuple(row[:(level + 1)]), level + 1, {}), mdd, level + 1)
+    else:
+        mdd_node.transition[value] = add_row_to_mdd(row, mdd_node.transition[value], mdd, level + 1)
+
+    mdd.MDD_cache[prefix] = mdd_node
+
+    return prefix
+
+def reduce_mdd(mdd_node, mdd, level):
+    """
+        Auxiliary function performing the reduction step of the MDD (step 1.1)
+        :param mdd_node: the current MDD node the algorithm is operating on
+        :param mdd: the current MDD
+        :param level: at which level of the MDD construction is happening
+        :return: A prefix identifying the new MDD node after reduction
+    """
+    if isinstance(mdd_node, TerminatingState):
+        return mdd_node
+
+    mdd_node = lookup_mdd(mdd_node, mdd.MDD_cache)
+
+    B = {}
+    for key in mdd_node.transition.keys():
+        reduced_mdd = reduce_mdd(mdd_node.transition[key], mdd, level + 1)
+        if reduced_mdd != False:
+            B[key] = reduced_mdd
+
+    if len(B.keys()) == 0:
+        return False
+
+    G = MDD_node(mdd_node.prefix, level, B)
+
+    temp = None
+
+    key = MDD_node_key(G)
+    lookups = mdd.MDD_cache_reverse.get(key, set())
+
+    for lookup in lookups:
+        if lookup in mdd.repeated_keys:
+            return lookup.__deepcopy__()
+        else:
+            temp = lookup.__deepcopy__()
+
+    if temp is not None:
+        mdd.repeated_keys.add(temp)
+        return temp
+
+    mdd.MDD_cache[Prefix(mdd_node.prefix)] = G
+
+    return Prefix(mdd_node.prefix)
+
+def construct_mdd(table):
+    """
+        Coordinator function for constructing and reducing the MDD (Step 1)
+        :param table: The table to convert to an MDD
+        :return: The resulting MDD (represented as a lookup hash table)
+    """
+    mdd = MDD()
+
+    mdd_node = MDD_node(tuple(), 0, {})
+
+    for i in range(0, table.shape[0]):
+        row = table[i]
+        mdd_node = add_row_to_mdd(row, mdd_node, mdd, 0)
+
+    for lookup, node in mdd.MDD_cache.items():
+        key = MDD_node_key(node)
+        mdd.MDD_cache_reverse[key].add(lookup)
+    mdd_node = lookup_mdd(mdd_node, mdd.MDD_cache)
+    for key in mdd_node.transition.keys():
+        reduced_mdd = reduce_mdd(mdd_node.transition[key], mdd, 1)
+        mdd_node.transition[key] = reduced_mdd
+
+    return mdd.MDD_cache
+
+def dom_size(x):
+    return x.ub - x.lb + 1
+
+class Flow:
+    """
+        Class representing the ingoing and outgoing flow associated with a MDD node.
+    """
+    def __init__(self):
+        self.flow_in = []
+        self.flow_out = []
+
+    def add_flow_in(self, value):
+        self.flow_in.append(value)
+
+    def add_flow_out(self, value):
+        self.flow_out.append(value)
+
+def get_corresponding_bv(column_index, X):
+    """
+        Retrieves the correct direct encoding variable given the column index of the Boolean table.
+    :param column_index: The column index of the Boolean table
+    :param X: The variable of the Table constraint
+    :return: The corresponding Boolean variable
+    """
+    cumulative = 0
+
+    for i, x in enumerate(X):
+        d_size = dom_size(x)
+
+        if column_index < cumulative + d_size:
+            offset = column_index - cumulative
+
+            return x == (offset + x.lb)
+
+        cumulative += d_size
+
+    return None
+
+def mdd_to_flow(mdd_cache, X):
+    """
+    Performs Step 2 of the decomposition algorithm: converting the obtained MDD to flow constraints.
+    """
+    domains = np.array([dom_size(x) for x in X])
+    lb = np.array([x.lb for x in X])
+
+    no_columns = sum(domains)
+
+    column_counter = {k: 0 for k in range(no_columns)}
+    flow = {k: Flow() for k in mdd_cache.keys()}
+    flow['snk'] = Flow()
+
+    for key in mdd_cache.keys():
+        val = lookup_mdd(mdd_cache[key], mdd_cache)
+        for (k, v) in val.transition.items():
+            column = sum(domains[:val.level]) + k - lb[val.level]
+            if column < 0 or column >= len(column_counter):
+                continue
+            column_counter[column] += 1
+            flow[key].add_flow_out((column, column_counter[column]))
+            if isinstance(v, Prefix):
+                flow[v].add_flow_in((column, column_counter[column]))
+            if isinstance(v, TerminatingState):
+                flow['snk'].add_flow_in((column, column_counter[column]))
+
+    cons = []
+    substitution = {}
+    for key in column_counter.keys():
+        if column_counter[key] == 0:
+            continue
+        elif column_counter[key] == 1:
+            substitution[(key, 1)] = get_corresponding_bv(key, X)
+        else:
+            bvs = cp.boolvar(shape=column_counter[key], name=f"e_{key}")
+
+            for n in range(1, column_counter[key] + 1):
+                substitution[(key, n)] = bvs[n - 1]
+
+    excluded = {Prefix(tuple()), "snk"}
+    for key in sorted(
+            (k for k in flow if k not in excluded),
+            key=lambda k: (len(k.prefix), k.prefix)
+    ):
+        if (len(flow[key].flow_in) == 0) or (len(flow[key].flow_out) == 0):
+            continue
+        elif (len(flow[key].flow_in) == 1 and len(flow[key].flow_out) == 1
+              and substitution[flow[key].flow_out[0]] == substitution[flow[key].flow_in[0]]):
+            continue
+        elif (len(flow[key].flow_in) == 1 and len(flow[key].flow_out) == 1
+              and column_counter[flow[key].flow_in[0][0]] > 1 and column_counter[flow[key].flow_out[0][0]] > 1):
+            substitution[flow[key].flow_out[0]] = substitution[flow[key].flow_in[0]]
+        else:
+            cons += [cp.sum([substitution[(c, m)] for (c, m) in flow[key].flow_in]) == cp.sum([substitution[(c, m)] for (c, m) in flow[key].flow_out])]
+
+    cons += [cp.sum([substitution[(c, m)] for (c, m) in flow['snk'].flow_in]) == 1]
+    cons += [cp.sum([substitution[(c, m)] for (c, m) in flow[Prefix(tuple())].flow_out]) == 1]
+
+    for key in column_counter.keys():
+        if column_counter[key] > 1:
+            cons += [cp.sum([substitution[(key, n)] for n in range(1, column_counter[key] + 1)]) == get_corresponding_bv(key, X)]
+    return cons
+
+
+def filter_table(X, table):
+    """
+    Filters rows with values that are invalid for the domain out of the table.
+    """
+    lb = np.array([x.lb for x in X])
+    ub = np.array([x.ub for x in X])
+
+    mask = np.all((table >= lb) & (table <= ub), axis=1)
+    new_table = table[mask]
+
+    return new_table

--- a/cpmpy/expressions/mdd_encoding.py
+++ b/cpmpy/expressions/mdd_encoding.py
@@ -278,7 +278,7 @@ def mdd_to_flow(mdd_cache, X):
         elif column_counter[key] == 1:
             substitution[(key, 1)] = get_corresponding_bv(key, X)
         else:
-            bvs = cp.boolvar(shape=column_counter[key], name=f"e_{key}")
+            bvs = cp.boolvar(shape=column_counter[key])
 
             for n in range(1, column_counter[key] + 1):
                 substitution[(key, n)] = bvs[n - 1]

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -34,7 +34,8 @@ def decompose_in_tree(lst_of_expr: Sequence[Expression],
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
                       csemap: Optional[Dict[Expression, Expression]] = None,
-                      decompose_custom: Optional[Dict[str, Callable]] = None) -> List[Expression]:
+                      decompose_custom: Optional[Dict[str, Callable]] = None,
+                      decompose_positive: Optional[Dict[str, Callable]] = None) -> List[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -46,6 +47,8 @@ def decompose_in_tree(lst_of_expr: Sequence[Expression],
     :param _toplevel: DEPRECATED
     :param nested: DEPRECATED
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
+    :param decompose_custom: a dictionary containing custom for global constraints
+    :param decompose_positive: a dictionary containing custom decompositions for global constraints that can only be positively reified
 
     Supported numerical global functions remain in the expression tree as is. They can be rewritten using
     :func:`cpmpy.transformations.reification.reify_rewrite`
@@ -59,13 +62,13 @@ def decompose_in_tree(lst_of_expr: Sequence[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    changed, newlst_of_expr, todo_toplevel = _decompose_in_tree(lst_of_expr, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom)
+    changed, newlst_of_expr, todo_toplevel = _decompose_in_tree(lst_of_expr, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
     if not changed:
         return list(lst_of_expr)
 
     # new toplevel constraints may need to be decomposed too
     while len(todo_toplevel):
-        changed, decomp, next_toplevel = _decompose_in_tree(todo_toplevel, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom)
+        changed, decomp, next_toplevel = _decompose_in_tree(todo_toplevel, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
         if not changed:
             newlst_of_expr.extend(todo_toplevel)
             break
@@ -81,7 +84,8 @@ def decompose_objective(expr: Expression,
                         supported: Optional[AbstractSet[str]] = None,
                         supported_reified: Optional[AbstractSet[str]] = None,
                         csemap: Optional[Dict[Expression, Expression]] = None,
-                        decompose_custom: Optional[Dict[str, Callable]]=None) -> Tuple[Expression, List[Expression]]:
+                        decompose_custom: Optional[Dict[str, Callable]]=None,
+                        decompose_positive: Optional[Dict[str, Callable]]=None) -> Tuple[Expression, List[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver
     in the objective function expression (numeric or global).
@@ -108,7 +112,7 @@ def decompose_objective(expr: Expression,
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    changed, newexpr, todo_toplevel = _decompose_in_tree((expr,), supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
+    changed, newexpr, todo_toplevel = _decompose_in_tree((expr,), supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
     if not changed:
         return expr, []
 
@@ -121,7 +125,8 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
                        supported_reified: AbstractSet[str],
                        is_toplevel: bool,
                        csemap: Optional[Dict[Expression, Expression]]=None,
-                       decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Expression], List[Expression]]:
+                       decompose_custom:Optional[Dict[str, Callable]]=None,
+                       decompose_positive:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Expression], List[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver, recursive internal version.
 
@@ -134,6 +139,8 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
     :param is_toplevel: whether ``lst_of_expr`` is the toplevel list of constraints.
         If False, ``lst_of_expr`` is an argument to another expression and its global constraints must support reification.
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
+    :param decompose_custom: a dictionary containing custom for global constraints
+    :param decompose_positive: a dictionary containing custom decompositions for global constraints that can only be positively reified
 
     :returns: ``(changed, newexpr, toplevel)`` where:
         - ``changed`` is True if a decomposition was done (or a recursive call changed something).
@@ -155,7 +162,7 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
             elif isinstance(expr, np.ndarray) and expr.dtype != object:
                 pass  # only constants, nothing to do
             else:
-                rec_changed, rec_expr, rec_toplevel = _decompose_in_tree(expr, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
+                rec_changed, rec_expr, rec_toplevel = _decompose_in_tree(expr, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
                 if rec_changed:
                     expr = rec_expr
                     toplevel.extend(rec_toplevel)
@@ -165,7 +172,7 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
 
         # if an expression, decompose its arguments first
         if isinstance(expr, Expression) and expr.has_subexpr():
-            rec_changed, newargs, rec_toplevel = _decompose_in_tree(expr.args, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
+            rec_changed, newargs, rec_toplevel = _decompose_in_tree(expr.args, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
             if rec_changed:
                 expr = copy.copy(expr)
                 expr.update_args(newargs)
@@ -183,7 +190,9 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
                     # we might have already decomposed it previously
                     newexpr = csemap[expr]
                 else:
-                    if decompose_custom is not None and expr.name in decompose_custom:
+                    if is_toplevel and decompose_positive is not None and expr.name in decompose_positive:
+                        newexpr, define = decompose_positive[expr.name](expr)
+                    elif decompose_custom is not None and expr.name in decompose_custom:
                         newexpr, define = decompose_custom[expr.name](expr)
                     else:
                         newexpr, define = expr.decompose()
@@ -191,7 +200,7 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
 
                     # decomposed constraints may introduce new globals
                     if isinstance(newexpr, list):  # globals return a list instead of a single expression (TODO: change?)
-                        rec_changed, rec_newexpr, rec_toplevel = _decompose_in_tree(newexpr, supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
+                        rec_changed, rec_newexpr, rec_toplevel = _decompose_in_tree(newexpr, supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
                         if rec_changed:
                             newexpr_lst = rec_newexpr
                             toplevel.extend(rec_toplevel)
@@ -199,7 +208,7 @@ def _decompose_in_tree(lst_of_expr: Union[Sequence[Expression], NDVarArray],
                             newexpr_lst = newexpr  # for mypy
                         newexpr = cpm_all(newexpr_lst)  # make the list a single expression
                     else:
-                        rec_changed, rec_lst_newexpr, rec_toplevel = _decompose_in_tree((newexpr,), supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
+                        rec_changed, rec_lst_newexpr, rec_toplevel = _decompose_in_tree((newexpr,), supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
                         if rec_changed:
                             newexpr = rec_lst_newexpr[0]
                             toplevel.extend(rec_toplevel)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -581,8 +581,9 @@ def decompose_linear(lst_of_expr: Sequence[Expression],
         supported_reified = frozenset[str]()
 
     decompose_custom = get_linear_decompositions()
+    decompose_positive = get_positive_decompositions()
 
-    return decompose_in_tree(lst_of_expr, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    return decompose_in_tree(lst_of_expr, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom, decompose_positive=decompose_positive)
 
 def decompose_linear_objective(obj: Expression,
                                supported: Optional[AbstractSet[str]] = None,
@@ -608,9 +609,20 @@ def get_linear_decompositions():
     """
     return dict(
         alldifferent=AllDifferent.decompose_linear,
-        element=Element.decompose_linear,
+        element=Element.decompose_linear
     )
-    # Should we add Gleb's table decomposition? or is it not non-reifiable?
+
+def get_positive_decompositions():
+    """
+        Implementation of custom linear decompositions for some global constraints that can only be positively reified.
+
+        returns:
+            dict: a dictionary mapping expression names to a function, taking as argument the expression to decompose
+    """
+
+    return dict(
+        table=Table.decompose_positive
+    )
 
 
 def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import cpmpy as cp
@@ -138,6 +139,59 @@ class TestTransLinearize:
     
         n_sols = cp.Model(lincons).solveAll(display=cb)
         assert n_sols == 3 * 2 * 1# 1 and 3 not allowed
+
+    def test_table(self):
+        x = cp.intvar(shape=3, lb=1, ub=5)
+        cons = [
+            cp.Table(x, [[2, 1, 1], [3, 2, 2], [4, 3, 3], [1, 2, 3], [2, 1, 2]]),
+            x[0] != 2,
+            x[2] != 2
+        ]
+
+        lincons = linearize_constraint(decompose_linear(cons))
+
+
+        sols = []
+
+        def cb():
+            assert all(con.value() for con in cons)
+            sols.append(tuple(x.value()))
+
+        n_sols = cp.Model(lincons).solveAll(display=cb)
+
+        assert n_sols == 2
+        assert set(sols) == {(1, 2, 3), (4, 3, 3)}
+
+        cons = [
+            cp.Table(x, [[2, 1, 1]])
+
+        ]
+
+        lincons = linearize_constraint(decompose_linear(cons))
+
+        sols = []
+
+        n_sols = cp.Model(lincons).solveAll(display=cb)
+
+        assert n_sols == 1
+        assert set(sols) == {(2,1,1)}
+
+        cons = [
+            cp.Table(x, np.empty((0, len(x)), dtype=int))
+        ]
+
+        lincons = linearize_constraint(decompose_linear(cons))
+
+        sols = []
+
+        def cb():
+            assert all(con.value() for con in cons)
+            sols.append(tuple(x.value()))
+
+        n_sols = cp.Model(lincons).solveAll(display=cb)
+
+        assert n_sols == 0
+        assert set(sols) == set()
 
     # def test_issue_580(self): -> Modulo is now a global constraint
     #     x = cp.intvar(1, 5, name='x')

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -186,9 +186,10 @@ class TestTransfDecomp:
                             {"sum([20, 30, 40] * [a == 1, a == 2, a == 3]) == 8"}  # a == 0 is False (a in 1..3) 
 
         # test table
-        cons = cp.Table(x, [[1,1], [2,3]])
+        # has become obsolete due to new linear decomposition for table
+        '''cons = cp.Table(x, [[1,1], [2,3]])
         assert set(map(str, decompose_linear([cons]))) == \
-                            {'((a == 1) and (b == 1)) or ((a == 2) and (b == 3))'}
+                            {'((a == 1) and (b == 1)) or ((a == 2) and (b == 3))'}'''
 
         # test count
         cons = cp.Count(x, 2) >= 1


### PR DESCRIPTION
The MDD decomposition for the Table global constraint has been added.

At this moment, the decomposition only happens for top-level Table constraints. This decomposition should also be valid for positively reified Table constraints, however.
