### PR TITLE
Ruff autoformatting expressions/ folder

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -1,18 +1,18 @@
 """
-    Classes and functions that represent and create expressions (constraints and objectives)
+Classes and functions that represent and create expressions (constraints and objectives)
 
-    ==================
-    List of submodules
-    ==================
-    .. autosummary::
-        :nosignatures:
+==================
+List of submodules
+==================
+.. autosummary::
+:nosignatures:
 
-        variables
-        core
-        globalconstraints
-        globalfunctions
-        python_builtins
-        utils
+variables
+core
+globalconstraints
+globalfunctions
+python_builtins
+utils
 
 
 """
@@ -20,12 +20,52 @@
 # we only import methods/classes that are used for modelling
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
-from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
-from .globalconstraints import AllDifferent, AllDifferentExcept0, AllDifferentExceptN, AllEqual, AllEqualExceptN, Circuit, Inverse, Table, ShortTable, Xor, Cumulative, CumulativeOptional, \
-    IfThenElse, GlobalCardinalityCount, DirectConstraint, InDomain, Increasing, Decreasing, IncreasingStrict, DecreasingStrict, \
-    LexLess, LexLessEq, LexChainLess, LexChainLessEq, Precedence, NoOverlap, NoOverlapOptional, \
-    NegativeTable, Regular
-from .globalconstraints import alldifferent, allequal, circuit # Old, to be deprecated
-from .globalfunctions import Minimum, Maximum, Abs, Multiplication, Division, Modulo, Power, Element, Count, Among, NValue, NValueExcept
+from .variables import BoolVar, IntVar, cparray  # Old, to be deprecated
+from .globalconstraints import (
+    AllDifferent,
+    AllDifferentExcept0,
+    AllDifferentExceptN,
+    AllEqual,
+    AllEqualExceptN,
+    Circuit,
+    Inverse,
+    Table,
+    ShortTable,
+    Xor,
+    Cumulative,
+    CumulativeOptional,
+    IfThenElse,
+    GlobalCardinalityCount,
+    DirectConstraint,
+    InDomain,
+    Increasing,
+    Decreasing,
+    IncreasingStrict,
+    DecreasingStrict,
+    LexLess,
+    LexLessEq,
+    LexChainLess,
+    LexChainLessEq,
+    Precedence,
+    NoOverlap,
+    NoOverlapOptional,
+    NegativeTable,
+    Regular,
+)
+from .globalconstraints import alldifferent, allequal, circuit  # Old, to be deprecated
+from .globalfunctions import (
+    Minimum,
+    Maximum,
+    Abs,
+    Multiplication,
+    Division,
+    Modulo,
+    Power,
+    Element,
+    Count,
+    Among,
+    NValue,
+    NValueExcept,
+)
 from .core import BoolVal
 from .python_builtins import all, any, max, min, sum, abs

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -1,102 +1,117 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## expressions.py
 ##
 """
-    The :class:`~cpmpy.expressions.core.Expression` superclass and common subclasses :class:`~cpmpy.expressions.core.Comparison` and :class:`~cpmpy.expressions.core.Operator`.
-    
-    None of these objects should be directly created, they are automatically created through operator
-    overloading on variables and expressions.
+The :class:`~cpmpy.expressions.core.Expression` superclass and common subclasses :class:`~cpmpy.expressions.core.Comparison` and :class:`~cpmpy.expressions.core.Operator`.
 
-    Here is a list of standard python operators and what object (with what expr.name) it creates:
+None of these objects should be directly created, they are automatically created through operator
+overloading on variables and expressions.
 
-    Comparisons
-    -----------
-    ===================  ==========================
-    Python Operator      CPMpy Object                     
-    ===================  ==========================
-    `x == y`             `Comparison("==", x, y)`         
-    `x != y`             `Comparison("!=", x, y)`         
-    `x < y`              `Comparison("<", x, y)`          
-    `x <= y`             `Comparison("<=", x, y)`         
-    `x > y`              `Comparison(">", x, y)`          
-    `x >= y`             `Comparison(">=", x, y)`         
-    ===================  ==========================
+Here is a list of standard python operators and what object (with what expr.name) it creates:
 
-    Arithmetic Operators
-    --------------------
-    ===========================  ===============================================
-    Python Operator              CPMpy Object                                  
-    ===========================  ===============================================
-    `-x`                         `Operator("-", [x])`                          
-    `x + y`                      `Operator("sum", [x, y])`                     
-    `sum([x,y,z])`               `Operator("sum", [x, y, z])`                  
-    `sum([c0*x, c1*y, c2*z])`    `Operator("wsum", [[c0, c1, c2], [x, y, z]])` 
-    `x - y`                      `Operator("sum", [x, -y])`                    
-    `x * y`                      `globalfunctions.Multiplication(x, y)`
-    `x // y`                     `globalfunctions.Division([x, y])` (integer division, rounding towards zero)
-    `x % y`                      `globalfunctions.Modulo([x, y])` (remainder after integer division)
-    `x ** y`                     `globalfunctions.Power([x, y])`
-    ===========================  ===============================================
+Comparisons
+-----------
+===================  ==========================
+Python Operator      CPMpy Object
+===================  ==========================
+`x == y`             `Comparison("==", x, y)`
+`x != y`             `Comparison("!=", x, y)`
+`x < y`              `Comparison("<", x, y)`
+`x <= y`             `Comparison("<=", x, y)`
+`x > y`              `Comparison(">", x, y)`
+`x >= y`             `Comparison(">=", x, y)`
+===================  ==========================
 
-    
-    Logical Operators
-    -----------------
-    ===================  =======================================================
-    Python Operator      CPMpy Object  
-    ===================  =======================================================                                        
-    `x & y`              `Operator("and", [x, y])`                             
-    `x | y`              `Operator("or", [x, y])`                              
-    `~x`                 `Operator("not", [x])` or `NegBoolView(x)` if Boolean 
-    `x ^ y`              `globalconstraints.Xor([x, y])`
-    ===================  =======================================================
+Arithmetic Operators
+--------------------
+===========================  ===============================================
+Python Operator              CPMpy Object
+===========================  ===============================================
+`-x`                         `Operator("-", [x])`
+`x + y`                      `Operator("sum", [x, y])`
+`sum([x,y,z])`               `Operator("sum", [x, y, z])`
+`sum([c0*x, c1*y, c2*z])`    `Operator("wsum", [[c0, c1, c2], [x, y, z]])`
+`x - y`                      `Operator("sum", [x, -y])`
+`x * y`                      `globalfunctions.Multiplication(x, y)`
+`x // y`                     `globalfunctions.Division([x, y])` (integer division, rounding towards zero)
+`x % y`                      `globalfunctions.Modulo([x, y])` (remainder after integer division)
+`x ** y`                     `globalfunctions.Power([x, y])`
+===========================  ===============================================
 
-    Python has no built-in operator for `implication` that can be overloaded.
-    CPMpy hence has a function :func:`~cpmpy.expressions.core.Expression.implies` that can be called:
 
-    ===================  ======================
-    Python Operator      CPMpy Object          
-    ===================  ======================
-    `x.implies(y)`       `Operator("->", [x,y])` 
-    ===================  ======================
+Logical Operators
+-----------------
+===================  =======================================================
+Python Operator      CPMpy Object
+===================  =======================================================
+`x & y`              `Operator("and", [x, y])`
+`x | y`              `Operator("or", [x, y])`
+`~x`                 `Operator("not", [x])` or `NegBoolView(x)` if Boolean
+`x ^ y`              `globalconstraints.Xor([x, y])`
+===================  =======================================================
 
-    Apart from operator overloading, expressions implement two important functions:
+Python has no built-in operator for `implication` that can be overloaded.
+CPMpy hence has a function :func:`~cpmpy.expressions.core.Expression.implies` that can be called:
 
-    - :func:`~cpmpy.expressions.core.Expression.is_bool`   
-        which returns whether the return type of the expression is Boolean.
-        If it does, the expression can be used as top-level constraint
-        or in logical operators.
+===================  ======================
+Python Operator      CPMpy Object
+===================  ======================
+`x.implies(y)`       `Operator("->", [x,y])`
+===================  ======================
 
-    - :func:`~cpmpy.expressions.core.Expression.value`    
-        computes the value of this expression, by calling .value() on its
-        subexpressions and doing the appropriate computation
-        this is used to conveniently print variable values, objective values
-        and any other expression value (e.g. during debugging).
-    
-    ===============
-    List of classes
-    ===============
-    .. autosummary::
-        :nosignatures:
+Apart from operator overloading, expressions implement two important functions:
 
-        Expression
-        Comparison
-        Operator
+- :func:`~cpmpy.expressions.core.Expression.is_bool`
+which returns whether the return type of the expression is Boolean.
+If it does, the expression can be used as top-level constraint
+or in logical operators.
+
+- :func:`~cpmpy.expressions.core.Expression.value`
+computes the value of this expression, by calling .value() on its
+subexpressions and doing the appropriate computation
+this is used to conveniently print variable values, objective values
+and any other expression value (e.g. during debugging).
+
+===============
+List of classes
+===============
+.. autosummary::
+:nosignatures:
+
+Expression
+Comparison
+Operator
 """
+
 import copy
 import warnings
 from typing import Any, Optional, TypeAlias, TypeVar, Union, Sequence, Iterable
 import numpy as np
 import cpmpy as cp
 
-from .utils import is_int, is_num, is_any_list, flatlist, get_bounds, is_boolexpr, is_true_cst, is_false_cst, argvals, is_bool
-from ..exceptions import IncompleteFunctionError, TypeError
+from .utils import (
+    is_num,
+    is_any_list,
+    flatlist,
+    get_bounds,
+    is_boolexpr,
+    is_true_cst,
+    is_false_cst,
+    argvals,
+    is_bool,
+)
+from ..exceptions import TypeError
 
 # Common typing helpers
 T = TypeVar("T")
-ListLike: TypeAlias = Union[list[T], tuple[T, ...], np.ndarray]  # matches is_any_list() check
-ExprLike: TypeAlias = Union["Expression", int, np.integer, np.bool_]  # expression or int (incl np variants, e.g. user facing)
+ListLike: TypeAlias = Union[
+    list[T], tuple[T, ...], np.ndarray
+]  # matches is_any_list() check
+ExprLike: TypeAlias = Union[
+    "Expression", int, np.integer, np.bool_
+]  # expression or int (incl np variants, e.g. user facing)
 
 
 class Expression(object):
@@ -129,7 +144,10 @@ class Expression(object):
         """
         self.name = name
         if not isinstance(arg_list, tuple):
-            warnings.warn(f"DEPRECATED: Argument list of {name} is not a tuple, updated the constructor!", UserWarning)
+            warnings.warn(
+                f"DEPRECATED: Argument list of {name} is not a tuple, updated the constructor!",
+                UserWarning,
+            )
             arg_list = tuple(arg_list)
         self._args = arg_list
 
@@ -139,11 +157,14 @@ class Expression(object):
 
     @args.setter
     def args(self, args: Iterable[Any]) -> None:
-        raise AttributeError("Cannot modify read-only attribute 'args', use 'update_args()'")
+        raise AttributeError(
+            "Cannot modify read-only attribute 'args', use 'update_args()'"
+        )
 
     def update_args(self, args: Iterable[Any]) -> None:
-        """ Allows in-place update of the expression's arguments.
-            Resets all cached computations which depend on the expression tree.
+        """
+        Allows in-place update of the expression's arguments.
+        Resets all cached computations which depend on the expression tree.
         """
         self._args = tuple(args)
         # Reset cached "_has_subexpr"
@@ -160,9 +181,8 @@ class Expression(object):
             return self.__repr__()
         out = self.desc
         if self._full_print:
-            out += " -- "+self.__repr__()
+            out += " -- " + self.__repr__()
         return out
-
 
     def __repr__(self):
         strargs = []
@@ -179,16 +199,17 @@ class Expression(object):
         return hash(self.__repr__())
 
     def has_subexpr(self):
-        """ Does it contains nested :class:`Expressions <cpmpy.expressions.core.Expression>` (anything other than a :class:`~cpmpy.expressions.variables._NumVarImpl` or a constant)?
-            Is of importance when deciding whether certain transformations are needed
-            along particular paths of the expression tree.
-            Results are cached for future calls and reset when the expression changes
-            (in-place argument update).
+        """
+        Does it contains nested :class:`Expressions <cpmpy.expressions.core.Expression>` (anything other than a :class:`~cpmpy.expressions.variables._NumVarImpl` or a constant)?
+        Is of importance when deciding whether certain transformations are needed
+        along particular paths of the expression tree.
+        Results are cached for future calls and reset when the expression changes
+        (in-place argument update).
         """
         # return cached result
-        if hasattr(self, '_has_subexpr'):
+        if hasattr(self, "_has_subexpr"):
             return self._has_subexpr
-        
+
         # micro-optimisations, cache the lookups
         _NumVarImpl = cp.variables._NumVarImpl
         _NDVarArray = cp.variables.NDVarArray
@@ -220,22 +241,26 @@ class Expression(object):
         return False
 
     def is_bool(self):
-        """ is it a Boolean (return type) Operator?
-            Default: yes
+        """
+        Is it a Boolean (return type) Operator?
+        Default: yes
         """
         return True
 
     def value(self):
-        return None # default
+        return None  # default
 
     def get_bounds(self):
         if self.is_bool():
-            return 0, 1 #default for boolean expressions
+            return 0, 1  # default for boolean expressions
         raise NotImplementedError(f"`get_bounds` is not implemented for type {self}")
 
     # keep for backwards compatibility
     def deepcopy(self, memodict={}):
-        warnings.warn("Deprecated, use copy.deepcopy() instead, will be removed in stable version", DeprecationWarning)
+        warnings.warn(
+            "Deprecated, use copy.deepcopy() instead, will be removed in stable version",
+            DeprecationWarning,
+        )
         return copy.deepcopy(self, memodict)
 
     # implication constraint: self -> other
@@ -247,7 +272,7 @@ class Expression(object):
             return BoolVal(True)
         if is_false_cst(other):
             return ~self
-        return Operator('->', [self, other])
+        return Operator("->", [self, other])
 
     # Comparisons
     def __eq__(self, other):
@@ -282,8 +307,10 @@ class Expression(object):
             return self
         # catch beginner mistake
         if is_num(other) and not is_bool(other):
-            raise TypeError(f"{self}&{other} is not valid because {other} is a number, did you forget to put brackets? "
-                            f"E.g. always write (x==2)&(y<5).")
+            raise TypeError(
+                f"{self}&{other} is not valid because {other} is a number, did you forget to put brackets? "
+                f"E.g. always write (x==2)&(y<5)."
+            )
         return Operator("and", [self, other])
 
     def __rand__(self, other):
@@ -292,8 +319,10 @@ class Expression(object):
             return self
         # catch beginner mistake
         if is_num(other) and not is_bool(other):
-            raise TypeError(f"{other}&{self} is not valid because {other} is a number, "
-                            f"did you forget to put brackets? E.g. always write (x==2)&(y<5).")
+            raise TypeError(
+                f"{other}&{self} is not valid because {other} is a number, "
+                f"did you forget to put brackets? E.g. always write (x==2)&(y<5)."
+            )
         return Operator("and", [other, self])
 
     def __or__(self, other):
@@ -302,8 +331,10 @@ class Expression(object):
             return self
         # catch beginner mistake
         if is_num(other) and not is_bool(other):
-            raise TypeError(f"{self}|{other} is not valid because {other} is a number, "
-                            f"did you forget to put brackets? E.g. always write (x==2)|(y<5).")
+            raise TypeError(
+                f"{self}|{other} is not valid because {other} is a number, "
+                f"did you forget to put brackets? E.g. always write (x==2)|(y<5)."
+            )
         return Operator("or", [self, other])
 
     def __ror__(self, other):
@@ -312,8 +343,10 @@ class Expression(object):
             return self
         # catch beginner mistake
         if is_num(other) and not is_bool(other):
-            raise TypeError(f"{other}|{self} is not valid because {other} is a number, "
-                            f"did you forget to put brackets? E.g. always write (x==2)|(y<5).")
+            raise TypeError(
+                f"{other}|{self} is not valid because {other} is a number, "
+                f"did you forget to put brackets? E.g. always write (x==2)|(y<5)."
+            )
         return Operator("or", [other, self])
 
     def __xor__(self, other):
@@ -356,7 +389,7 @@ class Expression(object):
         #     return -self
         # return Operator("sub", [other, self])
         return (-self).__radd__(other)
-    
+
     # multiplication: use GlobalFunction Multiplication so it can be decomposed (e.g. to linear)
     def __mul__(self, other):
         if is_num(other) and other == 1:
@@ -369,15 +402,19 @@ class Expression(object):
         return cp.Multiplication(other, self)
 
     # matrix multipliciation TODO?
-    #object.__matmul__(self, other)
+    # object.__matmul__(self, other)
 
     # other mathematical ones
     def __truediv__(self, other):
-        warnings.warn("We only support floordivision, use // in stead of /", SyntaxWarning)
+        warnings.warn(
+            "We only support floordivision, use // in stead of /", SyntaxWarning
+        )
         return self.__floordiv__(other)
 
     def __rtruediv__(self, other):
-        warnings.warn("We only support floordivision, use // in stead of /", SyntaxWarning)
+        warnings.warn(
+            "We only support floordivision, use // in stead of /", SyntaxWarning
+        )
         return self.__rfloordiv__(other)
 
     def __floordiv__(self, other):
@@ -395,21 +432,21 @@ class Expression(object):
         return cp.Modulo(other, self)
 
     def __pow__(self, other, modulo=None):
-        assert (modulo is None), "Power operator: modulo not supported"
+        assert modulo is None, "Power operator: modulo not supported"
         if is_num(other) and other == 1:
             return self
         return cp.Power(self, other)
 
     def __rpow__(self, other, modulo=None):
-        assert (modulo is None), "Power operator: modulo not supported"
+        assert modulo is None, "Power operator: modulo not supported"
         return cp.Power(other, self)
 
     # Not implemented: (yet?)
-    #object.__divmod__(self, other)
+    # object.__divmod__(self, other)
 
     # unary mathematical operators
     def __neg__(self):
-        if self.name == 'wsum':
+        if self.name == "wsum":
             # negate the constant weights
             return Operator(self.name, [[-a for a in self.args[0]], self.args[1]])
         return Operator("-", [self])
@@ -422,20 +459,23 @@ class Expression(object):
 
     def __invert__(self):
         if not (is_boolexpr(self)):
-            raise TypeError("Not operator is only allowed on boolean expressions: {0}".format(self))
+            raise TypeError(
+                "Not operator is only allowed on boolean expressions: {0}".format(self)
+            )
         return Operator("not", [self])
 
     def __bool__(self):
-        raise ValueError(f"__bool__ should not be called on a CPMPy expression {self} as it will always return True\n"
-                         "Do not use an expression as argument in an `if` statement and use cpmpy.any, cpmpy.max instead of python builtins\n"
-                         "If you think this is an error, please report on github")
+        raise ValueError(
+            f"__bool__ should not be called on a CPMPy expression {self} as it will always return True\n"
+            "Do not use an expression as argument in an `if` statement and use cpmpy.any, cpmpy.max instead of python builtins\n"
+            "If you think this is an error, please report on github"
+        )
+
 
 class BoolVal(Expression):
-    """
-        Wrapper for python or numpy BoolVals
-    """
+    """Wrapper for python or numpy BoolVals"""
 
-    def __init__(self, arg: bool|np.bool_) -> None:
+    def __init__(self, arg: bool | np.bool_) -> None:
         arg = bool(arg)  # will raise ValueError if not a Boolean-able
         super(BoolVal, self).__init__("boolval", (arg,))
 
@@ -455,79 +495,87 @@ class BoolVal(Expression):
 
     def get_bounds(self) -> tuple[int, int]:
         v = int(self.args[0])
-        return (v,v)
+        return (v, v)
 
     def __and__(self, other):
-        if is_bool(other): # Boolean constant
+        if is_bool(other):  # Boolean constant
             return BoolVal(self.args[0] and other)
         elif isinstance(other, Expression) and other.is_bool():
             if self.args[0]:
                 return other
             else:
                 return BoolVal(False)
-        raise ValueError(f"{self}&{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}.")
-        
-    
-    def __rand__(self, other):
-        if is_bool(other): # Boolean constant
-            return BoolVal(self.args[0] and other)
-        elif isinstance(other, Expression) and other.is_bool():
-            if self.args[0]:
-                return other
-            else:
-                return BoolVal(False)
-        raise ValueError(f"{self}&{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}.")
+        raise ValueError(
+            f"{self}&{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}."
+        )
 
-    
+    def __rand__(self, other):
+        if is_bool(other):  # Boolean constant
+            return BoolVal(self.args[0] and other)
+        elif isinstance(other, Expression) and other.is_bool():
+            if self.args[0]:
+                return other
+            else:
+                return BoolVal(False)
+        raise ValueError(
+            f"{self}&{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}."
+        )
+
     def __or__(self, other):
-        if is_bool(other): # Boolean constant
+        if is_bool(other):  # Boolean constant
             return BoolVal(self.args[0] or other)
         elif isinstance(other, Expression) and other.is_bool():
             if not self.args[0]:
                 return other
             else:
                 return BoolVal(True)
-        raise ValueError(f"{self}|{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}.")
-        
-        
+        raise ValueError(
+            f"{self}|{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}."
+        )
+
     def __ror__(self, other):
-        if is_bool(other): # Boolean constant
+        if is_bool(other):  # Boolean constant
             return BoolVal(self.args[0] or other)
         elif isinstance(other, Expression) and other.is_bool():
             if not self.args[0]:
                 return other
             else:
                 return BoolVal(True)
-        raise ValueError(f"{self}|{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}.")
-        
+        raise ValueError(
+            f"{self}|{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}."
+        )
+
     def __xor__(self, other):
-        if is_bool(other): # Boolean constant
+        if is_bool(other):  # Boolean constant
             return BoolVal(self.args[0] ^ other)
         elif isinstance(other, Expression) and other.is_bool():
             if self.args[0]:
                 return ~other
             else:
                 return other
-        raise ValueError(f"{self}^^{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}.")
-    
-    
+        raise ValueError(
+            f"{self}^^{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}."
+        )
+
     def __rxor__(self, other):
-        if is_bool(other): # Boolean constant
+        if is_bool(other):  # Boolean constant
             return BoolVal(self.args[0] ^ other)
         elif isinstance(other, Expression) and other.is_bool():
             if self.args[0]:
                 return ~other
             else:
                 return other
-        raise ValueError(f"{self}^^{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}.")
-    
+        raise ValueError(
+            f"{self}^^{other} is not valid. Expected Boolean constant or Boolean Expression, but got {other} of type {type(other)}."
+        )
 
     def has_subexpr(self) -> bool:
-        """ Does it contains nested Expressions (anything other than a _NumVarImpl or a constant)?
-            Is of importance when deciding whether certain transformations are needed
-            along particular paths of the expression tree.
         """
-        return False # BoolVal is a wrapper for a python or numpy constant boolean.
+        Does it contains nested Expressions (anything other than a _NumVarImpl or a constant)?
+        Is of importance when deciding whether certain transformations are needed
+        along particular paths of the expression tree.
+        """
+        return False  # BoolVal is a wrapper for a python or numpy constant boolean.
 
     def implies(self, other: ExprLike) -> Expression:
         my_val: bool = self.args[0]
@@ -535,7 +583,9 @@ class BoolVal(Expression):
             assert other.is_bool(), "implies: other must be a boolean expression"
             if my_val:  # T -> other :: other
                 return other
-            return Operator("->", [self, other])  # do not simplify to True, would remove other from user view
+            return Operator(
+                "->", [self, other]
+            )  # do not simplify to True, would remove other from user view
         else:
             # should we check whether it actually is bool and not int?
             if my_val:  # T -> other :: other
@@ -546,9 +596,9 @@ class BoolVal(Expression):
 
 
 class Comparison(Expression):
-    """Represents a comparison between two sub-expressions
-    """
-    allowed = {'==', '!=', '<=', '<', '>=', '>'}
+    """Represents a comparison between two sub-expressions"""
+
+    allowed = {"==", "!=", "<=", "<", ">=", ">"}
 
     def __init__(self, name: str, left: ExprLike, right: ExprLike) -> None:
         """
@@ -556,37 +606,45 @@ class Comparison(Expression):
             name (str): Comparison operator (one of :attr:`Comparison.allowed`)
             left (ExprLike): Left-hand side (expression or constant)
             right (ExprLike): Right-hand side (expression or constant)
-        
+
         We expect at least one of the two to be an :class:`Expression`.
+
         """
-        assert (name in Comparison.allowed), f"Symbol {name} not allowed"
+        assert name in Comparison.allowed, f"Symbol {name} not allowed"
         super().__init__(name, (left, right))
 
     def __repr__(self) -> str:
         if all(isinstance(x, Expression) for x in self.args):
-            return "({}) {} ({})".format(self.args[0], self.name, self.args[1]) 
+            return "({}) {} ({})".format(self.args[0], self.name, self.args[1])
         # if not: prettier printing without braces
-        return "{} {} {}".format(self.args[0], self.name, self.args[1]) 
-    
+        return "{} {} {}".format(self.args[0], self.name, self.args[1])
+
     def __bool__(self) -> bool:
         # will be called when comparing elements in a container, but always with `==`
         if self.name == "==":
             return repr(self.args[0]) == repr(self.args[1])
-        return super().__bool__() # default to exception
+        return super().__bool__()  # default to exception
 
     # return the value of the expression
     # optional, default: None
     def value(self) -> Optional[bool]:
         arg_vals = argvals(self.args)
 
-        if any(a is None for a in arg_vals): return None
-        if   self.name == "==": return arg_vals[0] == arg_vals[1]
-        elif self.name == "!=": return arg_vals[0] != arg_vals[1]
-        elif self.name == "<":  return arg_vals[0] < arg_vals[1]
-        elif self.name == "<=": return arg_vals[0] <= arg_vals[1]
-        elif self.name == ">":  return arg_vals[0] > arg_vals[1]
-        elif self.name == ">=": return arg_vals[0] >= arg_vals[1]
-        return None # default
+        if any(a is None for a in arg_vals):
+            return None
+        if self.name == "==":
+            return arg_vals[0] == arg_vals[1]
+        elif self.name == "!=":
+            return arg_vals[0] != arg_vals[1]
+        elif self.name == "<":
+            return arg_vals[0] < arg_vals[1]
+        elif self.name == "<=":
+            return arg_vals[0] <= arg_vals[1]
+        elif self.name == ">":
+            return arg_vals[0] > arg_vals[1]
+        elif self.name == ">=":
+            return arg_vals[0] >= arg_vals[1]
+        return None  # default
 
 
 class Operator(Expression):
@@ -596,65 +654,85 @@ class Operator(Expression):
     Convention for 2-ary operators: if one of the two is a constant,
     it is stored first (as expr[0]), this eases weighted sum detection
     """
-    allowed = {
-        #name: (arity, is_bool)       arity 0 = n-ary, min 2
-        'and': (0, True),
-        'or':  (0, True),
-        '->':  (2, True),
-        'not': (1, True),
-        'sum': (0, False),
-        'wsum': (2, False),
-        'sub': (2, False), # x - y
-        '-':   (1, False), # -x
-    }
-    printmap = {'sum': '+', 'sub': '-'}
 
-    def __init__(self, name: str, arg_list: Sequence[ExprLike | ListLike[ExprLike]]) -> None:
+    allowed = {
+        # name: (arity, is_bool)       arity 0 = n-ary, min 2
+        "and": (0, True),
+        "or": (0, True),
+        "->": (2, True),
+        "not": (1, True),
+        "sum": (0, False),
+        "wsum": (2, False),
+        "sub": (2, False),  # x - y
+        "-": (1, False),  # -x
+    }
+    printmap = {"sum": "+", "sub": "-"}
+
+    def __init__(
+        self, name: str, arg_list: Sequence[ExprLike | ListLike[ExprLike]]
+    ) -> None:
         """
         Arguments:
-            name (str): Operator name (one of :attr:`Operator.allowed`)
-            arg_list (Sequence[ExprLike | ListLike[ExprLike]]): List of expressions/constants, 
-                        or list of size 2 with list of weights and list of expressions for wsum.
+        name (str): Operator name (one of :attr:`Operator.allowed`)
+        arg_list (Sequence[ExprLike | ListLike[ExprLike]]): List of expressions/constants,
+                    or list of size 2 with list of weights and list of expressions for wsum.
+
         """
         # sanity checks
-        assert (name in Operator.allowed), "Operator {} not allowed".format(name)
-        assert is_any_list(arg_list), f"Operator: arg_list must be a list of expressions or constants, got {arg_list}"
+        assert name in Operator.allowed, "Operator {} not allowed".format(name)
+        assert is_any_list(arg_list), (
+            f"Operator: arg_list must be a list of expressions or constants, got {arg_list}"
+        )
         arity, is_bool_op = Operator.allowed[name]
         if is_bool_op:
-            #only boolean arguments allowed
+            # only boolean arguments allowed
             for arg in arg_list:
                 if not is_boolexpr(arg):
-                    raise TypeError("{}-operator only accepts boolean arguments, not {}".format(name,arg))
+                    raise TypeError(
+                        "{}-operator only accepts boolean arguments, not {}".format(
+                            name, arg
+                        )
+                    )
         if arity == 0:
             arg_list = flatlist(arg_list)
-            assert (len(arg_list) >= 1), "Operator: n-ary operators require at least one argument"
+            assert len(arg_list) >= 1, (
+                "Operator: n-ary operators require at least one argument"
+            )
         else:
-            assert (len(arg_list) == arity), "Operator: {}, number of arguments must be {}".format(name, arity)
+            assert len(arg_list) == arity, (
+                "Operator: {}, number of arguments must be {}".format(name, arity)
+            )
 
         # automatic weighted sum (wsum) creation:
         # if all args are an expression (not a constant)
         #    and one of the args is a wsum,
         #                    or a product of a constant and an expression,
         # then create a wsum of weights,expressions over all
-        if name == 'sum' and \
-                all(not is_num(a) for a in arg_list) and \
-                any(_wsum_should(a) for a in arg_list):
+        if (
+            name == "sum"
+            and all(not is_num(a) for a in arg_list)
+            and any(_wsum_should(a) for a in arg_list)
+        ):
             we = [_wsum_make(a) for a in arg_list]
             w: list[ExprLike] = [wi for w, _ in we for wi in w]
             e: list[ExprLike] = [ei for _, e in we for ei in e]
-            name = 'wsum'
+            name = "wsum"
             arg_list = (w, e)
 
         # we have the requirement that weighted sums are [weights, expressions]
-        if name == 'wsum':
-            assert isinstance(arg_list[0], (list, tuple, np.ndarray)), "wsum: arg0 has to be a list-like"
-            assert all(is_num(a) for a in arg_list[0]), "wsum: arg0 has to be all constants but is: "+str(arg_list[0])
+        if name == "wsum":
+            assert isinstance(arg_list[0], (list, tuple, np.ndarray)), (
+                "wsum: arg0 has to be a list-like"
+            )
+            assert all(is_num(a) for a in arg_list[0]), (
+                "wsum: arg0 has to be all constants but is: " + str(arg_list[0])
+            )
             weights: list[ExprLike] = []
             for a in arg_list[0]:
                 if isinstance(a, (bool, int, np.integer, np.bool_, BoolVal)):
-                    weights.append(int(a)) # bool or int, simplifies things later on
+                    weights.append(int(a))  # bool or int, simplifies things later on
                 else:
-                    weights.append(a) # can be float
+                    weights.append(a)  # can be float
             arg_list = (weights, arg_list[1])
 
         # small cleanup: nested n-ary operators are merged into the toplevel
@@ -662,37 +740,40 @@ class Operator(Expression):
         #  expressions the way the user wrote them)
         if arity == 0:
             arg_list = list(arg_list)  # make sure its a writable list
-            i = 0 # length can change
+            i = 0  # length can change
             while i < len(arg_list):
                 a = arg_list[i]
                 if isinstance(a, Operator) and a.name == name:
                     # merge args in at this position
                     l = len(a.args)
-                    arg_list[i:i+1] = a.args
+                    arg_list[i : i + 1] = a.args
                     i += l
                 i += 1
 
         super().__init__(name, tuple(arg_list))
 
     def is_bool(self) -> bool:
-        """ is it a Boolean (return type) Operator?
-        """
+        """Is it a Boolean (return type) Operator?"""
         return Operator.allowed[self.name][1]
 
     def __repr__(self) -> str:
 
         # special cases
-        if self.name == '-': # unary -
+        if self.name == "-":  # unary -
             return "-({})".format(self.args[0])
 
         # weighted sum
-        if self.name == 'wsum':
+        if self.name == "wsum":
             return f"sum({self.args[0]} * {self.args[1]})"
 
         if len(self.args) == 1:
-            return "{}({})".format(self.name, self.args[0])  # tuple of size 1 ommited in print
+            return "{}({})".format(
+                self.name, self.args[0]
+            )  # tuple of size 1 ommited in print
         elif len(self.args) == 2:  # infix printing of two arguments
-            printname = Operator.printmap.get(self.name, self.name) # default to self.name if not in printmap
+            printname = Operator.printmap.get(
+                self.name, self.name
+            )  # default to self.name if not in printmap
             arg0, arg1 = self.args
             str_arg0 = f"({arg0})" if isinstance(arg0, Expression) else str(arg0)
             str_arg1 = f"({arg1})" if isinstance(arg1, Expression) else str(arg1)
@@ -701,34 +782,39 @@ class Operator(Expression):
             return "{}{}".format(self.name, self.args)  # args is a tuple, will be in ()
 
     def value(self) -> Optional[int]:
-        """
-        Returns the value of the expression (or None if not everything has a value).
-        """
+        """Returns the value of the expression (or None if not everything has a value)."""
         if self.name == "wsum":
             # wsum: arg0 is list of constants, no .value() use as is
             arg_vals = [self.args[0], argvals(self.args[1])]
         else:
             arg_vals = argvals(self.args)
 
-
-        if any(a is None for a in arg_vals): return None
+        if any(a is None for a in arg_vals):
+            return None
         # non-boolean
-        elif self.name == "sum": return sum(arg_vals)
+        elif self.name == "sum":
+            return sum(arg_vals)
         elif self.name == "wsum":
             val = np.dot(arg_vals[0], arg_vals[1]).item()
-            if round(val) == val: # it is an integer
+            if round(val) == val:  # it is an integer
                 return int(val)
-            return val # can be a float
-        elif self.name == "sub": return arg_vals[0] - arg_vals[1]
-        elif self.name == "-":   return -arg_vals[0]
+            return val  # can be a float
+        elif self.name == "sub":
+            return arg_vals[0] - arg_vals[1]
+        elif self.name == "-":
+            return -arg_vals[0]
 
         # boolean
-        elif self.name == "and": return all(arg_vals)
-        elif self.name == "or" : return any(arg_vals)
-        elif self.name == "->": return (not arg_vals[0]) or arg_vals[1]
-        elif self.name == "not": return not arg_vals[0]
+        elif self.name == "and":
+            return all(arg_vals)
+        elif self.name == "or":
+            return any(arg_vals)
+        elif self.name == "->":
+            return (not arg_vals[0]) or arg_vals[1]
+        elif self.name == "not":
+            return not arg_vals[0]
 
-        return None # default
+        return None  # default
 
     def get_bounds(self) -> tuple[int, int]:
         """
@@ -737,66 +823,73 @@ class Operator(Expression):
         These bounds are not tight: it may be possible that the bound itself is not a possible value for the expression.
         """
         if self.is_bool():
-            return 0, 1 #boolean
-        elif self.name == 'sum':
+            return 0, 1  # boolean
+        elif self.name == "sum":
             lbs, ubs = get_bounds(self.args)
             lowerbound, upperbound = sum(lbs), sum(ubs)
-        elif self.name == 'wsum':
+        elif self.name == "wsum":
             weights, vars = self.args
-            lowerbound, upperbound = 0,0
-            #this may seem like too many lines, but avoiding np.sum avoids overflowing things at int32 bounds
+            lowerbound, upperbound = 0, 0
+            # this may seem like too many lines, but avoiding np.sum avoids overflowing things at int32 bounds
             for w, (lb, ub) in zip(weights, [get_bounds(arg) for arg in vars]):
-                x,y = int(w) * lb, int(w) * ub
-                if x <= y: # x is the lb of this arg
+                x, y = int(w) * lb, int(w) * ub
+                if x <= y:  # x is the lb of this arg
                     lowerbound += x
                     upperbound += y
                 else:
                     lowerbound += y
                     upperbound += x
 
-        elif self.name == 'sub':
+        elif self.name == "sub":
             lb1, ub1 = get_bounds(self.args[0])
             lb2, ub2 = get_bounds(self.args[1])
-            lowerbound, upperbound = lb1-ub2, ub1-lb2
+            lowerbound, upperbound = lb1 - ub2, ub1 - lb2
 
-        elif self.name == '-':
+        elif self.name == "-":
             lb1, ub1 = get_bounds(self.args[0])
             lowerbound, upperbound = -ub1, -lb1
 
         if lowerbound == None:
-            raise ValueError(f"Bound requested for unknown expression {self}, please report bug on github")
+            raise ValueError(
+                f"Bound requested for unknown expression {self}, please report bug on github"
+            )
         if lowerbound > upperbound:
-            #overflow happened
-            raise OverflowError(f'Overflow when calculating bounds, your expression exceeds integer bounds: {self}')
+            # overflow happened
+            raise OverflowError(
+                f"Overflow when calculating bounds, your expression exceeds integer bounds: {self}"
+            )
         return lowerbound, upperbound
 
 
 def _wsum_should(arg) -> bool:
-    """ Internal helper: should the arg be in a wsum instead of sum
+    """
+    Internal helper: should the arg be in a wsum instead of sum
 
     True if the arg is already a wsum,
     or if it is a Multiplication with is_lhs_num
     (negation '-' does not mean it SHOULD be a wsum, because then
      all substractions are transformed into less readable wsums)
     """
-    name = getattr(arg, 'name', None)
-    return name == 'wsum' or (name == 'mul' and arg.is_lhs_num)
+    name = getattr(arg, "name", None)
+    return name == "wsum" or (name == "mul" and arg.is_lhs_num)
+
 
 def _wsum_make(arg) -> tuple[list[int], list[ExprLike]]:
-    """ Internal helper: prep the arg for wsum
+    """
+    Internal helper: prep the arg for wsum
 
     returns ([weights], [expressions]) where 'weights' are constants.
     Handles Operator (wsum, sum, -) and Multiplication (name 'mul', constant lhs when is_lhs_num).
     """
-    name = getattr(arg, 'name', None)
-    if name == 'wsum':
+    name = getattr(arg, "name", None)
+    if name == "wsum":
         return arg.args
-    elif name == 'sum':
-        return [1]*len(arg.args), arg.args
-    elif name == 'mul':
+    elif name == "sum":
+        return [1] * len(arg.args), arg.args
+    elif name == "mul":
         if arg.is_lhs_num:
             return [arg.args[0]], [arg.args[1]]
-    elif name == '-':
+    elif name == "-":
         return [-1], [arg.args[0]]
     # default
     return [1], [arg]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1,138 +1,138 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## globalconstraints.py
 ##
 """
-    Global constraints conveniently express non-primitive constraints.
+Global constraints conveniently express non-primitive constraints.
 
-    Using global constraints
-    ------------------------
+Using global constraints
+------------------------
 
-    Solvers can have specialised implementations for global constraints. CPMpy has :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`
-    expressions so that they can be passed to the solver as is when supported.
+Solvers can have specialised implementations for global constraints. CPMpy has :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`
+expressions so that they can be passed to the solver as is when supported.
 
-    If a solver does not support a global constraint (see :ref:`Solver Interfaces <solver-interfaces>`) then it will be automatically
-    decomposed by calling its :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose()` function.
-    The :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose()` function returns two arguments:
-        - a list of simpler constraints replacing the global constraint
-        - if the decomposition introduces *new variables*, then the second argument has to be a list
-            of constraints that (totally) define those new variables
+If a solver does not support a global constraint (see :ref:`Solver Interfaces <solver-interfaces>`) then it will be automatically
+decomposed by calling its :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose()` function.
+The :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose()` function returns two arguments:
+- a list of simpler constraints replacing the global constraint
+- if the decomposition introduces *new variables*, then the second argument has to be a list
+of constraints that (totally) define those new variables
 
-    As a user you **should almost never subclass GlobalConstraint()** unless you know of a solver that
-    supports that specific global constraint, and that you will update its solver interface to support it.
+As a user you **should almost never subclass GlobalConstraint()** unless you know of a solver that
+supports that specific global constraint, and that you will update its solver interface to support it.
 
-    For all other use cases, it sufficies to write your own helper function that immediately returns the
-    decomposition, e.g.:
+For all other use cases, it sufficies to write your own helper function that immediately returns the
+decomposition, e.g.:
 
-    .. code-block:: python
+.. code-block:: python
 
-        def alldifferent_except0(args):
-            return [ ((var1!= 0) & (var2 != 0)).implies(var1 != var2) for var1, var2 in all_pairs(args)]
-
-
-    Numeric global constraints
-    --------------------------
-
-    CPMpy also implements `Numeric Global Constraints`. For these, the CPMpy :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` does not
-    exactly match what is implemented in the solver, but for good reason!!
-
-    For example solvers may implement the global constraint ``Minimum(iv1, iv2, iv3) == iv4`` through an API
-    call ``addMinimumEquals([iv1,iv2,iv3], iv4)``.
-
-    However, CPMpy also wishes to support the expressions ``Minimum(iv1, iv2, iv3) > iv4`` as well as
-    ``iv4 + Minimum(iv1, iv2, iv3)``. 
-
-    Hence, the CPMpy global constraint only captures the ``Minimum(iv1, iv2, iv3)`` part, whose return type
-    is numeric and can be used in any other CPMpy expression. Only at the time of transforming the CPMpy
-    model to the solver API, will the expressions be decomposed and auxiliary variables introduced as needed
-    such that the solver only receives ``Minimum(iv1, iv2, iv3) == ivX`` expressions.
-    This is the burden of the CPMpy framework, not of the user who wants to express a problem formulation.
+def alldifferent_except0(args):
+return [ ((var1!= 0) & (var2 != 0)).implies(var1 != var2) for var1, var2 in all_pairs(args)]
 
 
-    Subclassing GlobalConstraint
-    ----------------------------
-    
-    If you do wish to add a :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, because it is supported by solvers or because you will do
-    advanced analysis and rewriting on it, then preferably define it with a standard decomposition, e.g.:
+Numeric global constraints
+--------------------------
 
-    .. code-block:: python
+CPMpy also implements `Numeric Global Constraints`. For these, the CPMpy :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` does not
+exactly match what is implemented in the solver, but for good reason!!
 
-        class my_global(GlobalConstraint):
-            def __init__(self, args):
-                super().__init__("my_global", args)
+For example solvers may implement the global constraint ``Minimum(iv1, iv2, iv3) == iv4`` through an API
+call ``addMinimumEquals([iv1,iv2,iv3], iv4)``.
 
-            def decompose(self):
-                return [self.args[0] != self.args[1]] # your decomposition
+However, CPMpy also wishes to support the expressions ``Minimum(iv1, iv2, iv3) > iv4`` as well as
+``iv4 + Minimum(iv1, iv2, iv3)``.
 
-    ..
-
-    You can also implement a `.negate()` method if the global constraint has a better way to negate it than negating the decomposition.
-
-    If it is a :class:`~cpmpy.expressions.globalfunctions.GlobalFunction` meaning that its return type is numeric (see :class:`~cpmpy.expressions.globalfunctions.Minimum` and :class:`~cpmpy.expressions.globalfunctions.Element`)
-    then set `is_bool=False` in the super() constructor and preferably implement `.value()` accordingly.
+Hence, the CPMpy global constraint only captures the ``Minimum(iv1, iv2, iv3)`` part, whose return type
+is numeric and can be used in any other CPMpy expression. Only at the time of transforming the CPMpy
+model to the solver API, will the expressions be decomposed and auxiliary variables introduced as needed
+such that the solver only receives ``Minimum(iv1, iv2, iv3) == ivX`` expressions.
+This is the burden of the CPMpy framework, not of the user who wants to express a problem formulation.
 
 
-    Alternative decompositions
-    --------------------------
-    
-    For advanced use cases where you want to use another decomposition than the standard decomposition
-    of a :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` expression, you can overwrite the :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose` function of the class, e.g.:
+Subclassing GlobalConstraint
+----------------------------
 
-    .. code-block:: python
+If you do wish to add a :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, because it is supported by solvers or because you will do
+advanced analysis and rewriting on it, then preferably define it with a standard decomposition, e.g.:
 
-        def my_circuit_decomp(self):
-            return [self.args[0] == 1], [] # does not actually enforce circuit
+.. code-block:: python
 
-        circuit.decompose = my_circuit_decomp # attach it, no brackets!
+class my_global(GlobalConstraint):
+def __init__(self, args):
+super().__init__("my_global", args)
 
-        vars = intvar(1,9, shape=10)
-        constr = circuit(vars)
+def decompose(self):
+return [self.args[0] != self.args[1]] # your decomposition
 
-        Model(constr).solve()
+..
 
-    The above will use ``my_circuit_decomp``, if the solver does not
-    natively support :class:`~cpmpy.expressions.globalconstraints.Circuit`.
+You can also implement a `.negate()` method if the global constraint has a better way to negate it than negating the decomposition.
 
-    ===============
-    List of classes
-    ===============
+If it is a :class:`~cpmpy.expressions.globalfunctions.GlobalFunction` meaning that its return type is numeric (see :class:`~cpmpy.expressions.globalfunctions.Minimum` and :class:`~cpmpy.expressions.globalfunctions.Element`)
+then set `is_bool=False` in the super() constructor and preferably implement `.value()` accordingly.
 
-    .. autosummary::
-        :nosignatures:
 
-        AllDifferent
-        AllDifferentExcept0
-        AllDifferentExceptN
-        AllEqual
-        AllEqualExceptN
-        Circuit
-        Inverse
-        Table
-        ShortTable
-        NegativeTable
-        Regular
-        IfThenElse
-        InDomain
-        Xor
-        Cumulative
-        CumulativeOptional
-        NoOverlap
-        NoOverlapOptional
-        Precedence
-        GlobalCardinalityCount
-        Increasing
-        Decreasing
-        IncreasingStrict
-        DecreasingStrict
-        LexLess
-        LexLessEq
-        LexChainLess
-        LexChainLessEq
-        DirectConstraint
+Alternative decompositions
+--------------------------
+
+For advanced use cases where you want to use another decomposition than the standard decomposition
+of a :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint` expression, you can overwrite the :func:`~cpmpy.expressions.globalconstraints.GlobalConstraint.decompose` function of the class, e.g.:
+
+.. code-block:: python
+
+def my_circuit_decomp(self):
+return [self.args[0] == 1], [] # does not actually enforce circuit
+
+circuit.decompose = my_circuit_decomp # attach it, no brackets!
+
+vars = intvar(1,9, shape=10)
+constr = circuit(vars)
+
+Model(constr).solve()
+
+The above will use ``my_circuit_decomp``, if the solver does not
+natively support :class:`~cpmpy.expressions.globalconstraints.Circuit`.
+
+===============
+List of classes
+===============
+
+.. autosummary::
+:nosignatures:
+
+AllDifferent
+AllDifferentExcept0
+AllDifferentExceptN
+AllEqual
+AllEqualExceptN
+Circuit
+Inverse
+Table
+ShortTable
+NegativeTable
+Regular
+IfThenElse
+InDomain
+Xor
+Cumulative
+CumulativeOptional
+NoOverlap
+NoOverlapOptional
+Precedence
+GlobalCardinalityCount
+Increasing
+Decreasing
+IncreasingStrict
+DecreasingStrict
+LexLess
+LexLessEq
+LexChainLess
+LexChainLessEq
+DirectConstraint
 
 """
-import copy
+
 import warnings
 from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
 import numpy as np
@@ -141,8 +141,20 @@ import cpmpy as cp
 
 from .core import Expression, BoolVal, ExprLike, ListLike
 from .variables import cpm_array, intvar, boolvar, _BoolVarImpl
-from .utils import all_pairs, is_int, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies
-from .globalfunctions import * # XXX make this file backwards compatible
+from .utils import (
+    all_pairs,
+    is_int,
+    is_bool,
+    STAR,
+    get_bounds,
+    argvals,
+    is_any_list,
+    flatlist,
+    is_num,
+    is_boolexpr,
+    implies,
+)
+from .globalfunctions import *  # XXX make this file backwards compatible
 
 if TYPE_CHECKING:
     from cpmpy.solvers.solver_interface import SolverInterface
@@ -151,37 +163,39 @@ if TYPE_CHECKING:
 # Base class GlobalConstraint
 class GlobalConstraint(Expression):
     """
-        Abstract superclass of GlobalConstraints
+    Abstract superclass of GlobalConstraints
 
-        Like all expressions it has a ``.name`` and ``.args`` property.
-        Overwrites the ``.is_bool()`` method as all global constraints are Boolean.
+    Like all expressions it has a ``.name`` and ``.args`` property.
+    Overwrites the ``.is_bool()`` method as all global constraints are Boolean.
     """
 
     def is_bool(self) -> bool:
-        """ 
+        """
         Returns whether the global constraint is a Boolean (return type) Operator.
 
         Returns:
             bool: True, global constraints are Boolean
+
         """
         return True
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-            Returns a decomposition into (a conjunction of) smaller constraints.
+        Returns a decomposition into (a conjunction of) smaller constraints.
 
-            The decomposition might create auxiliary variables,
-            it can also use other global constraints as long as
-            it does not create a circular dependency.
+        The decomposition might create auxiliary variables,
+        it can also use other global constraints as long as
+        it does not create a circular dependency.
 
-            To ensure equivalence of decomposition, we split into constraints determining the value of the global constraint, and defining-constraints.
-            Defining constraints (totally) define new auxiliary variables needed for the decomposition, and can always be enforced at top-level.
+        To ensure equivalence of decomposition, we split into constraints determining the value of the global constraint, and defining-constraints.
+        Defining constraints (totally) define new auxiliary variables needed for the decomposition, and can always be enforced at top-level.
 
-            Tip: avoid creating auxiliary variables and use nested expressions instead!
-            (especially, don't create Booleans but use (iv == v) expressions instead, better for common subexpression elimination!)
+        Tip: avoid creating auxiliary variables and use nested expressions instead!
+        (especially, don't create Booleans but use (iv == v) expressions instead, better for common subexpression elimination!)
 
-            Returns:
-                tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        Returns:
+            tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         raise NotImplementedError("Decomposition for", self, "not available")
 
@@ -205,22 +219,24 @@ class GlobalConstraint(Expression):
 def alldifferent(args):
     """
     .. deprecated:: 0.9.0
-          Please use :class:`AllDifferent` instead.
+    Please use :class:`AllDifferent` instead.
     """
-    warnings.warn("Deprecated, use AllDifferent(v1,v2,...,vn) instead, will be removed in "
-                  "stable version", DeprecationWarning)
-    return AllDifferent(*args) # unfold list as individual arguments
+    warnings.warn(
+        "Deprecated, use AllDifferent(v1,v2,...,vn) instead, will be removed in "
+        "stable version",
+        DeprecationWarning,
+    )
+    return AllDifferent(*args)  # unfold list as individual arguments
 
 
 class AllDifferent(GlobalConstraint):
-    """
-    Enforces that all arguments have a different (distinct) value
-    """
+    """Enforces that all arguments have a different (distinct) value"""
 
-    def __init__(self, *args: ExprLike|ListLike[ExprLike]):
+    def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ExprLike|ListLike[ExprLike]): List of expressions or constants to be different from each other
+        args (ExprLike|ListLike[ExprLike]): List of expressions or constants to be different from each other
+
         """
         super().__init__("alldifferent", tuple(flatlist(args)))
 
@@ -230,6 +246,7 @@ class AllDifferent(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         return [var1 != var2 for var1, var2 in all_pairs(self.args)], []
 
@@ -237,17 +254,21 @@ class AllDifferent(GlobalConstraint):
         """
         Linear-friendly decomposition using sums over (arg[i] == val) expressions (which will become Boolean variables):
         at most one integer variable can take each value in the domain.
-        
+
         For use with integer linear programming and pb/sat solvers.
         """
         lbs, ubs = get_bounds(self.args)
         lb, ub = min(lbs), max(ubs)
-        return [cp.sum((arg_i == val) for arg_i in self.args) <= 1 for val in range(lb, ub + 1)], []
+        return [
+            cp.sum((arg_i == val) for arg_i in self.args) <= 1
+            for val in range(lb, ub + 1)
+        ], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         vals = argvals(self.args)
         if any(v is None for v in vals):
@@ -262,18 +283,22 @@ class AllDifferentExceptN(GlobalConstraint):
     Arguments:
         arr (Sequence[Expression]): List of expressions to be different from each other, except those equal to a value in n
         n (int or list[int]): Value or list of values that are excluded from satisfying the alldifferent condition
+
     """
 
-    def __init__(self, arr: ListLike[ExprLike], n: int|np.integer|list[int|np.integer]):
+    def __init__(
+        self, arr: ListLike[ExprLike], n: int | np.integer | list[int | np.integer]
+    ):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to a value in n
-            n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the distinctness constraint
+        arr (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to a value in n
+        n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the distinctness constraint
+
         """
         flatarr = flatlist(arr)
         if not is_any_list(n):
             n = cast(int, n)
-            n = [n] # ensure n is a list of ints
+            n = [n]  # ensure n is a list of ints
         super().__init__("alldifferent_except_n", (flatarr, n))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -282,20 +307,24 @@ class AllDifferentExceptN(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         cons = []
         arr, n = self.args
-        for x,y in all_pairs(arr):
-            cond = (x == y)
+        for x, y in all_pairs(arr):
+            cond = x == y
             if is_bool(cond):
                 cond = cp.BoolVal(cond)
-            cons.append(cond.implies(cp.any(x == a for a in n))) # equivalent to (x in n) | (y in n) | (x != y)
+            cons.append(
+                cond.implies(cp.any(x == a for a in n))
+            )  # equivalent to (x in n) | (y in n) | (x != y)
         return cons, []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         vals, exclude_vals = argvals(self.args)
         if any(v is None for v in vals):
@@ -306,13 +335,13 @@ class AllDifferentExceptN(GlobalConstraint):
 
 
 class AllDifferentExcept0(AllDifferentExceptN):
-    """
-    Enforces that all arguments, except those equal to 0, have a different (distinct) value.
-    """
+    """Enforces that all arguments, except those equal to 0, have a different (distinct) value."""
+
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to 0
+        args (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to 0
+
         """
         super().__init__(flatlist(args), 0)
 
@@ -320,21 +349,23 @@ class AllDifferentExcept0(AllDifferentExceptN):
 def allequal(args):
     """
     .. deprecated:: 0.9.0
-          Please use :class:`AllEqual` instead.
+    Please use :class:`AllEqual` instead.
     """
-    warnings.warn("Deprecated, use AllEqual(v1,v2,...,vn) instead, will be removed in stable version",
-                  DeprecationWarning)
-    return AllEqual(*args) # unfold list as individual arguments
+    warnings.warn(
+        "Deprecated, use AllEqual(v1,v2,...,vn) instead, will be removed in stable version",
+        DeprecationWarning,
+    )
+    return AllEqual(*args)  # unfold list as individual arguments
 
 
 class AllEqual(GlobalConstraint):
-    """
-    Enforces that all arguments have the same value
-    """
+    """Enforces that all arguments have the same value"""
+
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants to have the same value
+        args (ListLike[ExprLike]): List of expressions or constants to have the same value
+
         """
         super().__init__("allequal", tuple(flatlist(args)))
 
@@ -344,6 +375,7 @@ class AllEqual(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         # arg0 == arg1, arg1 == arg2, arg2 == arg3... no need to post n^2 equalities
         return [x == y for x, y in zip(self.args[:-1], self.args[1:])], []
@@ -351,7 +383,8 @@ class AllEqual(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         vals = argvals(self.args)
         if any(v is None for v in vals):
@@ -360,20 +393,21 @@ class AllEqual(GlobalConstraint):
 
 
 class AllEqualExceptN(GlobalConstraint):
-    """
-    Enforces that all arguments, except those equal to a value in n, have the same value.
-    """
+    """Enforces that all arguments, except those equal to a value in n, have the same value."""
 
-    def __init__(self, arr: ListLike[ExprLike], n: int|np.integer|list[int|np.integer]):
+    def __init__(
+        self, arr: ListLike[ExprLike], n: int | np.integer | list[int | np.integer]
+    ):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to have the same value, except those equal to a value in n
-            n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the equality constraint
+        arr (ListLike[ExprLike]): List of expressions or constants to have the same value, except those equal to a value in n
+        n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the equality constraint
+
         """
         flatarr = flatlist(arr)
         if not is_any_list(n):
             n = cast(int, n)
-            n = [n] # ensure n is a list of ints
+            n = [n]  # ensure n is a list of ints
         super().__init__("allequal_except_n", (flatarr, n))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -382,19 +416,22 @@ class AllEqualExceptN(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
-        """
 
+        """
         arr, n = self.args
         constraints = []
         for x, y in all_pairs(arr):
             # x and y are equal, or one of them is equal to an excluded value
-            constraints += [cp.any(x == a for a in n) | (x == y) | cp.any(y == a for a in n)]
+            constraints += [
+                cp.any(x == a for a in n) | (x == y) | cp.any(y == a for a in n)
+            ]
         return constraints, []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         vals, exclude_vals = argvals(self.args)
         if any(v is None for v in vals):
@@ -406,38 +443,43 @@ class AllEqualExceptN(GlobalConstraint):
 def circuit(args):
     """
     .. deprecated:: 0.9.0
-          Please use :class:`Circuit` instead.
+    Please use :class:`Circuit` instead.
     """
-    warnings.warn("Deprecated, use Circuit(v1,v2,...,vn) instead, will be removed in stable version",
-                  DeprecationWarning)
-    return Circuit(*args) # unfold list as individual arguments
+    warnings.warn(
+        "Deprecated, use Circuit(v1,v2,...,vn) instead, will be removed in stable version",
+        DeprecationWarning,
+    )
+    return Circuit(*args)  # unfold list as individual arguments
 
 
 class Circuit(GlobalConstraint):
-    """
-    Enforces that the sequence of variables form a circuit, where x[i] = j means that node j is the successor of node i.
-    """
+    """Enforces that the sequence of variables form a circuit, where x[i] = j means that node j is the successor of node i."""
+
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants representing the successors of the nodes to form the circuit
+        args (ListLike[ExprLike]): List of expressions or constants representing the successors of the nodes to form the circuit
+
         """
         flatargs = flatlist(args)
         if len(flatargs) < 2:
-            raise ValueError('Circuit constraint must be given a minimum of 2 variables')
+            raise ValueError(
+                "Circuit constraint must be given a minimum of 2 variables"
+            )
         super().__init__("circuit", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-            Decomposition of the Circuit global constraint using auxiliary variables to reprsent the order in which we visit all the nodes.
+        Decomposition of the Circuit global constraint using auxiliary variables to reprsent the order in which we visit all the nodes.
             Auxiliary variables are defined in the defining part of the decomposition, which is alwasy enforced top-level.
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         succ = cpm_array(self.args)
         n = len(succ)
-        order = intvar(0,n-1, shape=n)
+        order = intvar(0, n - 1, shape=n)
         defining: list[Expression] = []
         value: list[Expression] = []
 
@@ -449,13 +491,12 @@ class Circuit(GlobalConstraint):
         # This happens when the variables in succ don't take values in the domain of 'order',
         # i.e. for succ = [9,-1,0], there is no valid ordering, but we satisfy ~circuit(succ)
         # We explicitly deal with these cases by defining the variable 'a' that indicates if we can define an ordering.
-        # TODO at some point: do not introduce these auxiliary variables ourselves, rely on cse instead. 
+        # TODO at some point: do not introduce these auxiliary variables ourselves, rely on cse instead.
         # Blocking factor: need safening and decomposing of global constraints to be integrated.
         # accumulator = 0
         # for i = 0..n-1:
         #    accumulator = succ[accumulator]  # creates an element global function
         # return [0 == accumulator, cp.AllDiff(succ), cp.all(succ >= 0), cp.all(succ <= n)], []
-
 
         lbs, ubs = get_bounds(succ)
         if min(lbs) > 0 or max(ubs) < n - 1:
@@ -469,22 +510,26 @@ class Circuit(GlobalConstraint):
             a = boolvar()
             defining += [a == ((cp.Minimum(succ) >= 0) & (cp.Maximum(succ) < n))]
             for i in range(n):
-                defining += [(~a).implies(order[i] == 0)]  # assign arbitrary value, so a is totally defined.
+                defining += [
+                    (~a).implies(order[i] == 0)
+                ]  # assign arbitrary value, so a is totally defined.
 
         value += [AllDifferent(succ)]  # different successors
         value += [AllDifferent(order)]  # different orders
         value += [order[n - 1] == 0]  # symmetry breaking, last one is '0'
         defining += [a.implies(order[0] == succ[0])]
         for i in range(1, n):
-            defining += [a.implies(
-                order[i] == succ[order[i - 1]])]  # first one is successor of '0', ith one is successor of i-1
-        
+            defining += [
+                a.implies(order[i] == succ[order[i - 1]])
+            ]  # first one is successor of '0', ith one is successor of i-1
+
         return value, defining
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         idx = 0
         visited = set()
@@ -494,7 +539,7 @@ class Circuit(GlobalConstraint):
 
         while idx not in visited:
             if not (0 <= idx < len(arr)):
-                return False # out of bounds
+                return False  # out of bounds
             visited.add(idx)
             idx = arr[idx]
 
@@ -508,14 +553,18 @@ class Inverse(GlobalConstraint):
 
     Also known as channeling / assignment constraint.
     """
+
     def __init__(self, fwd: ListLike[ExprLike], rev: ListLike[ExprLike]):
         """
         Arguments:
-            fwd (ListLike[ExprLike]): List of expressions or constants representing the forward function
-            rev (ListLike[ExprLike]): List of expressions or constants representing the reverse function
+        fwd (ListLike[ExprLike]): List of expressions or constants representing the forward function
+        rev (ListLike[ExprLike]): List of expressions or constants representing the reverse function
+
         """
         if len(fwd) != len(rev):
-            raise ValueError("Length of fwd and rev must be equal for Inverse constraint")
+            raise ValueError(
+                "Length of fwd and rev must be equal for Inverse constraint"
+            )
         super().__init__("inverse", (fwd, rev))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -524,8 +573,8 @@ class Inverse(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
-        """
 
+        """
         # we try to avoid in-function imports (needed when cyclic dependency),
         # but decompose is typically only called once anyway, so here it is acceptable
         from cpmpy.transformations import safening
@@ -534,24 +583,29 @@ class Inverse(GlobalConstraint):
         rev = cpm_array(rev)
 
         constraining, defining = [], []
-        for i,x in enumerate(fwd):
-            if is_num(x) and not 0 <= x < len(rev): 
-                return [cp.BoolVal(False)], [] # can never satisfy the Inverse constraint
-           
+        for i, x in enumerate(fwd):
+            if is_num(x) and not 0 <= x < len(rev):
+                return [
+                    cp.BoolVal(False)
+                ], []  # can never satisfy the Inverse constraint
+
             lb, ub = get_bounds(x)
-            if lb >= 0 and ub < len(rev): # safe, index is within bounds
+            if lb >= 0 and ub < len(rev):  # safe, index is within bounds
                 constraining.append(rev[x] == i)
-            else: # partial! need safening here
-                is_defined, total_expr, toplevel = safening._safen_range(rev[x], (0, len(rev)-1), 1)
+            else:  # partial! need safening here
+                is_defined, total_expr, toplevel = safening._safen_range(
+                    rev[x], (0, len(rev) - 1), 1
+                )
                 constraining += [is_defined, total_expr == i]
                 defining += toplevel
-        
+
         return constraining, defining
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         fwd, rev = argvals(self.args)
         if any(x is None for x in fwd) or any(y is None for y in rev):
@@ -565,27 +619,35 @@ class Inverse(GlobalConstraint):
 
 
 class Table(GlobalConstraint):
-    """
-    Enforces that the values of the variables in 'array' correspond to a row in 'table'.
-    """
-    def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
+    """Enforces that the values of the variables in 'array' correspond to a row in 'table'."""
+
+    def __init__(
+        self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray
+    ):
         """
         Arguments:
-            array (ListLike[Expression]): List of expressions representing the array of variables
-            table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
+        array (ListLike[Expression]): List of expressions representing the array of variables
+        table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
+
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
-            raise TypeError(f"the first argument of a Table constraint should only contain variables/expressions: {array}")
+            raise TypeError(
+                f"the first argument of a Table constraint should only contain variables/expressions: {array}"
+            )
         if isinstance(table, np.ndarray):  # Ensure it is a list
             assert table.ndim == 2, "Table's table must be a 2D array"
-            assert table.dtype != object, "Table's table must have primitive type, not 'object'/expressions"
+            assert table.dtype != object, (
+                "Table's table must have primitive type, not 'object'/expressions"
+            )
             table = table.tolist()
         else:
             tmp = np.array(table)
             assert tmp.ndim == 2, "Table's table must be a 2D array"
-            assert tmp.dtype != object, "Table's table must have primitive type, not 'object'/expressions"
-            
+            assert tmp.dtype != object, (
+                "Table's table must have primitive type, not 'object'/expressions"
+            )
+
         super().__init__("table", (array, table))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -601,7 +663,8 @@ class Table(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         arr, tab = self.args
         arrval = argvals(arr)
@@ -614,7 +677,9 @@ class Table(GlobalConstraint):
 
     # specialisation to avoid recursing over big tables
     def has_subexpr(self) -> bool:
-        if not hasattr(self, '_has_subexpr'): # if _has_subexpr has not been computed before or has been reset
+        if not hasattr(
+            self, "_has_subexpr"
+        ):  # if _has_subexpr has not been computed before or has been reset
             arr, tab = self.args  # the table 'tab' is asserted to only hold constants
             self._has_subexpr = any(a.has_subexpr() for a in arr)
         return self._has_subexpr
@@ -625,16 +690,24 @@ class ShortTable(GlobalConstraint):
     Extension of the `Table` constraint where the `table` matrix may contain wildcards (STAR), meaning there are
     no restrictions for the corresponding variable in that tuple.
     """
-    def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int|Literal["*"]]] | np.ndarray):
+
+    def __init__(
+        self,
+        array: ListLike[Expression],
+        table: ListLike[ListLike[int | Literal["*"]]] | np.ndarray,
+    ):
         """
         Arguments:
-            array (ListLike[Expression]): List of expressions representing the array of variables
-            table (ListLike[ListLike[int | '*']] | np.ndarray): List of lists or 2D ndarray; entries are integers or STAR ('*')
-                STAR represents a wildcard (corresponding variable can take any value).
+        array (ListLike[Expression]): List of expressions representing the array of variables
+        table (ListLike[ListLike[int | '*']] | np.ndarray): List of lists or 2D ndarray; entries are integers or STAR ('*')
+            STAR represents a wildcard (corresponding variable can take any value).
+
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
-            raise TypeError("The first argument of a Table constraint should only contain variables/expressions")
+            raise TypeError(
+                "The first argument of a Table constraint should only contain variables/expressions"
+            )
         if isinstance(table, np.ndarray):
             assert table.ndim == 2, "ShortTable's table must be a 2D array"
             table = table.tolist()
@@ -650,12 +723,18 @@ class ShortTable(GlobalConstraint):
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
         """
         arr, tab = self.args
-        return [cp.any(cp.all(ai == ri for ai, ri in zip(arr, row) if ri != STAR) for row in tab)], []
+        return [
+            cp.any(
+                cp.all(ai == ri for ai, ri in zip(arr, row) if ri != STAR)
+                for row in tab
+            )
+        ], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         arr, tab = self.args
         arrval = argvals(arr)
@@ -664,49 +743,63 @@ class ShortTable(GlobalConstraint):
         arrval = np.asarray(arrval, dtype=int)
         tab = np.asarray(tab)
         for row in tab:
-            mask = (row != STAR)
+            mask = row != STAR
             if (row[mask].astype(int) == arrval[mask]).all():
                 return True
         return False
 
     # specialisation to avoid recursing over big tables
     def has_subexpr(self) -> bool:
-        if not hasattr(self, '_has_subexpr'): # if _has_subexpr has not been computed before or has been reset
-            arr, tab = self.args # the table 'tab' can only hold constants, never a nested expression
+        if not hasattr(
+            self, "_has_subexpr"
+        ):  # if _has_subexpr has not been computed before or has been reset
+            arr, tab = (
+                self.args
+            )  # the table 'tab' can only hold constants, never a nested expression
             self._has_subexpr = any(a.has_subexpr() for a in arr)
         return self._has_subexpr
 
+
 class NegativeTable(GlobalConstraint):
-    """
-    The values of the variables in 'array' do not correspond to any row in 'table'.
-    """
-    def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
+    """The values of the variables in 'array' do not correspond to any row in 'table'."""
+
+    def __init__(
+        self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray
+    ):
         """
         Arguments:
-            array (ListLike[Expression]): List of expressions representing the array of variables
-            table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
+        array (ListLike[Expression]): List of expressions representing the array of variables
+        table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
+
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
-            raise TypeError(f"the first argument of a NegativeTable constraint should only contain variables/expressions: {array}")
+            raise TypeError(
+                f"the first argument of a NegativeTable constraint should only contain variables/expressions: {array}"
+            )
         if isinstance(table, np.ndarray):  # Ensure it is a list
             assert table.ndim == 2, "NegativeTable's table must be a 2D array"
-            assert table.dtype != object, "NegativeTable's table must have primitive type, not 'object'/expressions"
+            assert table.dtype != object, (
+                "NegativeTable's table must have primitive type, not 'object'/expressions"
+            )
             table = table.tolist()
         else:
             tmp = np.array(table)
             assert tmp.ndim == 2, "NegativeTable's table must be a 2D array"
-            assert tmp.dtype != object, "NegativeTable's table must have primitive type, not 'object'/expressions"
-            
+            assert tmp.dtype != object, (
+                "NegativeTable's table must have primitive type, not 'object'/expressions"
+            )
+
         super().__init__("negative_table", (array, table))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-        Decomposition of the NegativeTable global constraint. 
+        Decomposition of the NegativeTable global constraint.
         Enforces that the values of the variables in 'array' do not correspond to any row in 'table'.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         arr, tab = self.args
         return [cp.all(cp.any(ai != ri for ai, ri in zip(arr, row)) for row in tab)], []
@@ -714,7 +807,8 @@ class NegativeTable(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         arr, tab = self.args
         arrval = argvals(arr)
@@ -724,14 +818,18 @@ class NegativeTable(GlobalConstraint):
 
     # specialisation to avoid recursing over big tables
     def has_subexpr(self) -> bool:
-        if not hasattr(self, '_has_subexpr'): # if _has_subexpr has not been computed before or has been reset
-            arr, tab = self.args # the table 'tab' can only hold constants, never a nested expression
+        if not hasattr(
+            self, "_has_subexpr"
+        ):  # if _has_subexpr has not been computed before or has been reset
+            arr, tab = (
+                self.args
+            )  # the table 'tab' can only hold constants, never a nested expression
             self._has_subexpr = any(a.has_subexpr() for a in arr)
         return self._has_subexpr
 
     def negate(self) -> Expression:
         return Table(self.args[0], self.args[1])
-    
+
 
 class Regular(GlobalConstraint):
     """
@@ -751,34 +849,60 @@ class Regular(GlobalConstraint):
                    start = "A",
                    accepting = ["C"])
     """
-    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]], start: int|str, accepting: ListLike[int|str]):
+
+    def __init__(
+        self,
+        array: ListLike[Expression],
+        transitions: ListLike[tuple[int | str, int, int | str]],
+        start: int | str,
+        accepting: ListLike[int | str],
+    ):
         """
         Arguments:
-            array (ListLike[Expression]): List of expressions representing the input sequence
-            transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
-            start (int | str): Starting node id
-            accepting (ListLike[int | str]): List of accepting node ids
+        array (ListLike[Expression]): List of expressions representing the input sequence
+        transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
+        start (int | str): Starting node id
+        accepting (ListLike[int | str]): List of accepting node ids
+
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
-            raise TypeError("The first argument of a regular constraint should only contain variables/expressions")
-        
+            raise TypeError(
+                "The first argument of a regular constraint should only contain variables/expressions"
+            )
+
         if not is_any_list(transitions):
-            raise TypeError("The second argument of a regular constraint should be a list of transitions")
+            raise TypeError(
+                "The second argument of a regular constraint should be a list of transitions"
+            )
         _node_type = type(transitions[0][0])
-        for s,v,e in transitions:
-            if not isinstance(s, _node_type) or not isinstance(e, _node_type) or not isinstance(v, int):
-                raise TypeError(f"The second argument of a regular constraint should be a list of transitions ({_node_type}, int, {_node_type})")
+        for s, v, e in transitions:
+            if (
+                not isinstance(s, _node_type)
+                or not isinstance(e, _node_type)
+                or not isinstance(v, int)
+            ):
+                raise TypeError(
+                    f"The second argument of a regular constraint should be a list of transitions ({_node_type}, int, {_node_type})"
+                )
         if not isinstance(start, _node_type):
-            raise TypeError("The third argument of a regular constraint should be a node id")
-        if not (is_any_list(accepting) and all(isinstance(e, _node_type) for e in accepting)):
-            raise TypeError("The fourth argument of a regular constraint should be a list of node ids")
-        super().__init__("regular", (list(array), list(transitions), start, list(accepting)))
+            raise TypeError(
+                "The third argument of a regular constraint should be a node id"
+            )
+        if not (
+            is_any_list(accepting) and all(isinstance(e, _node_type) for e in accepting)
+        ):
+            raise TypeError(
+                "The fourth argument of a regular constraint should be a list of node ids"
+            )
+        super().__init__(
+            "regular", (list(array), list(transitions), start, list(accepting))
+        )
 
         node_set = set()
         self.trans_dict = {}
         for s, v, e in transitions:
-            node_set.update([s,e])
+            node_set.update([s, e])
             self.trans_dict[(s, v)] = e
         self.nodes = sorted(node_set)
         # normalize node_ids to be 0..n-1, allows for smaller domains
@@ -786,41 +910,61 @@ class Regular(GlobalConstraint):
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-        Decomposition of the Regular global constraint. 
+        Decomposition of the Regular global constraint.
         Encodes the automaton by encoding the transition table into `class:cpmpy.expressions.globalconstraints.Table` constraints.
         Then enforces that the last state is accepting.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         # Decompose to transition table using Table constraints
-        
+
         arr, transitions, start, accepting = self.args
         lbs, ubs = get_bounds(arr)
         lb, ub = min(lbs), max(ubs)
-        
-        transitions = [[self.node_map[n_in], v, self.node_map[n_out]] for n_in, v, n_out in transitions]
+
+        transitions = [
+            [self.node_map[n_in], v, self.node_map[n_out]]
+            for n_in, v, n_out in transitions
+        ]
 
         # add a sink node for transitions that are not defined
         sink = len(self.nodes)
-        transitions += [[self.node_map[n], v, sink] for n in self.nodes for v in range(lb, ub + 1) if (n, v) not in self.trans_dict]
+        transitions += [
+            [self.node_map[n], v, sink]
+            for n in self.nodes
+            for v in range(lb, ub + 1)
+            if (n, v) not in self.trans_dict
+        ]
         transitions += [[sink, v, sink] for v in range(lb, ub + 1)]
 
         # keep track of current state when traversing the array
         state_vars = intvar(0, sink, shape=len(arr))
         id_start = self.node_map[start]
         # optimization: we know the entry node of the automaton, results in smaller table
-        defining: list[Expression] = [Table([arr[0], state_vars[0]], [[v,e] for s,v,e in transitions if s == id_start])]
+        defining: list[Expression] = [
+            Table(
+                [arr[0], state_vars[0]],
+                [[v, e] for s, v, e in transitions if s == id_start],
+            )
+        ]
         # define the rest of the automaton using transition table
-        defining += [Table([state_vars[i - 1], arr[i], state_vars[i]], transitions) for i in range(1, len(arr))]
-        
+        defining += [
+            Table([state_vars[i - 1], arr[i], state_vars[i]], transitions)
+            for i in range(1, len(arr))
+        ]
+
         # constraint is satisfied iff last state is accepting
-        return [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])], defining
+        return [
+            InDomain(state_vars[-1], [self.node_map[e] for e in accepting])
+        ], defining
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         arr, transitions, start, accepting = self.args
         arrval = argvals(arr)
@@ -834,6 +978,7 @@ class Regular(GlobalConstraint):
                 return False
         return curr_node in accepting
 
+
 # syntax of the form 'if b then x == 9 else x == 0' is not supported (no override possible)
 # same semantic as CPLEX IfThenElse constraint
 # https://www.ibm.com/docs/en/icos/12.9.0?topic=methods-ifthenelse-method
@@ -842,22 +987,31 @@ class IfThenElse(GlobalConstraint):
     Enforces a conditional expression of the form: if condition then if_true else if_false.
     `condition`, `if_true` and `if_false` are be boolean expressions.
     """
+
     def __init__(self, condition: ExprLike, if_true: ExprLike, if_false: ExprLike):
         """
         Arguments:
-            condition (ExprLike): Boolean expression or constant
-            if_true (ExprLike): Boolean expression or constant
-            if_false (ExprLike): Boolean expression or constant
+        condition (ExprLike): Boolean expression or constant
+        if_true (ExprLike): Boolean expression or constant
+        if_false (ExprLike): Boolean expression or constant
+
         """
-        if not is_boolexpr(condition) or not is_boolexpr(if_true) or not is_boolexpr(if_false):
-            raise TypeError(f"only boolean expression allowed in IfThenElse: Instead got "
-                            f"{condition, if_true, if_false}")
+        if (
+            not is_boolexpr(condition)
+            or not is_boolexpr(if_true)
+            or not is_boolexpr(if_false)
+        ):
+            raise TypeError(
+                f"only boolean expression allowed in IfThenElse: Instead got "
+                f"{condition, if_true, if_false}"
+            )
         super().__init__("ite", (condition, if_true, if_false))
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         condition, if_true, if_false = argvals(self.args)
         if condition is None or if_true is None or if_false is None:
@@ -877,7 +1031,7 @@ class IfThenElse(GlobalConstraint):
         """
         condition, if_true, if_false = self.args
         if is_bool(condition):
-            condition = cp.BoolVal(condition) # ensure it is a CPMpy expression
+            condition = cp.BoolVal(condition)  # ensure it is a CPMpy expression
         return [condition.implies(if_true), (~condition).implies(if_false)], []
 
     def __repr__(self) -> str:
@@ -888,36 +1042,37 @@ class IfThenElse(GlobalConstraint):
         return IfThenElse(self.args[0], self.args[2], self.args[1])
 
 
-
 class InDomain(GlobalConstraint):
-    """
-    Enforces the expression is assigned to a value in the given domain.
-    """
+    """Enforces the expression is assigned to a value in the given domain."""
 
-    def __init__(self, expr: ExprLike, arr: Iterable[int|np.integer]):
+    def __init__(self, expr: ExprLike, arr: Iterable[int | np.integer]):
         """
         Arguments:
-            expr (ExprLike): Expression or constant to be assigned to a value in the given domain
-            arr (Iterable[int | np.integer]): Iterable of integer constants representing the domain
+        expr (ExprLike): Expression or constant to be assigned to a value in the given domain
+        arr (Iterable[int | np.integer]): Iterable of integer constants representing the domain
+
         """
         if not all(is_int(x) for x in arr):
-            raise TypeError("The second argument of an InDomain constraint should be a list of integer constants")
+            raise TypeError(
+                "The second argument of an InDomain constraint should be a list of integer constants"
+            )
         super().__init__("InDomain", (expr, arr))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the InDomain global constraint.
         Enforces that the expression is assigned to a value in the given domain.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         expr, arr = self.args
         lb, ub = get_bounds(expr)
-        
+
         defining = []
-        #if expr is not a var
-        if not isinstance(expr,Expression):
+        # if expr is not a var
+        if not isinstance(expr, Expression):
             aux = intvar(lb, ub)
             defining.append(aux == expr)
             expr = aux
@@ -927,7 +1082,8 @@ class InDomain(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         expr, arr = self.args
         exprval = argvals(expr)
@@ -940,8 +1096,9 @@ class InDomain(GlobalConstraint):
 
     def negate(self) -> Expression:
         lb, ub = get_bounds(self.args[0])
-        return InDomain(self.args[0],
-                        [v for v in range(lb,ub+1) if v not in set(self.args[1])])
+        return InDomain(
+            self.args[0], [v for v in range(lb, ub + 1) if v not in set(self.args[1])]
+        )
 
 
 class Xor(GlobalConstraint):
@@ -954,10 +1111,15 @@ class Xor(GlobalConstraint):
     def __init__(self, arg_list: ListLike[ExprLike]):
         """
         Arguments:
-            arg_list (ListLike[ExprLike]): List of expressions or constants, to be xor'ed
+        arg_list (ListLike[ExprLike]): List of expressions or constants, to be xor'ed
+
         """
         if not all(is_boolexpr(arg) for arg in arg_list):
-            raise TypeError("Only Boolean arguments allowed in Xor global constraint: {}".format(arg_list))
+            raise TypeError(
+                "Only Boolean arguments allowed in Xor global constraint: {}".format(
+                    arg_list
+                )
+            )
         # convention for commutative binary operators:
         # swap if right is constant and left is not
         arg_list = list(arg_list)
@@ -969,9 +1131,10 @@ class Xor(GlobalConstraint):
         """
         Decomposition of the Xor global constraint.
         Recursively decomposes the constraint into a chain of binary xor-constraints, represented using a sum.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         # there are multiple decompositions possible, Recursively using sum allows it to be efficient for all solvers.
         decomp = [sum(self.args[:2]) == 1]
@@ -1017,46 +1180,70 @@ class Cumulative(GlobalConstraint):
     Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlap` when demand and capacity are equal to 1.
     Supports both varying demand across tasks or equal demand for all jobs.
     """
-    def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None, demand: Optional[ListLike[ExprLike]|ExprLike] = None, capacity: Optional[ExprLike] = None):
-        """
-            Arguments:
-                start (ListLike[ExprLike]): Start times of the tasks
-                duration (ListLike[ExprLike]): Durations of the tasks
-                end (ListLike[ExprLike] | None): Optional end times of the tasks
-                demand (ListLike[ExprLike] | ExprLike): Per-task demands or a single constant demand, required
-                capacity (ExprLike): Capacity of the resource, required
-            
-            Technical note: demand/capacity marked as Optional because it comes after an Optional argument
-        """
 
+    def __init__(
+        self,
+        start: ListLike[ExprLike],
+        duration: ListLike[ExprLike],
+        end: Optional[ListLike[ExprLike]] = None,
+        demand: Optional[ListLike[ExprLike] | ExprLike] = None,
+        capacity: Optional[ExprLike] = None,
+    ):
+        """
+        Arguments:
+            start (ListLike[ExprLike]): Start times of the tasks
+            duration (ListLike[ExprLike]): Durations of the tasks
+            end (ListLike[ExprLike] | None): Optional end times of the tasks
+            demand (ListLike[ExprLike] | ExprLike): Per-task demands or a single constant demand, required
+            capacity (ExprLike): Capacity of the resource, required
+
+        Technical note: demand/capacity marked as Optional because it comes after an Optional argument
+
+        """
         if not is_any_list(start):
             raise TypeError("start should be a list")
         if not is_any_list(duration):
             raise TypeError("duration should be a list")
         if end is not None and not is_any_list(end):
             raise TypeError("end should be a list if it is provided")
-        if demand is None:  # marked optional due to 'end' being optional and parameters after that must be optional too
+        if (
+            demand is None
+        ):  # marked optional due to 'end' being optional and parameters after that must be optional too
             raise TypeError("demand should be provided but was None")
-        if capacity is None:  # marked optional due to 'end' being optional and parameters after that must be optional too
+        if (
+            capacity is None
+        ):  # marked optional due to 'end' being optional and parameters after that must be optional too
             raise TypeError("capacity should be provided but was None")
-        
+
         if len(start) != len(duration):
             raise ValueError("Start and duration should have equal length")
         if end is not None and len(start) != len(end):
-            raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
+            raise ValueError(
+                f"Start and end should have equal length, but got {len(start)} and {len(end)}"
+            )
 
         demand_list = []
         if is_any_list(demand):
             demand_list = list(demand)
             if len(demand_list) != len(start):
-                raise ValueError(f"Demand should be supplied for each task or be single constant, but got {len(demand_list)} and {len(start)}")
-        else: # constant demand
+                raise ValueError(
+                    f"Demand should be supplied for each task or be single constant, but got {len(demand_list)} and {len(start)}"
+                )
+        else:  # constant demand
             demand_list = [demand] * len(start)
 
-        super(Cumulative, self).__init__("cumulative", (list(start), list(duration), list(end) if end is not None else None, demand_list, capacity))
+        super(Cumulative, self).__init__(
+            "cumulative",
+            (
+                list(start),
+                list(duration),
+                list(end) if end is not None else None,
+                demand_list,
+                capacity,
+            ),
+        )
 
-    
-    def decompose(self, how:str="auto") -> tuple[list[Expression], list[Expression]]:
+    def decompose(self, how: str = "auto") -> tuple[list[Expression], list[Expression]]:
         """
         Decompose the Cumulative constraint
         Support time-based decomposition or task-based decomposition.
@@ -1067,12 +1254,14 @@ class Cumulative(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
-
         if how not in ["time", "task", "auto"]:
-            raise ValueError(f"how can only be time, task, or auto (default), but got {how}")
+            raise ValueError(
+                f"how can only be time, task, or auto (default), but got {how}"
+            )
 
-        start= self.args[0]
+        start = self.args[0]
 
         lbs, ubs = get_bounds(start)
         horizon = max(ubs) - min(lbs)
@@ -1080,7 +1269,7 @@ class Cumulative(GlobalConstraint):
             return self._time_decomposition()
         elif (how == "task") or (how == "auto" and len(start) > horizon):
             return self._task_decomposition()
-        raise Exception # should not be reached
+        raise Exception  # should not be reached
 
     def _consistency_constraints(self) -> list[Expression]:
         """
@@ -1105,9 +1294,10 @@ class Cumulative(GlobalConstraint):
         Task-based decomposition of the cumulative constraint.
         Schutt, Andreas, et al. "Why cumulative decomposition is not as bad as it sounds."
         International Conference on Principles and Practice of Constraint Programming. Springer, Berlin, Heidelberg, 2009.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         start, duration, end, demand, capacity = self.args
 
@@ -1122,7 +1312,9 @@ class Cumulative(GlobalConstraint):
             demand_at_start_of_t = []
             for j in range(len(start)):
                 if t != j:
-                    demand_at_start_of_t += [demand[j] * ((start[j] <= start[t]) & (end[j] > start[t]))]
+                    demand_at_start_of_t += [
+                        demand[j] * ((start[j] <= start[t]) & (end[j] > start[t]))
+                    ]
 
             cons += [(demand[t] + sum(demand_at_start_of_t)) <= capacity]
 
@@ -1133,45 +1325,50 @@ class Cumulative(GlobalConstraint):
         Time-resource decomposition of the cumulative constraint.
         Schutt, Andreas, et al. "Why cumulative decomposition is not as bad as it sounds."
         International Conference on Principles and Practice of Constraint Programming. Springer, Berlin, Heidelberg, 2009.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         start, duration, end, demand, capacity = self.args
 
         cons = self._consistency_constraints()
         if end is None:
             end = [start[i] + duration[i] for i in range(len(start))]
-            
+
         # demand doesn't exceed capacity
         # for each time-step, we check if the running demand does not exceed the capacity
         lbs, ubs = get_bounds(start)
         lb, ub = min(lbs), max(ubs)
-        for t in range(lb,ub+1):
-            cons += [cp.sum(d * ((s <= t) & (e > t)) for s,e,d in zip(start, end, demand)) <= capacity]
+        for t in range(lb, ub + 1):
+            cons += [
+                cp.sum(d * ((s <= t) & (e > t)) for s, e, d in zip(start, end, demand))
+                <= capacity
+            ]
 
         return cons, []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         start, dur, end, demand, capacity = self.args
-        
+
         start, dur, demand, capacity = argvals([start, dur, demand, capacity])
         if any(a is None for a in flatlist([start, dur, demand, capacity])):
             return None
         if end is None:
-            end = [s + d for s,d in zip(start, dur)]
+            end = [s + d for s, d in zip(start, dur)]
         else:
             end = argvals(end)
             if any(a is None for a in end):
                 return None
-                
+
         if any(d < 0 for d in dur):
             return False
-        if any(s + d != e for s,d,e in zip(start, dur, end)):
+        if any(s + d != e for s, d, e in zip(start, dur, end)):
             return False
 
         if any(d < 0 for d in demand):
@@ -1179,45 +1376,50 @@ class Cumulative(GlobalConstraint):
 
         # ensure demand doesn't exceed capacity
         lb, ub = min(start), max(end)
-        start, end = np.array(start), np.array(end) # eases check below
-        for t in range(lb, ub+1):
+        start, end = np.array(start), np.array(end)  # eases check below
+        for t in range(lb, ub + 1):
             if capacity < sum(demand * ((start <= t) & (end > t))):
                 return False
 
         return True
 
+
 class CumulativeOptional(GlobalConstraint):
     """
-        Generalization of the Cumulative constraint which allows for optional tasks.
-        A task is only scheduled if the corresponing is_present variable is set to True.
+    Generalization of the Cumulative constraint which allows for optional tasks.
+    A task is only scheduled if the corresponing is_present variable is set to True.
 
-        If the task is present, the constraint enforces that:
-        - duration >= 0
-        - demand >= 0
-        - start + duration == end
+    If the task is present, the constraint enforces that:
+    - duration >= 0
+    - demand >= 0
+    - start + duration == end
 
-        If the task is not present, the constraint does not enforce any of the above.
+    If the task is not present, the constraint does not enforce any of the above.
 
-        Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlapOptional` when demand and capacity are equal to 1.
-        Supports both varying demand across tasks or equal demand for all jobs.
+    Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlapOptional` when demand and capacity are equal to 1.
+    Supports both varying demand across tasks or equal demand for all jobs.
     """
 
-    def __init__(self, start: ListLike[ExprLike], 
-                       duration: ListLike[ExprLike], 
-                       end: Optional[ListLike[ExprLike]] = None, 
-                       demand: Optional[ListLike[ExprLike]|ExprLike] = None, 
-                       capacity: Optional[ExprLike] = None, 
-                       is_present: Optional[ListLike[ExprLike]] = None):
+    def __init__(
+        self,
+        start: ListLike[ExprLike],
+        duration: ListLike[ExprLike],
+        end: Optional[ListLike[ExprLike]] = None,
+        demand: Optional[ListLike[ExprLike] | ExprLike] = None,
+        capacity: Optional[ExprLike] = None,
+        is_present: Optional[ListLike[ExprLike]] = None,
+    ):
         """
-            Arguments:
-                start (ListLike[ExprLike]): Start times of the tasks
-                duration (ListLike[ExprLike]): Durations of the tasks
-                end (ListLike[ExprLike] | None): Optional end times of the tasks
-                demand (ListLike[ExprLike] | ExprLike): Per-task demands or a single constant demand, required
-                capacity (ExprLike): Capacity of the resource, required
-                is_present (ListLike[ExprLike]): Presence of the tasks
-            
-            Technical note: demand/capacity marked as Optional because it comes after an Optional argument
+        Arguments:
+            start (ListLike[ExprLike]): Start times of the tasks
+            duration (ListLike[ExprLike]): Durations of the tasks
+            end (ListLike[ExprLike] | None): Optional end times of the tasks
+            demand (ListLike[ExprLike] | ExprLike): Per-task demands or a single constant demand, required
+            capacity (ExprLike): Capacity of the resource, required
+            is_present (ListLike[ExprLike]): Presence of the tasks
+
+        Technical note: demand/capacity marked as Optional because it comes after an Optional argument
+
         """
         if not is_any_list(start):
             raise TypeError("start should be a list")
@@ -1231,26 +1433,39 @@ class CumulativeOptional(GlobalConstraint):
             raise TypeError("capacity should be provided but was None")
         if is_present is None:
             raise TypeError("is_present should be provided but was None")
-        
+
         if len(start) != len(duration):
             raise ValueError("Start and duration should have equal length")
         if len(start) != len(is_present):
             raise ValueError("Start and is_present should have equal length")
         if end is not None and len(start) != len(end):
-            raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
+            raise ValueError(
+                f"Start and end should have equal length, but got {len(start)} and {len(end)}"
+            )
 
         demand_list = []
         if is_any_list(demand):
             demand_list = list(demand)
             if len(demand_list) != len(start):
-                raise ValueError(f"Demand should be supplied for each task or be single constant, but got {len(demand_list)} and {len(start)}")
-        else: # constant demand
+                raise ValueError(
+                    f"Demand should be supplied for each task or be single constant, but got {len(demand_list)} and {len(start)}"
+                )
+        else:  # constant demand
             demand_list = [demand] * len(start)
 
-        super().__init__("cumulative_optional", (list(start), list(duration), list(end) if end is not None else None, 
-                                                 demand_list, capacity, list(is_present)))
+        super().__init__(
+            "cumulative_optional",
+            (
+                list(start),
+                list(duration),
+                list(end) if end is not None else None,
+                demand_list,
+                capacity,
+                list(is_present),
+            ),
+        )
 
-    def decompose(self, how:str="auto") -> tuple[list[Expression], list[Expression]]:
+    def decompose(self, how: str = "auto") -> tuple[list[Expression], list[Expression]]:
         """
         Decompose the Cumulative constraint
         Support time-based decomposition or task-based decomposition.
@@ -1261,10 +1476,12 @@ class CumulativeOptional(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
-        """
 
+        """
         if how not in ["time", "task", "auto"]:
-            raise ValueError(f"how can only be time, task, or auto (default), but got {how}")
+            raise ValueError(
+                f"how can only be time, task, or auto (default), but got {how}"
+            )
 
         start, *args = self.args
 
@@ -1274,40 +1491,46 @@ class CumulativeOptional(GlobalConstraint):
             return self._time_decomposition()
         elif (how == "task") or (how == "auto" and len(start) > horizon):
             return self._task_decomposition()
-        raise Exception # should not be reached
+        raise Exception  # should not be reached
 
     def _consistency_constraints(self) -> list[Expression]:
         """
         Helper function to enforce concistency constraints, used in the decomposition.
-        
+
         Consistency constraints enforce that:
         - duration >= 0 if the task is present
         - demand >= 0 if the task is present
         - start + duration == end if the task is present
         """
-
         start, duration, end, demand, capacity, is_present = self.args
-        cons = [implies(p,d >= 0) for d, p in zip(duration, is_present)]  # enforce non-negative durations when present
-        cons += [implies(p,h >= 0) for h, p in zip(demand, is_present)]  # enforce non-negative demand when present
+        cons = [
+            implies(p, d >= 0) for d, p in zip(duration, is_present)
+        ]  # enforce non-negative durations when present
+        cons += [
+            implies(p, h >= 0) for h, p in zip(demand, is_present)
+        ]  # enforce non-negative demand when present
 
         # set duration of tasks, only if end is user-provided and the task is present
         if end is not None:
-            cons += [implies(is_present[i], start[i] + duration[i] == end[i]) for i in range(len(start))]
+            cons += [
+                implies(is_present[i], start[i] + duration[i] == end[i])
+                for i in range(len(start))
+            ]
 
         return cons
 
-    
     def _task_decomposition(self) -> tuple[list[Expression], list[Expression]]:
         """
         Task-based decomposition of the cumulative constraint.
         Schutt, Andreas, et al. "Why cumulative decomposition is not as bad as it sounds."
         International Conference on Principles and Practice of Constraint Programming. Springer, Berlin, Heidelberg, 2009.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         start, duration, end, demand, capacity, is_present = self.args
-        
+
         cons = self._consistency_constraints()
         if end is None:
             end = [start[i] + duration[i] for i in range(len(start))]
@@ -1319,9 +1542,16 @@ class CumulativeOptional(GlobalConstraint):
             demand_at_start_of_t = []
             for j in range(len(start)):
                 if t != j:
-                    demand_at_start_of_t += [demand[j] * (is_present[j] & (start[j] <= start[t]) & (end[j] > start[t]))]
+                    demand_at_start_of_t += [
+                        demand[j]
+                        * (is_present[j] & (start[j] <= start[t]) & (end[j] > start[t]))
+                    ]
 
-            cons += [implies(is_present[t], (demand[t] + sum(demand_at_start_of_t)) <= capacity)]
+            cons += [
+                implies(
+                    is_present[t], (demand[t] + sum(demand_at_start_of_t)) <= capacity
+                )
+            ]
 
         return cons, []
 
@@ -1330,9 +1560,10 @@ class CumulativeOptional(GlobalConstraint):
         Time-resource decomposition of the cumulative constraint.
         Schutt, Andreas, et al. "Why cumulative decomposition is not as bad as it sounds."
         International Conference on Principles and Practice of Constraint Programming. Springer, Berlin, Heidelberg, 2009.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         start, duration, end, demand, capacity, is_present = self.args
 
@@ -1344,37 +1575,50 @@ class CumulativeOptional(GlobalConstraint):
         # for each time-step, we check if the running demand does not exceed the capacity
         lbs, ubs = get_bounds(start)
         lb, ub = min(lbs), max(ubs)
-        for t in range(lb,ub+1):
-            cons += [cp.sum(d * (present & (s <= t) & (e > t)) for s,e,d,present in zip(start, end, demand, is_present)) <= capacity]
+        for t in range(lb, ub + 1):
+            cons += [
+                cp.sum(
+                    d * (present & (s <= t) & (e > t))
+                    for s, e, d, present in zip(start, end, demand, is_present)
+                )
+                <= capacity
+            ]
 
         return cons, []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
-        """        
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
+        """
         start, dur, end, demand, capacity, is_present = argvals(self.args)
         if end is None:
-            end = [s + d for s,d in zip(start, dur)]
+            end = [s + d for s, d in zip(start, dur)]
         else:
             end = argvals(end)
 
-        if any(a is None for a in flatlist([start, dur, end, demand, capacity, is_present])):
+        if any(
+            a is None for a in flatlist([start, dur, end, demand, capacity, is_present])
+        ):
             return None
-                
-        if any(p and d < 0 for d,p in zip(dur, is_present)):
+
+        if any(p and d < 0 for d, p in zip(dur, is_present)):
             return False
-        if any(p and s + d != e for s,d,e,p in zip(start, dur, end, is_present)):
+        if any(p and s + d != e for s, d, e, p in zip(start, dur, end, is_present)):
             return False
 
-        if any(p and d < 0 for d,p in zip(demand, is_present)):
+        if any(p and d < 0 for d, p in zip(demand, is_present)):
             return False
 
         # ensure demand doesn't exceed capacity
         lb, ub = min(start), max(end)
-        start, end, present = np.array(start), np.array(end), np.array(is_present) # eases check below
-        for t in range(lb, ub+1):
+        start, end, present = (
+            np.array(start),
+            np.array(end),
+            np.array(is_present),
+        )  # eases check below
+        for t in range(lb, ub + 1):
             if capacity < sum(demand * (present & (start <= t) & (end > t))):
                 return False
 
@@ -1384,47 +1628,58 @@ class CumulativeOptional(GlobalConstraint):
 class NoOverlap(GlobalConstraint):
     """
     Enforces that a set of tasks are scheduled without overlapping, and enforces:
-        - duration >= 0
-        - start + duration == end
+    - duration >= 0
+    - start + duration == end
     """
 
-    def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None):
+    def __init__(
+        self,
+        start: ListLike[ExprLike],
+        duration: ListLike[ExprLike],
+        end: Optional[ListLike[ExprLike]] = None,
+    ):
         """
         Arguments:
-            start (ListLike[ExprLike]): Start times of the tasks
-            duration (ListLike[ExprLike]): Durations of the tasks
-            end (ListLike[ExprLike] | None): Optional end times of the tasks
+        start (ListLike[ExprLike]): Start times of the tasks
+        duration (ListLike[ExprLike]): Durations of the tasks
+        end (ListLike[ExprLike] | None): Optional end times of the tasks
+
         """
-       
         if not is_any_list(start):
             raise TypeError("start should be a list")
         if not is_any_list(duration):
             raise TypeError("duration should be a list")
         if end is not None and not is_any_list(end):
             raise TypeError("end should be a list if it is provided")
-        
+
         if len(start) != len(duration):
             raise ValueError("Start and duration should have equal length")
         if end is not None and len(start) != len(end):
-            raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
-        
-        super().__init__("no_overlap", (list(start), list(duration), list(end) if end is not None else None))
+            raise ValueError(
+                f"Start and end should have equal length, but got {len(start)} and {len(end)}"
+            )
+
+        super().__init__(
+            "no_overlap",
+            (list(start), list(duration), list(end) if end is not None else None),
+        )
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the NoOverlap constraint, using pairwise no-overlap constraints.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         start, dur, end = self.args
         cons = [d >= 0 for d in dur]
-        
+
         if end is None:
-            end = [s+d for s,d in zip(start, dur)]
-        else: # can use the expression directly below
-            cons += [s + d == e for s,d,e in zip(start, dur, end)]
-            
+            end = [s + d for s, d in zip(start, dur)]
+        else:  # can use the expression directly below
+            cons += [s + d == e for s, d, e in zip(start, dur, end)]
+
         for (s1, e1), (s2, e2) in all_pairs(zip(start, end)):
             cons += [(e1 <= s2) | (e2 <= s1)]
         return cons, []
@@ -1432,48 +1687,60 @@ class NoOverlap(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         start, dur, end = argvals(self.args)
         if end is None:
             if any(s is None for s in start) or any(d is None for d in dur):
                 return None
-            end = [s + d for s,d in zip(start, dur)]
+            end = [s + d for s, d in zip(start, dur)]
         else:
-            if any(s is None for s in start) or any(d is None for d in dur) or any(e is None for e in end):
+            if (
+                any(s is None for s in start)
+                or any(d is None for d in dur)
+                or any(e is None for e in end)
+            ):
                 return None
-       
+
         if any(d < 0 for d in dur):
             return False
-        if any(s + d != e for s,d,e in zip(start, dur, end)):
+        if any(s + d != e for s, d, e in zip(start, dur, end)):
             return False
-        for (s1,d1), (s2,d2) in all_pairs(zip(start,dur)):
+        for (s1, d1), (s2, d2) in all_pairs(zip(start, dur)):
             if s1 + d1 > s2 and s2 + d2 > s1:
                 return False
         return True
 
+
 class NoOverlapOptional(GlobalConstraint):
     """
-        Generalization of the NoOverlap constraint which allows for optional tasks.
-        A task is only scheduled if the corresponing is_present variable is set to True.
+    Generalization of the NoOverlap constraint which allows for optional tasks.
+    A task is only scheduled if the corresponing is_present variable is set to True.
 
-        The constraint enforces that all present tasks are scheduled without overlapping, and for each present task, the constraint enforces that:
-        - duration >= 0
-        - demand >= 0
-        - start + duration == end
+    The constraint enforces that all present tasks are scheduled without overlapping, and for each present task, the constraint enforces that:
+    - duration >= 0
+    - demand >= 0
+    - start + duration == end
 
-        if the task is not present, it does not enforce any of the above.
+    if the task is not present, it does not enforce any of the above.
     """
-    
-    def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None, is_present: Optional[ListLike[ExprLike]] = None):
+
+    def __init__(
+        self,
+        start: ListLike[ExprLike],
+        duration: ListLike[ExprLike],
+        end: Optional[ListLike[ExprLike]] = None,
+        is_present: Optional[ListLike[ExprLike]] = None,
+    ):
         """
         Arguments:
-            start (ListLike[Expression]): List of Expression objects representing the start times of the tasks
-            duration (ListLike[Expression]): List of Expression objects representing the durations of the tasks
-            end (ListLike[Expression] | None): optional, list of Expression objects representing the end times of the tasks
-            is_present (ListLike[Expression]): List of Boolean Expression objects representing the presence of the tasks
+        start (ListLike[Expression]): List of Expression objects representing the start times of the tasks
+        duration (ListLike[Expression]): List of Expression objects representing the durations of the tasks
+        end (ListLike[Expression] | None): optional, list of Expression objects representing the end times of the tasks
+        is_present (ListLike[Expression]): List of Boolean Expression objects representing the presence of the tasks
+
         """
-       
         if not is_any_list(start):
             raise TypeError("start should be a list")
         if not is_any_list(duration):
@@ -1482,31 +1749,37 @@ class NoOverlapOptional(GlobalConstraint):
             raise TypeError("end should be a list if it is provided")
         if is_present is None or not is_any_list(is_present):
             raise ValueError("is_present should be provided and should be a list")
-        
+
         if len(start) != len(duration):
             raise ValueError("Start and duration should have equal length")
         if len(start) != len(is_present):
             raise ValueError("Start and is_present should have equal length")
         if end is not None and len(start) != len(end):
-            raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
-        
+            raise ValueError(
+                f"Start and end should have equal length, but got {len(start)} and {len(end)}"
+            )
+
         super().__init__("no_overlap_optional", (start, duration, end, is_present))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the NoOverlap constraint, using pairwise no-overlap constraints.
-        
+
         Returns:
             tuple[Sequence[Expression], Sequence[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         start, dur, end, is_present = self.args
         cons = [implies(p, d >= 0) for d, p in zip(dur, is_present)]
-        
+
         if end is None:
-            end = [s+d for s,d in zip(start, dur)]
-        else: # can use the expression directly below
-            cons += [implies(p, s + d == e) for s,d,e,p in zip(start, dur, end, is_present)]
-            
+            end = [s + d for s, d in zip(start, dur)]
+        else:  # can use the expression directly below
+            cons += [
+                implies(p, s + d == e)
+                for s, d, e, p in zip(start, dur, end, is_present)
+            ]
+
         for (s1, e1, p1), (s2, e2, p2) in all_pairs(zip(start, end, is_present)):
             cons += [implies(p1 & p2, (e1 <= s2) | (e2 <= s1))]
         return cons, []
@@ -1514,26 +1787,33 @@ class NoOverlapOptional(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         start, dur, end, is_present = argvals(self.args)
         if end is None:
             if any(s is None for s in start) or any(d is None for d in dur):
                 return None
-            end = [s + d for s,d in zip(start, dur)]
+            end = [s + d for s, d in zip(start, dur)]
         else:
-            if any(s is None for s in start) or any(d is None for d in dur) or any(e is None for e in end) or any(p is None for p in is_present):
+            if (
+                any(s is None for s in start)
+                or any(d is None for d in dur)
+                or any(e is None for e in end)
+                or any(p is None for p in is_present)
+            ):
                 return None
-       
-        if any(p and d < 0 for d,p in zip(dur, is_present)):
+
+        if any(p and d < 0 for d, p in zip(dur, is_present)):
             return False
-        if any(p and s + d != e for s,d,e,p in zip(start, dur, end, is_present)):
+        if any(p and s + d != e for s, d, e, p in zip(start, dur, end, is_present)):
             return False
-        for (s1,d1,p1), (s2,d2,p2) in all_pairs(zip(start,dur,is_present)):
+        for (s1, d1, p1), (s2, d2, p2) in all_pairs(zip(start, dur, is_present)):
             if p1 and p2 and (s1 + d1 > s2) and (s2 + d2 > s1):
                 return False
         return True
-    
+
+
 class Precedence(GlobalConstraint):
     """
     Enforces a precedence relationship between a set of variables.
@@ -1544,17 +1824,28 @@ class Precedence(GlobalConstraint):
         - X = [1,2,1,3] satisfies the precedence [1,2,3].
         - X = [4,1,2,1,3] also satisfies the precedence, as values not appearing in P can appear in any order.
         - X = [2,1,3] does not satisfy the precedence, as 1 does not appear before 2.
+
     """
-    def __init__(self, vars: ListLike[ExprLike], precedence: ListLike[int|np.integer]):
+
+    def __init__(
+        self, vars: ListLike[ExprLike], precedence: ListLike[int | np.integer]
+    ):
         """
         Arguments:
-            vars (ListLike[ExprLike]): List of expressions or constants representing the variables
-            precedence (ListLike[int | np.integer]): List of integer precedence values
+        vars (ListLike[ExprLike]): List of expressions or constants representing the variables
+        precedence (ListLike[int | np.integer]): List of integer precedence values
+
         """
         if not is_any_list(vars):
-            raise TypeError("Precedence expects a list of variables as first argument, but got", vars)
+            raise TypeError(
+                "Precedence expects a list of variables as first argument, but got",
+                vars,
+            )
         if not is_any_list(precedence) or not all(is_num(p) for p in precedence):
-            raise TypeError("Precedence expects a list of values as second argument, but got", precedence)
+            raise TypeError(
+                "Precedence expects a list of values as second argument, but got",
+                precedence,
+            )
         super().__init__("precedence", (list(vars), list(precedence)))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -1565,16 +1856,16 @@ class Precedence(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
-        """
 
+        """
         args, precedence = self.args
         args = cpm_array(args)
         constraints = []
-        for s,t in zip(precedence[:-1], precedence[1:]):
+        for s, t in zip(precedence[:-1], precedence[1:]):
             # constraint 1 from paper
-            constraints.append(args[0] != t) 
+            constraints.append(args[0] != t)
             # constraint 2 from paper
-            for j in range(1,len(args)):
+            for j in range(1, len(args)):
                 lhs = args[j] == t
                 if is_bool(lhs):  # args[j] and t could both be constants
                     lhs = BoolVal(lhs)
@@ -1584,14 +1875,15 @@ class Precedence(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         args, precedence = self.args
         vals = argvals(args)
         if any(v is None for v in vals):
             return None
         vals = np.array(vals)
-        for s,t in zip(precedence[:-1], precedence[1:]):
+        for s, t in zip(precedence[:-1], precedence[1:]):
             if vals[0] == t:
                 return False
             for j in range(len(args)):
@@ -1599,27 +1891,42 @@ class Precedence(GlobalConstraint):
                     return False
         return True
 
-class GlobalCardinalityCount(GlobalConstraint):
-    """
-    Enforces that the number of occurrences of each value `vals[i]` in the list of variables `vars` is equal to `occ[i]`.
-    """
 
-    def __init__(self, vars: ListLike[ExprLike], vals: ListLike[int|np.integer], occ: ListLike[ExprLike], closed: bool = False):
+class GlobalCardinalityCount(GlobalConstraint):
+    """Enforces that the number of occurrences of each value `vals[i]` in the list of variables `vars` is equal to `occ[i]`."""
+
+    def __init__(
+        self,
+        vars: ListLike[ExprLike],
+        vals: ListLike[int | np.integer],
+        occ: ListLike[ExprLike],
+        closed: bool = False,
+    ):
         """
         Arguments:
-            vars (ListLike[ExprLike]): List of expressions or constants representing the variables
-            vals (ListLike[int | np.integer]): List of integer values
-            occ (ListLike[ExprLike]): List of expressions or constants representing the number of occurrences of each value
-            closed (bool): Whether the constraint is closed, if true, `vars` can only take values in `vals`
+        vars (ListLike[ExprLike]): List of expressions or constants representing the variables
+        vals (ListLike[int | np.integer]): List of integer values
+        occ (ListLike[ExprLike]): List of expressions or constants representing the number of occurrences of each value
+        closed (bool): Whether the constraint is closed, if true, `vars` can only take values in `vals`
+
         """
         if not is_any_list(vars):
-            raise TypeError("GlobalCardinalityCount expects a list of variables, but got", vars)
+            raise TypeError(
+                "GlobalCardinalityCount expects a list of variables, but got", vars
+            )
         if not is_any_list(vals) or not all(is_num(v) for v in vals):
-            raise TypeError("GlobalCardinalityCount expects a list of values, but got", vals)
+            raise TypeError(
+                "GlobalCardinalityCount expects a list of values, but got", vals
+            )
         if not is_any_list(occ):
-            raise TypeError("GlobalCardinalityCount expects a list of variables as occurrences, but got", occ)
+            raise TypeError(
+                "GlobalCardinalityCount expects a list of variables as occurrences, but got",
+                occ,
+            )
         if len(vals) != len(occ):
-            raise ValueError(f"Number of values and occurrences must be equal, but got {len(vals)} and {len(occ)}")
+            raise ValueError(
+                f"Number of values and occurrences must be equal, but got {len(vals)} and {len(occ)}"
+            )
         super().__init__("gcc", (list(vars), list(vals), list(occ)))
         self.closed = closed
 
@@ -1637,7 +1944,8 @@ class GlobalCardinalityCount(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         vars, vals, occ = self.args
         vars, occ = argvals([vars, occ])
@@ -1648,21 +1956,21 @@ class GlobalCardinalityCount(GlobalConstraint):
         for val, cnt in zip(vals, occ):
             if sum(vars == val) != cnt:
                 return False
-        
+
         if self.closed and any(v not in frozenset(vals) for v in vars):
             return False
 
         return True
 
+
 class Increasing(GlobalConstraint):
-    """
-    Enforces that the expressions are assigned to (non-strictly) increasing values.
-    """
+    """Enforces that the expressions are assigned to (non-strictly) increasing values."""
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants to be assigned to increasing values
+        args (ListLike[ExprLike]): List of expressions or constants to be assigned to increasing values
+
         """
         super().__init__("increasing", tuple(flatlist(args)))
 
@@ -1672,134 +1980,141 @@ class Increasing(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         args = self.args
-        return [args[i] <= args[i+1] for i in range(len(args)-1)], []
+        return [args[i] <= args[i + 1] for i in range(len(args) - 1)], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         args = argvals(self.args)
         if any(x is None for x in args):
             return None
-        return all(args[i] <= args[i+1] for i in range(len(args)-1))
+        return all(args[i] <= args[i + 1] for i in range(len(args) - 1))
 
 
 class Decreasing(GlobalConstraint):
-    """
-    Enforces that the expressions are assigned to (non-strictly) decreasing values.
-    """
+    """Enforces that the expressions are assigned to (non-strictly) decreasing values."""
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants to be assigned to decreasing values
+        args (ListLike[ExprLike]): List of expressions or constants to be assigned to decreasing values
+
         """
         super().__init__("decreasing", tuple(flatlist(args)))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the Decreasing constraint.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         args = self.args
-        return [args[i] >= args[i+1] for i in range(len(args)-1)], []
+        return [args[i] >= args[i + 1] for i in range(len(args) - 1)], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         args = argvals(self.args)
         if any(x is None for x in args):
             return None
-        return all(args[i] >= args[i+1] for i in range(len(args)-1))
+        return all(args[i] >= args[i + 1] for i in range(len(args) - 1))
 
 
 class IncreasingStrict(GlobalConstraint):
-    """
-    Enforces that the expressions are assigned to strictly increasing values.
-    """
+    """Enforces that the expressions are assigned to strictly increasing values."""
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly increasing values
+        args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly increasing values
+
         """
         super().__init__("strictly_increasing", tuple(flatlist(args)))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the IncreasingStrict constraint.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         args = self.args
-        return [args[i] < args[i+1] for i in range(len(args)-1)], []
+        return [args[i] < args[i + 1] for i in range(len(args) - 1)], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         args = argvals(self.args)
         if any(x is None for x in args):
             return None
         args = argvals(self.args)
-        return all(args[i] < args[i+1] for i in range(len(args)-1))
+        return all(args[i] < args[i + 1] for i in range(len(args) - 1))
 
 
 class DecreasingStrict(GlobalConstraint):
-    """
-    Enforces that the expressions are assigned to strictly decreasing values.
-    """
+    """Enforces that the expressions are assigned to strictly decreasing values."""
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
-            args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly decreasing values
+        args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly decreasing values
+
         """
         super().__init__("strictly_decreasing", tuple(flatlist(args)))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the DecreasingStrict constraint.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         args = self.args
-        return [(args[i] > args[i+1]) for i in range(len(args)-1)], []
+        return [(args[i] > args[i + 1]) for i in range(len(args) - 1)], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         args = argvals(self.args)
         if any(x is None for x in args):
             return None
         args = argvals(self.args)
-        return all(args[i] > args[i+1] for i in range(len(args)-1))
+        return all(args[i] > args[i + 1] for i in range(len(args) - 1))
 
 
 class LexLess(GlobalConstraint):
-    """ 
-    Enforces that the first list is lexicographically smaller than the second list.
-    """
+    """Enforces that the first list is lexicographically smaller than the second list."""
+
     def __init__(self, list1: ListLike[ExprLike], list2: ListLike[ExprLike]):
         """
         Arguments:
-            list1 (ListLike[ExprLike]): First List of expressions or constants to be compared lexicographically
-            list2 (ListLike[ExprLike]): Second List of expressions or constants to be compared lexicographically
-        """ 
+        list1 (ListLike[ExprLike]): First List of expressions or constants to be compared lexicographically
+        list2 (ListLike[ExprLike]): Second List of expressions or constants to be compared lexicographically
+
+        """
         if len(list1) != len(list2):
-            raise ValueError(f"The 2 lists given in LexLess must have the same size: list1 length is {len(list1)} and list2 length is {len(list2)}")
+            raise ValueError(
+                f"The 2 lists given in LexLess must have the same size: list1 length is {len(list1)} and list2 length is {len(list2)}"
+            )
         super().__init__("lex_less", (list1, list2))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -1821,18 +2136,21 @@ class LexLess(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         X, Y = cpm_array(self.args)
 
         if len(X) == 0 == len(Y):
-            return [cp.BoolVal(False)], [] # based on the decomp, it's false...
+            return [cp.BoolVal(False)], []  # based on the decomp, it's false...
 
         bvar = boolvar(shape=(len(X) + 1))
 
         # Constraint ensuring that each element in X is less than or equal to the corresponding element in Y,
         # until a strict inequality is encountered.
         defining = []
-        defining.extend(bvar == ((X <= Y) & ((X < Y) | bvar[1:])))  # vectorized expression, treat as list
+        defining.extend(
+            bvar == ((X <= Y) & ((X < Y) | bvar[1:]))
+        )  # vectorized expression, treat as list
         # enforce the last element to be true iff (X[-1] < Y[-1]), enforcing strict lexicographic order
         defining.append(bvar[-1] == (X[-1] < Y[-1]))
         constraining = [bvar[0]]
@@ -1842,26 +2160,31 @@ class LexLess(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         X, Y = argvals(self.args)
         if any(val is None for val in X + Y):
             return None
-        return any((X[i] < Y[i]) & all(X[j] <= Y[j] for j in range(i)) for i in range(len(X)))
+        return any(
+            (X[i] < Y[i]) & all(X[j] <= Y[j] for j in range(i)) for i in range(len(X))
+        )
 
 
 class LexLessEq(GlobalConstraint):
-    """
-    Enforces that the first list is lexicographically smaller than or equal to the second list.
-    """
+    """Enforces that the first list is lexicographically smaller than or equal to the second list."""
+
     def __init__(self, list1: ListLike[ExprLike], list2: ListLike[ExprLike]):
         """
         Arguments:
-            list1 (ListLike[ExprLike]): First List of expressions or constants to be compared lexicographically
-            list2 (ListLike[ExprLike]): Second List of expressions or constants to be compared lexicographically
+        list1 (ListLike[ExprLike]): First List of expressions or constants to be compared lexicographically
+        list2 (ListLike[ExprLike]): Second List of expressions or constants to be compared lexicographically
+
         """
         if len(list1) != len(list2):
-            raise ValueError(f"The 2 lists given in LexLessEq must have the same size: list1 length is {len(list1)} and list2 length is {len(list2)}")
+            raise ValueError(
+                f"The 2 lists given in LexLessEq must have the same size: list1 length is {len(list1)} and list2 length is {len(list2)}"
+            )
         super().__init__("lex_lesseq", (list1, list2))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -1883,15 +2206,18 @@ class LexLessEq(GlobalConstraint):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         X, Y = cpm_array(self.args)
 
         if len(X) == 0 == len(Y):
-            return [cp.BoolVal(False)], [] # based on the decomp, it's false...
+            return [cp.BoolVal(False)], []  # based on the decomp, it's false...
 
         bvar = boolvar(shape=(len(X) + 1))
         defining = []
-        defining.extend(bvar == ((X <= Y) & ((X < Y) | bvar[1:])))  # vectorized expression, treat as list
+        defining.extend(
+            bvar == ((X <= Y) & ((X < Y) | bvar[1:]))
+        )  # vectorized expression, treat as list
         defining.append(bvar[-1] == (X[-1] <= Y[-1]))
         constraining = [bvar[0]]
 
@@ -1900,34 +2226,40 @@ class LexLessEq(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         X, Y = argvals(self.args)
         if any(val is None for val in X + Y):
             return None
-        return any((X[i] < Y[i]) & all(X[j] <= Y[j] for j in range(i)) for i in range(len(X))) | all(X[i] == Y[i] for i in range(len(X)))
+        return any(
+            (X[i] < Y[i]) & all(X[j] <= Y[j] for j in range(i)) for i in range(len(X))
+        ) | all(X[i] == Y[i] for i in range(len(X)))
 
 
 class LexChainLess(GlobalConstraint):
-    """
-    Enforces that all rows of the matrix are lexicographically ordered.
-    """
+    """Enforces that all rows of the matrix are lexicographically ordered."""
+
     def __init__(self, X: ListLike[ListLike[ExprLike]]):
         """
         Arguments:
-            X (ListLike[ListLike[ExprLike]]): Matrix (List of lists) of expressions or constants to be compared lexicographically
+        X (ListLike[ListLike[ExprLike]]): Matrix (List of lists) of expressions or constants to be compared lexicographically
+
         """
-        Xarr = np.array(X) # also checks length of each row is equal
+        Xarr = np.array(X)  # also checks length of each row is equal
         if Xarr.ndim != 2:
-            raise ValueError(f"The matrix given in LexChainLess must be 2D, but got {Xarr.ndim} dimensions")
+            raise ValueError(
+                f"The matrix given in LexChainLess must be 2D, but got {Xarr.ndim} dimensions"
+            )
         super().__init__("lex_chain_less", tuple(Xarr.tolist()))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Decomposition of the LexChainLess constraint.
-        
+
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+
         """
         X = self.args
         return [LexLess(prev_row, curr_row) for prev_row, curr_row in zip(X, X[1:])], []
@@ -1935,64 +2267,80 @@ class LexChainLess(GlobalConstraint):
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         X = argvals(self.args)
         if any(val is None for val in flatlist(X)):
             return None
-        return all(LexLess(prev_row, curr_row).value() for prev_row, curr_row in zip(X, X[1:]))
+        return all(
+            LexLess(prev_row, curr_row).value() for prev_row, curr_row in zip(X, X[1:])
+        )
 
 
 class LexChainLessEq(GlobalConstraint):
-    """ 
-    Enforces that all rows of the matrix are lexicographically ordered (less or equal)
-    """
+    """Enforces that all rows of the matrix are lexicographically ordered (less or equal)"""
+
     def __init__(self, X: ListLike[ListLike[ExprLike]]):
         """
         Arguments:
-            X (ListLike[ListLike[ExprLike]]): Matrix (List of lists) of expressions or constants to be compared lexicographically
+        X (ListLike[ListLike[ExprLike]]): Matrix (List of lists) of expressions or constants to be compared lexicographically
+
         """
-        Xarr = np.array(X) # also checks length of each row is equal
+        Xarr = np.array(X)  # also checks length of each row is equal
         if Xarr.ndim != 2:
-            raise ValueError(f"The matrix given in LexChainLessEq must be 2D, but got {Xarr.ndim} dimensions")
+            raise ValueError(
+                f"The matrix given in LexChainLessEq must be 2D, but got {Xarr.ndim} dimensions"
+            )
         super().__init__("lex_chain_lesseq", tuple(Xarr.tolist()))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
-        """ Decompose to a series of LexLessEq constraints between subsequent rows
-        """
+        """Decompose to a series of LexLessEq constraints between subsequent rows"""
         X = self.args
-        return [LexLessEq(prev_row, curr_row) for prev_row, curr_row in zip(X, X[1:])], []
+        return [
+            LexLessEq(prev_row, curr_row) for prev_row, curr_row in zip(X, X[1:])
+        ], []
 
     def value(self) -> Optional[bool]:
         """
         Returns:
-            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+
         """
         X = argvals(self.args)
         if any(val is None for val in flatlist(X)):
             return None
-        return all(LexLessEq(prev_row, curr_row).value() for prev_row, curr_row in zip(X, X[1:]))
+        return all(
+            LexLessEq(prev_row, curr_row).value()
+            for prev_row, curr_row in zip(X, X[1:])
+        )
 
 
 class DirectConstraint(Expression):
     """
-        A ``DirectConstraint`` will directly call a function of the underlying solver when added to a CPMpy solver
+    A ``DirectConstraint`` will directly call a function of the underlying solver when added to a CPMpy solver
 
-        It can not be reified, it is not flattened, it can not contain other CPMpy expressions than variables.
-        When added to a CPMpy solver, it will literally just directly call a function on the underlying solver,
-        replacing CPMpy variables by solver variables along the way.
+    It can not be reified, it is not flattened, it can not contain other CPMpy expressions than variables.
+    When added to a CPMpy solver, it will literally just directly call a function on the underlying solver,
+    replacing CPMpy variables by solver variables along the way.
 
-        See the documentation of the solver (constructor) for details on how that solver handles them.
+    See the documentation of the solver (constructor) for details on how that solver handles them.
 
-        If you want/need to use what the solver returns (e.g. an identifier for use in other constraints),
-        then use :func:`~cpmpy.expressions.variables.directvar` instead, or access the solver object from the solver interface directly.
+    If you want/need to use what the solver returns (e.g. an identifier for use in other constraints),
+    then use :func:`~cpmpy.expressions.variables.directvar` instead, or access the solver object from the solver interface directly.
     """
-    def __init__(self, name: str, arguments: tuple[Any, ...], novar: Optional[ListLike[int]] = None):
+
+    def __init__(
+        self,
+        name: str,
+        arguments: tuple[Any, ...],
+        novar: Optional[ListLike[int]] = None,
+    ):
         """
-            name (str): Name of the solver function that you wish to call
-            arguments (tuple[Any, ...]): Tuple of arguments to pass to the solver function with name `name`
-            novar (Optional[ListLike[int]]): Optional List of indices (offset 0) of arguments in `arguments` that contain no variables,
-                   that can be passed 'as is' without scanning for variables
+        Name (str): Name of the solver function that you wish to call
+        arguments (tuple[Any, ...]): Tuple of arguments to pass to the solver function with name `name`
+        novar (Optional[ListLike[int]]): Optional List of indices (offset 0) of arguments in `arguments` that contain no variables,
+               that can be passed 'as is' without scanning for variables
         """
         if not isinstance(arguments, tuple):
             arguments = (arguments,)  # force tuple
@@ -2000,13 +2348,12 @@ class DirectConstraint(Expression):
         self.novar = novar
 
     def is_bool(self) -> bool:
-        """ is it a Boolean (return type) Operator?
-        """
+        """Is it a Boolean (return type) Operator?"""
         return True
 
     def callSolver(self, CPMpy_solver: "SolverInterface", Native_solver: Any) -> Any:
         """
-            Call the `directname()` function of the native solver,
+        Call the `directname()` function of the native solver,
             with stored arguments replacing CPMpy variables with solver variables as needed.
 
             SolverInterfaces will call this function when this constraint is added.
@@ -2024,4 +2371,3 @@ class DirectConstraint(Expression):
                 solver_args[i] = CPMpy_solver.solver_vars(solver_args[i])
         # len(native_args) should match nr of arguments of `native_function`
         return solver_function(*solver_args)
-

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -892,7 +892,7 @@ class Element(GlobalFunction):
 
 def element(arg_list):
     """
-    DEPRECATED: Use Element(arr,idx) instead of element([arr,idx]).
+    DEPRECATED: Use cpmpy.Element(arr,idx) instead
 
     Arguments:
         arg_list (list[Expression]): List containing array and index (2 elements)

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -1,77 +1,78 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## globalfunctions.py
 ##
 """
-    Global functions conveniently express numerical global constraints in function form.
+Global functions conveniently express numerical global constraints in function form.
 
-    For example `cp.Maximum(iv1, iv2, iv3) == iv4`, or `cp.Abs(iv1) > iv2` or `m.minimize(cp.Count(IVS, 0))`,
-    or other nested numeric expressions.
+For example `cp.Maximum(iv1, iv2, iv3) == iv4`, or `cp.Abs(iv1) > iv2` or `m.minimize(cp.Count(IVS, 0))`,
+or other nested numeric expressions.
 
-    Global functions are implemented as classes that inherit from :class:`GlobalFunction <cpmpy.expressions.globalfunctions.GlobalFunction>`.
-
-
-    Solver perspective
-    ------------------
-
-    * Native support: some solvers natively support the function form of global functions,
-    such as other CP languages, SMT solvers, Cplex, Hexaly etc.
-
-    * Predicate form: CP solvers and MINLP solvers only support the predicate form of global functions.
-    For example, `cp.Maximum(iv1, iv2, iv3) == iv4` has to be posted to the solver API
-    as `addMaximumEquals([iv1,iv2,iv3], iv4)`, and expressions like `cp.Abs(iv1) > iv2` have to be flattened
-    and posted as `addAbsEquals(iv1, aux)` and `aux > iv2`. This is automatically done by the flattening
-    transformation in the `flatten_model` transformation.
-
-    * Decomposition: if a solver does not support a global function, then it will be automatically
-    decomposed by the :func:`decompose_in_tree() <cpmpy.transformations.decompose_global.decompose_in_tree>` transformation, which will call its :meth:`decompose() <cpmpy.expressions.globalfunctions.GlobalFunction.decompose>` method.
-
-    The `.decompose()` function returns two arguments:
-        1. A single CPMpy expression representing the numerical value of the global function,
-            this is often an auxiliary variable, a sum of auxiliary variables or a sum over
-            nested expressions.
-        2. If the decomposition introduces new *auxiliary variables*, then the second argument
-            has to be a list of constraints that (totally) define those new variables.
-
-    To make maximum use of simplification and common subexpression elimination, we recommend that decompositions
-        use nested expression as much as possible and avoid creating auxiliary variables unless not expressible
-        in a more direct way.
+Global functions are implemented as classes that inherit from :class:`GlobalFunction <cpmpy.expressions.globalfunctions.GlobalFunction>`.
 
 
-    Example:
+Solver perspective
+------------------
 
-    .. code-block:: python
+* Native support: some solvers natively support the function form of global functions,
+such as other CP languages, SMT solvers, Cplex, Hexaly etc.
 
-        class MySum(GlobalFunction):
-            def __init__(self, args):
-                assert len(args) == 2, "MySum takes 2 arguments"
-                super().__init__("my_sum", args)
+* Predicate form: CP solvers and MINLP solvers only support the predicate form of global functions.
+For example, `cp.Maximum(iv1, iv2, iv3) == iv4` has to be posted to the solver API
+as `addMaximumEquals([iv1,iv2,iv3], iv4)`, and expressions like `cp.Abs(iv1) > iv2` have to be flattened
+and posted as `addAbsEquals(iv1, aux)` and `aux > iv2`. This is automatically done by the flattening
+transformation in the `flatten_model` transformation.
 
-            def decompose(self):
-                return (self.args[0] + self.args[1]), []  # the decomposition
+* Decomposition: if a solver does not support a global function, then it will be automatically
+decomposed by the :func:`decompose_in_tree() <cpmpy.transformations.decompose_global.decompose_in_tree>` transformation, which will call its :meth:`decompose() <cpmpy.expressions.globalfunctions.GlobalFunction.decompose>` method.
 
-    ===============
-    List of classes
-    ===============
+The `.decompose()` function returns two arguments:
+1. A single CPMpy expression representing the numerical value of the global function,
+this is often an auxiliary variable, a sum of auxiliary variables or a sum over
+nested expressions.
+2. If the decomposition introduces new *auxiliary variables*, then the second argument
+has to be a list of constraints that (totally) define those new variables.
 
-    .. autosummary::
-        :nosignatures:
+To make maximum use of simplification and common subexpression elimination, we recommend that decompositions
+use nested expression as much as possible and avoid creating auxiliary variables unless not expressible
+in a more direct way.
 
-        Minimum
-        Maximum
-        Abs
-        Multiplication
-        Division
-        Modulo
-        Power
-        Element
-        Count
-        Among
-        NValue
-        NValueExcept
+
+Example:
+
+.. code-block:: python
+
+class MySum(GlobalFunction):
+def __init__(self, args):
+assert len(args) == 2, "MySum takes 2 arguments"
+super().__init__("my_sum", args)
+
+def decompose(self):
+return (self.args[0] + self.args[1]), []  # the decomposition
+
+===============
+List of classes
+===============
+
+.. autosummary::
+:nosignatures:
+
+Minimum
+Maximum
+Abs
+Multiplication
+Division
+Modulo
+Power
+Element
+Count
+Among
+NValue
+NValueExcept
 
 """
+
 import warnings  # for deprecation warning
 from typing import Optional
 import numpy as np
@@ -79,8 +80,18 @@ import cpmpy as cp
 
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
 from .core import Expression, Operator, ExprLike, ListLike
-from .variables import boolvar, intvar, cpm_array
-from .utils import flatlist, argval, is_num, is_int, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, implies
+from .variables import intvar
+from .utils import (
+    flatlist,
+    argval,
+    is_num,
+    eval_comparison,
+    is_any_list,
+    is_boolexpr,
+    get_bounds,
+    argvals,
+    implies,
+)
 
 
 class GlobalFunction(Expression):
@@ -94,13 +105,14 @@ class GlobalFunction(Expression):
     def is_bool(self) -> bool:
         """
         Returns:
-            bool: False, global functions are numeric
+        bool: False, global functions are numeric
+
         """
         return False
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
         """
-            Returns a decomposition into smaller constraints as a tuple of
+        Returns a decomposition into smaller constraints as a tuple of
             (numerical expression, list of constraints defining auxiliary variables)
 
             The first one will replace the GlobalFunction expression in-place,
@@ -112,12 +124,15 @@ class GlobalFunction(Expression):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the numerical expression and a list of constraints defining auxiliary variables
+
         """
         raise NotImplementedError("Decomposition for", self, "not available")
 
-    def decompose_comparison(self, cmp_op: str, cmp_rhs: Expression) -> tuple[list[Expression], list[Expression]]:
+    def decompose_comparison(
+        self, cmp_op: str, cmp_rhs: Expression
+    ) -> tuple[list[Expression], list[Expression]]:
         """
-            DEPRECATED: returns a list of constraints representing the decomposed
+        DEPRECATED: returns a list of constraints representing the decomposed
             comparison of the global function (and any auxiliary variables introduced).
 
         Arguments:
@@ -126,9 +141,13 @@ class GlobalFunction(Expression):
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing two lists: constraints representing the comparison, and constraints defining auxiliary variables
+
         """
-        warnings.warn(f"Deprecated, use {self}.decompose() instead, will be removed in "
-                      "stable version", DeprecationWarning)
+        warnings.warn(
+            f"Deprecated, use {self}.decompose() instead, will be removed in "
+            "stable version",
+            DeprecationWarning,
+        )
         valexpr, cons = self.decompose()
         return [eval_comparison(cmp_op, valexpr, cmp_rhs)], cons
 
@@ -138,36 +157,37 @@ class GlobalFunction(Expression):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound)
+
         """
         raise NotImplementedError("Bounds calculation for", self, "not available")
 
     def is_total(self) -> bool:
         """
-            Returns whether it is a total function.
-            If true, its value is defined for all arguments
+        Returns whether it is a total function.
+        If true, its value is defined for all arguments
 
-            TODO: I do not find anywhere where we set it dynamically to False?
-            TODO: REMOVE??
+        TODO: I do not find anywhere where we set it dynamically to False?
+        TODO: REMOVE??
         """
         return True
 
 
 class Minimum(GlobalFunction):
-    """
-    Computes the minimum value of the arguments
-    """
+    """Computes the minimum value of the arguments"""
 
     def __init__(self, arg_list: ListLike[ExprLike]):
         """
         Arguments:
-            arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the minimum
+        arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the minimum
+
         """
         super().__init__("min", tuple(flatlist(arg_list)))
 
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The minimum value of the arguments, or None if any argument is not assigned
+        Optional[int]: The minimum value of the arguments, or None if any argument is not assigned
+
         """
         vargs = [argval(a) for a in self.args]
         if any(val is None for val in vargs):
@@ -185,9 +205,12 @@ class Minimum(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the auxiliary variable representing the minimum value, and a list of constraints defining it
+
         """
         _min = intvar(*self.get_bounds())
-        return _min, [_min <= a for a in self.args] + [cp.any(_min >= a for a in self.args)]
+        return _min, [_min <= a for a in self.args] + [
+            cp.any(_min >= a for a in self.args)
+        ]
 
     def get_bounds(self) -> tuple[int, int]:
         """
@@ -195,27 +218,28 @@ class Minimum(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the minimum value
+
         """
         bnds = [get_bounds(x) for x in self.args]
         return min(lb for lb, ub in bnds), min(ub for lb, ub in bnds)
 
 
 class Maximum(GlobalFunction):
-    """
-    Computes the maximum value of the arguments
-    """
+    """Computes the maximum value of the arguments"""
 
     def __init__(self, arg_list: ListLike[ExprLike]):
         """
         Arguments:
-            arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the maximum
+        arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the maximum
+
         """
         super().__init__("max", tuple(flatlist(arg_list)))
 
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The maximum value of the arguments, or None if any argument is not assigned
+        Optional[int]: The maximum value of the arguments, or None if any argument is not assigned
+
         """
         vargs = [argval(a) for a in self.args]
         if any(val is None for val in vargs):
@@ -233,9 +257,12 @@ class Maximum(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the auxiliary variable representing the maximum value, and a list of constraints defining it
+
         """
         _max = intvar(*self.get_bounds())
-        return _max, [_max >= a for a in self.args] + [cp.any(_max <= a for a in self.args)]
+        return _max, [_max >= a for a in self.args] + [
+            cp.any(_max <= a for a in self.args)
+        ]
 
     def get_bounds(self) -> tuple[int, int]:
         """
@@ -243,27 +270,28 @@ class Maximum(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the maximum value
+
         """
         bnds = [get_bounds(x) for x in self.args]
         return max(lb for lb, ub in bnds), max(ub for lb, ub in bnds)
 
 
 class Abs(GlobalFunction):
-    """
-    Computes the absolute value of the argument
-    """
+    """Computes the absolute value of the argument"""
 
     def __init__(self, expr: Expression):
         """
         Arguments:
-            expr (Expression): Expression of which to compute the absolute value
+        expr (Expression): Expression of which to compute the absolute value
+
         """
         super().__init__("abs", (expr,))
 
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The absolute value of the argument, or None if the argument is not assigned
+        Optional[int]: The absolute value of the argument, or None if the argument is not assigned
+
         """
         varg = argval(self.args[0])
         if varg is None:
@@ -281,12 +309,13 @@ class Abs(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the expression representing the absolute value (may be the argument itself, its negation, or an auxiliary variable), and a list of constraints defining it (empty if no auxiliary variable is needed)
+
         """
         arg = self.args[0]
         lb, ub = get_bounds(arg)
-        if lb >= 0: # always positive
+        if lb >= 0:  # always positive
             return arg, []
-        if ub <= 0: # always negative
+        if ub <= 0:  # always negative
             return -arg, []
 
         _abs = intvar(*self.get_bounds())
@@ -298,6 +327,7 @@ class Abs(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the absolute value
+
         """
         lb, ub = get_bounds(self.args[0])
         if lb >= 0:
@@ -320,10 +350,11 @@ class Multiplication(GlobalFunction):
         Arguments:
             x (ExprLike): First factor (expression or constant)
             y (ExprLike): Second factor (expression or constant)
-        
+
         We expect at least one of the two is an Expression
 
         Normalizes so a constant is first when one factor is numeric (sets .is_lhs_num).
+
         """
         is_lhs_num = False
         if is_num(x):
@@ -336,8 +367,9 @@ class Multiplication(GlobalFunction):
         self.is_lhs_num = is_lhs_num
 
     def update_args(self, args):
-        """ Allows in-place update of the expression's arguments.
-            Resets all cached computations which depend on the expression tree.
+        """
+        Allows in-place update of the expression's arguments.
+        Resets all cached computations which depend on the expression tree.
         """
         x, y = args
         is_lhs_num = False
@@ -421,8 +453,8 @@ class Multiplication(GlobalFunction):
 
         # encoding z_v == (a == v)*b via (a==v)->(z_v == b) & (a!=v)->(z_v == 0)
         encoding = []
-        z_lb = min(0, lb_b) # make sure it can take 0
-        z_ub = max(0, ub_b) # make sure it can take 0
+        z_lb = min(0, lb_b)  # make sure it can take 0
+        z_ub = max(0, ub_b)  # make sure it can take 0
         zs = cp.intvar(z_lb, z_ub, shape=(len(dom_a),))
         for v, z_v in zip(dom_a, zs):
             encoding.append((a == v).implies(z_v == b))
@@ -447,19 +479,23 @@ class Division(GlobalFunction):
     def __init__(self, x: ExprLike, y: ExprLike):
         """
         Arguments:
-            x (ExprLike): Expression or constant to divide
-            y (ExprLike): Expression or constant to divide by
+        x (ExprLike): Expression or constant to divide
+        y (ExprLike): Expression or constant to divide by
+
         """
         super().__init__("div", (x, y))
 
     def __repr__(self):
         """
         Returns:
-            str: String representation of integer division as 'x div y'
+        str: String representation of integer division as 'x div y'
+
         """
-        x,y = self.args
-        return "{} div {}".format(f"({x})" if isinstance(x, Expression) else x,
-                                  f"({y})" if isinstance(y, Expression) else y)
+        x, y = self.args
+        return "{} div {}".format(
+            f"({x})" if isinstance(x, Expression) else x,
+            f"({y})" if isinstance(y, Expression) else y,
+        )
 
     def decompose(self):
         """
@@ -470,34 +506,44 @@ class Division(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the auxiliary variable representing the integer division, and a list of constraints defining it
+
         """
-        x,y = self.args
+        x, y = self.args
         safen = []
 
         y_lb, y_ub = get_bounds(y)
         if y_lb <= 0 <= y_ub:
             safen = [y != 0]
-            warnings.warn(f"Division constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions")
+            warnings.warn(
+                f"Division constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions"
+            )
 
         r = intvar(*get_bounds(x % y))  # remainder
         _div = intvar(*self.get_bounds())
-        return _div, safen + [(x == (y * _div) + r), abs(r) < abs(y), abs(y) * abs(_div) <= abs(x)]
+        return _div, safen + [
+            (x == (y * _div) + r),
+            abs(r) < abs(y),
+            abs(y) * abs(_div) <= abs(x),
+        ]
 
     def value(self):
         """
         Returns:
-            int: The integer division of the arguments, or None if the arguments are not assigned
+        int: The integer division of the arguments, or None if the arguments are not assigned
+
         """
-        x,y = argvals(self.args)
+        x, y = argvals(self.args)
         if x is None or y is None:
             return None
 
         try:
             return int(x / y)  # integer division, rounding towards zero
         except ZeroDivisionError:
-            raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}"
-                                          + "\n Use argval(expr) to get the value of expr with relational "
-                                            "semantics.")
+            raise IncompleteFunctionError(
+                f"Division by zero during value computation for expression {self}"
+                + "\n Use argval(expr) to get the value of expr with relational "
+                "semantics."
+            )
 
     def get_bounds(self):
         """
@@ -505,8 +551,9 @@ class Division(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the integer division
+
         """
-        x,y = self.args
+        x, y = self.args
         x_lb, x_ub = get_bounds(x)
         y_lb, y_ub = get_bounds(y)
 
@@ -518,11 +565,22 @@ class Division(GlobalFunction):
             if y_ub == 0:
                 y_ub = -1
             bounds = [
-                int(x_lb / y_lb), int(x_lb / -1), int(x_lb / 1), int(x_lb / y_ub),
-                int(x_ub / y_lb), int(x_ub / -1), int(x_ub / 1), int(x_ub / y_ub)
+                int(x_lb / y_lb),
+                int(x_lb / -1),
+                int(x_lb / 1),
+                int(x_lb / y_ub),
+                int(x_ub / y_lb),
+                int(x_ub / -1),
+                int(x_ub / 1),
+                int(x_ub / y_ub),
             ]
         else:
-            bounds = [int(x_lb / y_lb), int(x_lb / y_ub), int(x_ub / y_lb), int(x_ub / y_ub)]
+            bounds = [
+                int(x_lb / y_lb),
+                int(x_lb / y_ub),
+                int(x_ub / y_lb),
+                int(x_ub / y_ub),
+            ]
 
         return min(bounds), max(bounds)
 
@@ -530,7 +588,6 @@ class Division(GlobalFunction):
 class Modulo(GlobalFunction):
     """
     Computes the modulo of the arguments, the remainder with integer division (rounding towards zero): `x - (y * (x div y))`
-
 
     Warning: this is different from the Python's modulo operator `%`, which gives the remainder of the float division `x / y`
 
@@ -542,59 +599,68 @@ class Modulo(GlobalFunction):
     def __init__(self, x: ExprLike, y: ExprLike):
         """
         Arguments:
-            x (ExprLike): Expression or constant for the dividend
-            y (ExprLike): Expression or constant for the divisor
+        x (ExprLike): Expression or constant for the dividend
+        y (ExprLike): Expression or constant for the divisor
+
         """
         super().__init__("mod", (x, y))
 
     def __repr__(self):
         """
         Returns:
-            str: String representation with 'mod' as notation
+        str: String representation with 'mod' as notation
+
         """
-        x,y = self.args
-        return "{} mod {}".format(f"({x})" if isinstance(x, Expression) else x,
-                                  f"({y})" if isinstance(y, Expression) else y)
+        x, y = self.args
+        return "{} mod {}".format(
+            f"({x})" if isinstance(x, Expression) else x,
+            f"({y})" if isinstance(y, Expression) else y,
+        )
 
     def decompose(self):
         """
         Decomposition of Modulo global function, using integer division (rounding towards zero)
-        
+
         Decomposes `x mod y = z` as `x = k * y + z` with `|z| < |y|` and `sign(x) = sign(z)`
         https://en.wikipedia.org/wiki/Modulo
         https://marcelkliemannel.com/articles/2021/dont-confuse-integer-division-with-floor-division/
         """
-        x,y = self.args
+        x, y = self.args
         safen = []
 
         y_lb, y_ub = get_bounds(y)
         if y_lb <= 0 <= y_ub:
             safen = [y != 0]
-            warnings.warn(f"Modulo constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions")
+            warnings.warn(
+                f"Modulo constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions"
+            )
 
         _mod = intvar(*self.get_bounds())
         k = intvar(*get_bounds((x - _mod) // y))  # integer quotient (multiplier)
         return _mod, safen + [
-            k * y + _mod == x,   # module is remainder of integer division
+            k * y + _mod == x,  # module is remainder of integer division
             abs(_mod) < abs(y),  # remainder is smaller than divisor
-            x * _mod >= 0        # remainder is negative iff x is negative
+            x * _mod >= 0,  # remainder is negative iff x is negative
         ]
 
     def value(self):
         """
         Returns:
-            int: The modulo of the arguments, or None if the arguments are not assigned
+        int: The modulo of the arguments, or None if the arguments are not assigned
+
         """
-        x,y = argvals(self.args)
+        x, y = argvals(self.args)
         if x is None or y is None:
             return None
 
         try:  # modulo defined with integer division
             return x - (y * int(x / y))
         except ZeroDivisionError:
-            raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}"
-                                          + "\n Use argval(expr) to get the value of expr with relational "
-                                            "semantics.")
+            raise IncompleteFunctionError(
+                f"Division by zero during value computation for expression {self}"
+                + "\n Use argval(expr) to get the value of expr with relational "
+                "semantics."
+            )
 
     def get_bounds(self):
         """
@@ -602,6 +668,7 @@ class Modulo(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the modulo
+
         """
         lb1, ub1 = get_bounds(self.args[0])
         lb2, ub2 = get_bounds(self.args[1])
@@ -625,16 +692,21 @@ class Power(GlobalFunction):
     Only non-negative constant integer exponents are supported.
     """
 
-    def __init__(self, base: ExprLike, exponent: int|np.integer):
+    def __init__(self, base: ExprLike, exponent: int | np.integer):
         """
         Arguments:
-            base (ExprLike): Expression or constant to raise to the power
-            exponent (int | np.integer): Non-negative integer exponent (constant only, no variable)
+        base (ExprLike): Expression or constant to raise to the power
+        exponent (int | np.integer): Non-negative integer exponent (constant only, no variable)
+
         """
         if not is_num(exponent):
-            raise TypeError(f"Power constraint takes an integer number as second argument, not: {exponent}")
+            raise TypeError(
+                f"Power constraint takes an integer number as second argument, not: {exponent}"
+            )
         if exponent < 0:
-            raise ValueError(f"Power constraint only supports non-negative integer exponents, not: {exponent}")
+            raise ValueError(
+                f"Power constraint only supports non-negative integer exponents, not: {exponent}"
+            )
         super().__init__("pow", (base, exponent))
 
     def decompose(self):
@@ -645,20 +717,22 @@ class Power(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the auxiliary variable representing the power, and a list of constraints defining it
+
         """
         base, exp = self.args
         if exp == 0:
-            return 1,[]
+            return 1, []
 
         _pow = base
-        for _ in range(1,exp):
+        for _ in range(1, exp):
             _pow *= base
-        return _pow,[]
+        return _pow, []
 
     def value(self):
         """
         Returns:
-            int: The power of the arguments, or None if the arguments are not assigned
+        int: The power of the arguments, or None if the arguments are not assigned
+
         """
         base, exp = argvals(self.args)
         if base is None or exp is None:
@@ -672,11 +746,12 @@ class Power(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the power
+
         """
         base, exp = self.args
         lb_base, ub_base = get_bounds(base)
 
-        bounds = [lb_base ** exp, ub_base ** exp]
+        bounds = [lb_base**exp, ub_base**exp]
         return min(bounds), max(bounds)
 
 
@@ -699,24 +774,32 @@ class Element(GlobalFunction):
     def __init__(self, arr: ListLike[ExprLike], idx: ExprLike):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to index into
-            idx (ExprLike): Integer expression or constant for the index (not a boolean expression)
+        arr (ListLike[ExprLike]): List of expressions or constants to index into
+        idx (ExprLike): Integer expression or constant for the index (not a boolean expression)
+
         """
         if is_boolexpr(idx):
-            raise TypeError(f"Element(arr, idx) takes an integer expression as second argument, not a boolean expression: {idx}")
+            raise TypeError(
+                f"Element(arr, idx) takes an integer expression as second argument, not a boolean expression: {idx}"
+            )
         if is_any_list(idx):
-            raise TypeError(f"Element(arr, idx) takes an integer expression as second argument, not a list: {idx}")
+            raise TypeError(
+                f"Element(arr, idx) takes an integer expression as second argument, not a list: {idx}"
+            )
         assert len(arr) > 0, "Element: array should not be empty"
 
         super().__init__("element", (arr, idx))
 
     def __getitem__(self, index):
-        raise CPMpyException("For using multi-dimensional Element, use comma-separated indices on the original array, e.g. instead of Arr[Idx1][Idx2], do Arr[Idx1, Idx2].")
+        raise CPMpyException(
+            "For using multi-dimensional Element, use comma-separated indices on the original array, e.g. instead of Arr[Idx1][Idx2], do Arr[Idx1, Idx2]."
+        )
 
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The value of the array element at the given index, or None if the index is not assigned or the array element is not assigned
+        Optional[int]: The value of the array element at the given index, or None if the index is not assigned or the array element is not assigned
+
         """
         arr, idx = self.args
         vidx = argval(idx)
@@ -724,8 +807,10 @@ class Element(GlobalFunction):
             return None
 
         if vidx < 0 or vidx >= len(arr):
-            raise IncompleteFunctionError(f"Index {vidx} out of range for array of length {len(arr)} while calculating value for expression {self}"
-                                            + "\n Use argval(expr) to get the value of expr with relational semantics.")
+            raise IncompleteFunctionError(
+                f"Index {vidx} out of range for array of length {len(arr)} while calculating value for expression {self}"
+                + "\n Use argval(expr) to get the value of expr with relational semantics."
+            )
         return argval(arr[vidx])  # can be None
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
@@ -738,6 +823,7 @@ class Element(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the auxiliary variable representing the element value, and a list of constraints defining it
+
         """
         arr, idx = self.args
 
@@ -745,12 +831,16 @@ class Element(GlobalFunction):
         defining = []
         if not (idx_lb >= 0 and idx_ub < len(arr)):
             defining += [idx >= 0, idx < len(arr)]
-            warnings.warn(f"Element constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions")
+            warnings.warn(
+                f"Element constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions"
+            )
 
         aux = intvar(*self.get_bounds())
 
-        lb, ub = max(idx_lb, 0), min(idx_ub, len(arr)-1)
-        return aux, [implies(idx == i, aux == arr[i]) for i in range(lb, ub+1)] + defining
+        lb, ub = max(idx_lb, 0), min(idx_ub, len(arr) - 1)
+        return aux, [
+            implies(idx == i, aux == arr[i]) for i in range(lb, ub + 1)
+        ] + defining
 
     def decompose_linear(self) -> tuple[Expression, list[Expression]]:
         """
@@ -762,6 +852,7 @@ class Element(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the expression representing the element value, and an empty list of constraints (no auxiliary variables needed)
+
         """
         arr, idx = self.args
 
@@ -769,10 +860,12 @@ class Element(GlobalFunction):
         defining = []
         if not (idx_lb >= 0 and idx_ub < len(arr)):
             defining += [idx >= 0, idx < len(arr)]
-            warnings.warn(f"Element constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions")
+            warnings.warn(
+                f"Element constraint is unsafe, and will be forced to be total by this decomposition. If you are using {self} in a nested context, this is not valid, and you need to safen first using cpmpy.transformations.safening.no_partial_functions"
+            )
 
-        lb, ub = max(idx_lb, 0), min(idx_ub, len(arr)-1)
-        return cp.sum((idx == i)*arr[i] for i in range(lb, ub+1)), defining
+        lb, ub = max(idx_lb, 0), min(idx_ub, len(arr) - 1)
+        return cp.sum((idx == i) * arr[i] for i in range(lb, ub + 1)), defining
 
     def get_bounds(self) -> tuple[int, int]:
         """
@@ -780,10 +873,11 @@ class Element(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the element value
+
         """
         arr, idx = self.args
         bnds = [get_bounds(x) for x in arr]
-        return min(lb for lb,ub in bnds), max(ub for lb,ub in bnds)
+        return min(lb for lb, ub in bnds), max(ub for lb, ub in bnds)
 
     def __repr__(self) -> str:
         """
@@ -791,8 +885,10 @@ class Element(GlobalFunction):
 
         Returns:
             str: String representation of the Element global function.
+
         """
         return f"{self.args[0]}[{self.args[1]}]"
+
 
 def element(arg_list):
     """
@@ -803,27 +899,34 @@ def element(arg_list):
 
     Returns:
         Element: An Element global function instance
+
     """
-    warnings.warn("Deprecated, use Element(arr,idx) instead, will be removed in stable version", DeprecationWarning)
-    assert (len(arg_list) == 2), "Element expression takes 2 arguments: Arr, Idx"
+    warnings.warn(
+        "Deprecated, use Element(arr,idx) instead, will be removed in stable version",
+        DeprecationWarning,
+    )
+    assert len(arg_list) == 2, "Element expression takes 2 arguments: Arr, Idx"
     return Element(arg_list[0], arg_list[1])
 
 
 class Count(GlobalFunction):
-    """
-    The Count global function represents the number of occurrences of a value in an array
-    """
+    """The Count global function represents the number of occurrences of a value in an array"""
 
     def __init__(self, arr: ListLike[ExprLike], val: ExprLike):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to count in
-            val (ExprLike): 'Value' to count occurences of (can also be an expression)
+        arr (ListLike[ExprLike]): List of expressions or constants to count in
+        val (ExprLike): 'Value' to count occurences of (can also be an expression)
+
         """
         if not is_any_list(arr):
-            raise TypeError(f"Count(arr, val) takes an array of expressions as first argument, not: {arr}")
+            raise TypeError(
+                f"Count(arr, val) takes an array of expressions as first argument, not: {arr}"
+            )
         if is_any_list(val):
-            raise TypeError(f"Count(arr, val) takes a numeric expression as second argument, not a list: {val}")
+            raise TypeError(
+                f"Count(arr, val) takes a numeric expression as second argument, not a list: {val}"
+            )
         super().__init__("count", (arr, val))
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
@@ -834,6 +937,7 @@ class Count(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the sum expression representing the count, and an empty list of constraints (no auxiliary variables needed)
+
         """
         arr, val = self.args
         return cp.sum((a == val) for a in arr), []
@@ -841,7 +945,8 @@ class Count(GlobalFunction):
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The number of occurrences of val in arr, or None if val or any element in arr is not assigned
+        Optional[int]: The number of occurrences of val in arr, or None if val or any element in arr is not assigned
+
         """
         arr, val = self.args
         vval = argval(val)
@@ -860,10 +965,10 @@ class Count(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the count value
+
         """
         arr, val = self.args
         return 0, len(arr)
-
 
 
 class Among(GlobalFunction):
@@ -875,11 +980,12 @@ class Among(GlobalFunction):
     returns the number of variables among x1, x2, x3, x4 that take the value 1 or 2.
     """
 
-    def __init__(self, arr: ListLike[ExprLike], vals: ListLike[int|np.integer]):
+    def __init__(self, arr: ListLike[ExprLike], vals: ListLike[int | np.integer]):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to count occurrences in
-            vals (ListLike[int | np.integer]): List of integer constants whose occurrences are counted
+        arr (ListLike[ExprLike]): List of expressions or constants to count occurrences in
+        vals (ListLike[int | np.integer]): List of integer constants whose occurrences are counted
+
         """
         if not is_any_list(arr) or not is_any_list(vals):
             raise TypeError(f"Among takes as input two arrays, not: {arr} and {vals}")
@@ -896,6 +1002,7 @@ class Among(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the sum expression representing the total number of occurrences, and an empty list of constraints (no auxiliary variables needed)
+
         """
         arr, vals = self.args
         return cp.sum(Count(arr, val) for val in vals), []
@@ -903,7 +1010,8 @@ class Among(GlobalFunction):
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The number of variables in arr that take a value present in vals, or None if any element in arr is not assigned
+        Optional[int]: The number of variables in arr that take a value present in vals, or None if any element in arr is not assigned
+
         """
         arr, vals = self.args
         varr = argvals(arr)  # recursive handling of nested structures
@@ -918,6 +1026,7 @@ class Among(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the among count value
+
         """
         arr, vals = self.args
         return 0, len(arr)
@@ -934,7 +1043,8 @@ class NValue(GlobalFunction):
     def __init__(self, arr: ListLike[ExprLike]):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to count distinct values in
+        arr (ListLike[ExprLike]): List of expressions or constants to count distinct values in
+
         """
         if not is_any_list(arr):
             raise ValueError(f"NValue(arr) takes an array as input, not: {arr}")
@@ -956,16 +1066,18 @@ class NValue(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the sum expression representing the number of distinct values, and an empty list of constraints (no auxiliary variables needed)
+
         """
         lbs, ubs = get_bounds(self.args)
         lb, ub = min(lbs), max(ubs)
 
-        return cp.sum(cp.any(a == v for a in self.args) for v in range(lb, ub+1)), []
+        return cp.sum(cp.any(a == v for a in self.args) for v in range(lb, ub + 1)), []
 
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The number of distinct values in the array, or None if any element in arr is not assigned
+        Optional[int]: The number of distinct values in the array, or None if any element in arr is not assigned
+
         """
         vargs = [argval(a) for a in self.args]
         if any(v is None for v in vargs):
@@ -979,6 +1091,7 @@ class NValue(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the number of distinct values
+
         """
         return 1, len(self.args)
 
@@ -993,16 +1106,19 @@ class NValueExcept(GlobalFunction):
     excluding 0).
     """
 
-    def __init__(self, arr: ListLike[ExprLike], n: int|np.integer):
+    def __init__(self, arr: ListLike[ExprLike], n: int | np.integer):
         """
         Arguments:
-            arr (ListLike[ExprLike]): List of expressions or constants to count distinct values in
-            n (int | np.integer): Integer constant to exclude from the count
+        arr (ListLike[ExprLike]): List of expressions or constants to count distinct values in
+        n (int | np.integer): Integer constant to exclude from the count
+
         """
         if not is_any_list(arr):
             raise ValueError("NValueExcept takes an array as input")
         if not is_num(n):
-            raise ValueError(f"NValueExcept takes an integer as second argument, but got {n} of type {type(n)}")
+            raise ValueError(
+                f"NValueExcept takes an integer as second argument, but got {n} of type {type(n)}"
+            )
         super().__init__("nvalue_except", (arr, n))
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
@@ -1015,18 +1131,22 @@ class NValueExcept(GlobalFunction):
 
         Returns:
             tuple[Expression, list[Expression]]: A tuple containing the sum expression representing the number of distinct values (excluding n), and an empty list of constraints (no auxiliary variables needed)
+
         """
         arr, n = self.args
 
         lbs, ubs = get_bounds(arr)
         lb, ub = min(lbs), max(ubs)
 
-        return cp.sum([cp.any(a == v for a in arr) for v in range(lb, ub+1) if v != n]), []
+        return cp.sum(
+            [cp.any(a == v for a in arr) for v in range(lb, ub + 1) if v != n]
+        ), []
 
     def value(self) -> Optional[int]:
         """
         Returns:
-            Optional[int]: The number of distinct values in the array, excluding value n, or None if any element in arr is not assigned
+        Optional[int]: The number of distinct values in the array, excluding value n, or None if any element in arr is not assigned
+
         """
         arr, n = self.args
         varr = [argval(a) for a in arr]
@@ -1044,6 +1164,7 @@ class NValueExcept(GlobalFunction):
 
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the number of distinct values (excluding n)
+
         """
         arr, n = self.args
         return 0, len(arr)

--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## python_builtins.py
 ##
 """
-    Overwrites a number of python built-ins, so that they work over variables as expected.
+Overwrites a number of python built-ins, so that they work over variables as expected.
 
-    =================
-    List of functions
-    =================
-    .. autosummary::
-        :nosignatures:
+=================
+List of functions
+=================
+.. autosummary::
+:nosignatures:
 
-        all
-        any
-        max
-        min
-        sum
-        abs
+all
+any
+max
+min
+sum
+abs
 """
+
 import builtins  # to use the original Python-builtins
 import numpy as np
 
@@ -32,18 +33,19 @@ from .globalfunctions import Minimum, Maximum, Abs
 # all: listwise 'and'
 def all(iterable):
     """
-        all() overwrites python built-in,
-        if iterable contains any `Expression`, then returns an Operator("and", iterable)
-        otherwise returns whether all of the arguments are true
+    all() overwrites python built-in,
+    if iterable contains any `Expression`, then returns an Operator("and", iterable)
+    otherwise returns whether all of the arguments are true
     """
-    if isinstance(iterable, NDVarArray): iterable=iterable.flat # 1D iterator
-    collect = [] # logical expressions
+    if isinstance(iterable, NDVarArray):
+        iterable = iterable.flat  # 1D iterator
+    collect = []  # logical expressions
     is_expr, return_false = False, False
     for elem in iterable:
-        if isinstance(elem, Expression): # probably most likely case
+        if isinstance(elem, Expression):  # probably most likely case
             is_expr = True
             if isinstance(elem, BoolVal):
-                if not elem.args[0]: # False constant
+                if not elem.args[0]:  # False constant
                     return_false = True
             elif elem.is_bool():
                 collect.append(elem)
@@ -57,7 +59,7 @@ def all(iterable):
             raise Exception("Encountered list in 'all', only accept non-nested lists")
         else:
             raise Exception("Unexpected argument '{}' to 'all'".format(elem))
-    
+
     if return_false:
         return BoolVal(False) if is_expr else False
     if len(collect) == 0:
@@ -72,18 +74,19 @@ def all(iterable):
 # any: listwise 'or'
 def any(iterable):
     """
-        any() overwrites python built-in,
-        if iterable contains an `Expression`, then returns an Operator("or", iterable)
-        otherwise returns whether any of the arguments is true
+    any() overwrites python built-in,
+    if iterable contains an `Expression`, then returns an Operator("or", iterable)
+    otherwise returns whether any of the arguments is true
     """
-    if isinstance(iterable, NDVarArray): iterable=iterable.flat # 1D iterator
-    collect = [] # logical expressions
+    if isinstance(iterable, NDVarArray):
+        iterable = iterable.flat  # 1D iterator
+    collect = []  # logical expressions
     is_expr, return_true = False, False
     for elem in iterable:
-        if isinstance(elem, Expression): # probably most likely case
+        if isinstance(elem, Expression):  # probably most likely case
             is_expr = True
             if isinstance(elem, BoolVal):
-                if elem.args[0]: # True constant
+                if elem.args[0]:  # True constant
                     return_true = True
             elif elem.is_bool():
                 collect.append(elem)
@@ -97,7 +100,7 @@ def any(iterable):
             raise Exception("Encountered list in 'all', only accept non-nested lists")
         else:
             raise Exception("Unexpected argument '{}' to 'all'".format(elem))
-    
+
     if return_true:
         return BoolVal(True) if is_expr else True
     if len(collect) == 0:
@@ -111,84 +114,95 @@ def any(iterable):
 
 def max(*iterable, **kwargs):
     """
-        max() overwrites the python built-in to support decision variables.
+    max() overwrites the python built-in to support decision variables.
 
-        if iterable does not contain CPMpy expressions, the built-in is called
-        else a Maximum functional global constraint is constructed; no keyword
-        arguments are supported in that case
+    if iterable does not contain CPMpy expressions, the built-in is called
+    else a Maximum functional global constraint is constructed; no keyword
+    arguments are supported in that case
     """
     if len(iterable) == 1:
         iterable = iterable[0]  # because of *iterable signature
 
     if isinstance(iterable, np.ndarray):
-        if iterable.dtype != object or \
-           not builtins.any(isinstance(elem, (Expression, NDVarArray)) for elem in iterable.flat):
+        if iterable.dtype != object or not builtins.any(
+            isinstance(elem, (Expression, NDVarArray)) for elem in iterable.flat
+        ):
             return builtins.max(iterable.flat, **kwargs)  # does not contain expressions
     else:
         iterable = tuple(iterable)  # convert iterable (possibly generator) to tuple
-        if not builtins.any(isinstance(elem, (Expression, NDVarArray)) for elem in iterable):
+        if not builtins.any(
+            isinstance(elem, (Expression, NDVarArray)) for elem in iterable
+        ):
             return builtins.max(iterable, **kwargs)  # does not contain expressions
 
-    assert len(kwargs)==0, "max over expressions does not support keyword arguments"
+    assert len(kwargs) == 0, "max over expressions does not support keyword arguments"
     return Maximum(iterable)
 
 
 def min(*iterable, **kwargs):
     """
-        min() overwrites the python built-in to support decision variables.
+    min() overwrites the python built-in to support decision variables.
 
-        if iterable does not contain CPMpy expressions, the built-in is called
-        else a Minimum functional global constraint is constructed; no keyword
-        arguments are supported in that case
+    if iterable does not contain CPMpy expressions, the built-in is called
+    else a Minimum functional global constraint is constructed; no keyword
+    arguments are supported in that case
     """
     if len(iterable) == 1:
         iterable = iterable[0]  # because of *iterable signature
 
     if isinstance(iterable, np.ndarray):
-        if iterable.dtype != object or \
-           not builtins.any(isinstance(elem, (Expression, NDVarArray)) for elem in iterable.flat):
+        if iterable.dtype != object or not builtins.any(
+            isinstance(elem, (Expression, NDVarArray)) for elem in iterable.flat
+        ):
             return builtins.min(iterable.flat, **kwargs)  # does not contain expressions
     else:
         iterable = tuple(iterable)  # convert iterable (possibly generator) to tuple
-        if not builtins.any(isinstance(elem, (Expression, NDVarArray)) for elem in iterable):
+        if not builtins.any(
+            isinstance(elem, (Expression, NDVarArray)) for elem in iterable
+        ):
             return builtins.min(iterable, **kwargs)  # does not contain expressions
 
-    assert len(kwargs)==0, "min over expressions does not support keyword arguments"
+    assert len(kwargs) == 0, "min over expressions does not support keyword arguments"
     return Minimum(iterable)
 
 
 def sum(iterable, **kwargs):
     """
-        sum() overwrites the python built-in to support decision variables.
+    sum() overwrites the python built-in to support decision variables.
 
-        if iterable does not contain CPMpy expressions, the built-in is called
-        checks if all constants and uses built-in sum() in that case
+    if iterable does not contain CPMpy expressions, the built-in is called
+    checks if all constants and uses built-in sum() in that case
     """
     if isinstance(iterable, np.ndarray):
-        if iterable.dtype != object or \
-           not builtins.any(isinstance(elem, (Expression, NDVarArray)) for elem in iterable.flat):
+        if iterable.dtype != object or not builtins.any(
+            isinstance(elem, (Expression, NDVarArray)) for elem in iterable.flat
+        ):
             return builtins.sum(iterable.flat, **kwargs)  # does not contain expressions
     else:
         iterable = tuple(iterable)  # convert iterable (possibly generator) to tuple
-        if not builtins.any(isinstance(elem, (Expression, NDVarArray)) for elem in iterable):
+        if not builtins.any(
+            isinstance(elem, (Expression, NDVarArray)) for elem in iterable
+        ):
             return builtins.sum(iterable, **kwargs)  # does not contain expressions
 
-    assert len(kwargs)==0, "sum over expressions does not support keyword arguments"
+    assert len(kwargs) == 0, "sum over expressions does not support keyword arguments"
     return Operator("sum", iterable)
 
 
 def abs(element):
     """
-        abs() overwrites the python built-in to support decision variables.
+    abs() overwrites the python built-in to support decision variables.
 
-        if the element given is not a CPMpy expression, the built-in is called
-        else an Absolute functional global constraint is constructed.
+    if the element given is not a CPMpy expression, the built-in is called
+    else an Absolute functional global constraint is constructed.
     """
-    if is_any_list(element):  # compat: not allowed by builtins.abs(), but allowed by numpy.abs()
+    if is_any_list(
+        element
+    ):  # compat: not allowed by builtins.abs(), but allowed by numpy.abs()
         return cpm_array([abs(elem) for elem in element])
 
     if isinstance(element, Expression):
         # create global
         return Abs(element)
-    
+
     return builtins.abs(element)

--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -33,7 +33,8 @@ from .globalfunctions import Minimum, Maximum, Abs
 # all: listwise 'and'
 def all(iterable):
     """
-    all() overwrites python built-in,
+    Overwrites python built-in `all` function, to support decision variables.
+    
     if iterable contains any `Expression`, then returns an Operator("and", iterable)
     otherwise returns whether all of the arguments are true
     """
@@ -74,7 +75,8 @@ def all(iterable):
 # any: listwise 'or'
 def any(iterable):
     """
-    any() overwrites python built-in,
+    Overwrites python built-in `any` function, to support decision variables.
+
     if iterable contains an `Expression`, then returns an Operator("or", iterable)
     otherwise returns whether any of the arguments is true
     """
@@ -114,7 +116,7 @@ def any(iterable):
 
 def max(*iterable, **kwargs):
     """
-    max() overwrites the python built-in to support decision variables.
+    Overwrites the python built-in `max` function, to support decision variables.
 
     if iterable does not contain CPMpy expressions, the built-in is called
     else a Maximum functional global constraint is constructed; no keyword
@@ -141,7 +143,7 @@ def max(*iterable, **kwargs):
 
 def min(*iterable, **kwargs):
     """
-    min() overwrites the python built-in to support decision variables.
+    Overwrites the python built-in `min` function, to support decision variables.
 
     if iterable does not contain CPMpy expressions, the built-in is called
     else a Minimum functional global constraint is constructed; no keyword
@@ -168,7 +170,7 @@ def min(*iterable, **kwargs):
 
 def sum(iterable, **kwargs):
     """
-    sum() overwrites the python built-in to support decision variables.
+    Overwrites the python built-in `sum` function, to support decision variables.
 
     if iterable does not contain CPMpy expressions, the built-in is called
     checks if all constants and uses built-in sum() in that case
@@ -191,7 +193,7 @@ def sum(iterable, **kwargs):
 
 def abs(element):
     """
-    abs() overwrites the python built-in to support decision variables.
+    Overwrites the python built-in `abs` function, to support decision variables.
 
     if the element given is not a CPMpy expression, the built-in is called
     else an Absolute functional global constraint is constructed.

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -1,33 +1,34 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## utils.py
 ##
 """
 Internal utilities for expression handling.
 
-    =================
-    List of functions
-    =================
-    .. autosummary::
-        :nosignatures:
+=================
+List of functions
+=================
+.. autosummary::
+:nosignatures:
 
-        is_bool
-        is_int
-        is_num
-        is_false_cst
-        is_true_cst
-        is_boolexpr
-        is_pure_list
-        is_any_list
-        is_transition
-        flatlist
-        all_pairs
-        argval
-        argvals
-        eval_comparison
-        get_bounds     
+is_bool
+is_int
+is_num
+is_false_cst
+is_true_cst
+is_boolexpr
+is_pure_list
+is_any_list
+is_transition
+flatlist
+all_pairs
+argval
+argvals
+eval_comparison
+get_bounds
 """
+
 from __future__ import annotations  # treat annotations lazy (as string)
 
 import cpmpy as cp
@@ -35,35 +36,33 @@ import numpy as np
 import math
 from collections.abc import Iterable  # for flatten
 from itertools import combinations
-from typing import TYPE_CHECKING, TypeGuard, Union, Optional
+from typing import TYPE_CHECKING, TypeGuard
 from cpmpy.exceptions import IncompleteFunctionError
 
 if TYPE_CHECKING:
     # only import for type checking
-    from cpmpy.expressions.core import ListLike, ExprLike
+    pass
 
 
 def is_bool(arg):
-    """ is it a boolean (incl numpy variants)
-    """
+    """Is it a boolean (incl numpy variants)"""
     return isinstance(arg, (bool, np.bool_, cp.BoolVal))
 
 
 def is_int(arg):
-    """ can it be interpreted as an integer? (incl bool and numpy variants)
-    """
+    """Can it be interpreted as an integer? (incl bool and numpy variants)"""
     return isinstance(arg, (bool, np.bool_, cp.BoolVal, int, np.integer))
 
 
 def is_num(arg):
-    """ is it an int or float? (incl numpy variants)
-    """
-    return isinstance(arg, (bool, np.bool_, cp.BoolVal, int, np.integer, float, np.floating))
+    """Is it an int or float? (incl numpy variants)"""
+    return isinstance(
+        arg, (bool, np.bool_, cp.BoolVal, int, np.integer, float, np.floating)
+    )
 
 
 def is_false_cst(arg):
-    """ is the argument the constant False (can be of type bool, np.bool and BoolVal)
-    """
+    """Is the argument the constant False (can be of type bool, np.bool and BoolVal)"""
     if arg is False or arg is np.False_:
         return True
     elif isinstance(arg, cp.BoolVal):
@@ -72,8 +71,7 @@ def is_false_cst(arg):
 
 
 def is_true_cst(arg):
-    """ is the argument the constant True (can be of type bool, np.bool and BoolVal)
-    """
+    """Is the argument the constant True (can be of type bool, np.bool and BoolVal)"""
     if arg is True or arg is np.True_:
         return True
     elif isinstance(arg, cp.BoolVal):
@@ -82,36 +80,34 @@ def is_true_cst(arg):
 
 
 def is_boolexpr(expr):
-    """ is the argument a boolean expression or a boolean value
-    """
-    #boolexpr
-    if hasattr(expr, 'is_bool'):
+    """Is the argument a boolean expression or a boolean value"""
+    # boolexpr
+    if hasattr(expr, "is_bool"):
         return expr.is_bool()
-    #boolean constant
+    # boolean constant
     return is_bool(expr)
 
 
 def is_pure_list(arg):
-    """ is it a list or tuple?
-    """
+    """Is it a list or tuple?"""
     return isinstance(arg, (list, tuple))
 
 
 def is_any_list(arg) -> TypeGuard[list | tuple | np.ndarray]:
-    """ is it a list or tuple or numpy array?
-    """
+    """Is it a list or tuple or numpy array?"""
     return isinstance(arg, (list, tuple, np.ndarray))
 
+
 def flatlist(args):
-    """ recursively flatten arguments into one single list
-    """
+    """Recursively flatten arguments into one single list"""
     return list(_flatten(args))
 
 
 def _flatten(args):
-    """ flattens the irregular nested list into an iterator
+    """
+    Flattens the irregular nested list into an iterator
 
-        from: https://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists
+    from: https://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists
     """
     for el in args:
         if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
@@ -121,15 +117,15 @@ def _flatten(args):
 
 
 def all_pairs(args):
-    """ returns all pairwise combinations of elements in args
-    """
+    """Returns all pairwise combinations of elements in args"""
     return list(combinations(args, 2))
 
 
 def argval(a):
-    """ returns .value() of Expression, otherwise the variable itself
+    """
+    Returns .value() of Expression, otherwise the variable itself
 
-        We check with hasattr instead of isinstance to avoid circular dependency
+    We check with hasattr instead of isinstance to avoid circular dependency
     """
     if hasattr(a, "value"):
         try:
@@ -143,7 +139,7 @@ def argval(a):
         val = a
 
     if isinstance(val, np.generic):
-        return val.item() # ensure it is a Python native value
+        return val.item()  # ensure it is a Python native value
     return val
 
 
@@ -155,44 +151,45 @@ def argvals(arr):
 
 def eval_comparison(str_op, lhs, rhs):
     """
-        Internal function: evaluates the textual `str_op` comparison operator
-        lhs <str_op> rhs
+    Internal function: evaluates the textual `str_op` comparison operator
+    lhs <str_op> rhs
 
-        Valid str_op's:
-        * '=='
-        * '!='
-        * '>'
-        * '>='
-        * '<'
-        * '<='
+    Valid str_op's:
+    * '=='
+    * '!='
+    * '>'
+    * '>='
+    * '<'
+    * '<='
 
-        Especially useful in decomposition and transformation functions that already involve a comparison.
+    Especially useful in decomposition and transformation functions that already involve a comparison.
     """
     if isinstance(lhs, (np.integer, np.bool_)):
         lhs = int(lhs)
     if isinstance(rhs, (np.integer, np.bool_)):
         rhs = int(rhs)
 
-    if str_op == '==':
+    if str_op == "==":
         return lhs == rhs
-    elif str_op == '!=':
+    elif str_op == "!=":
         return lhs != rhs
-    elif str_op == '>':
+    elif str_op == ">":
         return lhs > rhs
-    elif str_op == '>=':
+    elif str_op == ">=":
         return lhs >= rhs
-    elif str_op == '<':
+    elif str_op == "<":
         return lhs < rhs
-    elif str_op == '<=':
+    elif str_op == "<=":
         return lhs <= rhs
     else:
         raise Exception("Not a known comparison:", str_op)
 
+
 def get_bounds(expr):
-    """ return the bounds of the expression
+    """
+    Return the bounds of the expression
     returns appropriately rounded integers
     """
-
     # import here to avoid circular import
     # from cpmpy.expressions.core import Expression
     # from cpmpy.expressions.variables import cpm_array
@@ -203,13 +200,16 @@ def get_bounds(expr):
         lbs, ubs = zip(*[get_bounds(e) for e in expr])
         return list(lbs), list(ubs)
     else:
-        assert is_num(expr), f"All Expressions should have a get_bounds function, `{expr}`"
+        assert is_num(expr), (
+            f"All Expressions should have a get_bounds function, `{expr}`"
+        )
         if is_bool(expr):
             return int(expr), int(expr)
         return math.floor(expr), math.ceil(expr)
 
+
 def implies(expr, other):
-    """ like :func:`~cpmpy.expressions.core.Expression.implies`, but also safe to use for non-expressions """
+    """Like :func:`~cpmpy.expressions.core.Expression.implies`, but also safe to use for non-expressions"""
     if isinstance(expr, (cp.expressions.core.Expression, cp.variables.NDVarArray)):
         # both implement .implies()
         return expr.implies(other)
@@ -220,18 +220,22 @@ def implies(expr, other):
     else:
         return expr.implies(other)
 
+
 # Specific stuff for scheduling constraints
+
 
 def get_nonneg_args(args, condition=None):
     """
-        Replace arguments with negative lowerbound with their nonnegative counterpart
-        arguments:
-            - args: list of expressions
-            - condition: list of boolean expressions, indicating whether the argument is present or not (e.g., optional tasks)
+    Replace arguments with negative lowerbound with their nonnegative counterpart
+    arguments:
+        - args: list of expressions
+        - condition: list of boolean expressions, indicating whether the argument is present or not (e.g., optional tasks)
     """
     if condition is None:
         condition = [True] * len(args)
-    assert len(args) == len(condition), f"Args and is_present must have the same length but got {len(args)} and {len(condition)}"
+    assert len(args) == len(condition), (
+        f"Args and is_present must have the same length but got {len(args)} and {len(condition)}"
+    )
 
     lbs, ubs = zip(*[get_bounds(arg) for arg in args])
     new_args = []
@@ -240,18 +244,19 @@ def get_nonneg_args(args, condition=None):
         if lb < 0:
             if ub >= 0:
                 iv = cp.intvar(0, ub)
-            else: # ub < 0  
-                iv = cp.intvar(0,0)
-            cons.append(implies(cond, arg == iv)) # will always be False if ub < 0
+            else:  # ub < 0
+                iv = cp.intvar(0, 0)
+            cons.append(implies(cond, arg == iv))  # will always be False if ub < 0
             new_args.append(iv)
         else:
             new_args.append(arg)
     return new_args, cons
 
+
 # Specific stuff for ShortTabel global (should this be in globalconstraints.py instead?)
-STAR = "*" # define constant here
+STAR = "*"  # define constant here
+
+
 def is_star(arg):
-    """
-        Check if arg is star as used in the ShortTable global constraint
-    """
+    """Check if arg is star as used in the ShortTable global constraint"""
     return isinstance(arg, type(STAR)) and arg == STAR

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -1,65 +1,66 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-
 ##
 ## variables.py
 ##
 """
-    Integer and Boolean decision variables (as n-dimensional numpy objects)
+Integer and Boolean decision variables (as n-dimensional numpy objects)
 
-    =================
-    List of functions
-    =================
-    .. autosummary::
-        :nosignatures:
+=================
+List of functions
+=================
+.. autosummary::
+:nosignatures:
 
-        boolvar
-        intvar
-        cpm_array
+boolvar
+intvar
+cpm_array
 
-    ==================
-    Module description
-    ==================
+==================
+Module description
+==================
 
-    A decision variable is a variable whose value will be determined by the solver.
+A decision variable is a variable whose value will be determined by the solver.
 
-    Boolean and Integer decision variables are the key elements of a CP model.
+Boolean and Integer decision variables are the key elements of a CP model.
 
-    All variables in CPMpy are n-dimensional array objects and have defined dimensions. 
-    Following the numpy library, the dimension sizes of an n-dimenionsal array is called its ``shape``. 
-    In CPMpy all variables are considered an array with a given shape. For 'single' variables the shape 
-    is '1'. For an array of length `n` the shape is 'n'. An `n*m` matrix has shape (n,m), and tensors 
-    with more than 2 dimensions are all supported too. For the implementation of this, 
-    CPMpy builts on numpy's n-dimensional `ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_ 
-    and inherits many of its benefits (vectorized operators and advanced indexing).
+All variables in CPMpy are n-dimensional array objects and have defined dimensions.
+Following the numpy library, the dimension sizes of an n-dimenionsal array is called its ``shape``.
+In CPMpy all variables are considered an array with a given shape. For 'single' variables the shape
+is '1'. For an array of length `n` the shape is 'n'. An `n*m` matrix has shape (n,m), and tensors
+with more than 2 dimensions are all supported too. For the implementation of this,
+CPMpy builts on numpy's n-dimensional `ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_
+and inherits many of its benefits (vectorized operators and advanced indexing).
 
-    This module contains the cornerstone ``boolvar()`` and ``intvar()`` functions, which create (numpy arrays of) 
-    variables. There is also a helper function ``cpm_array()`` for wrapping standard numpy arrays so they can be 
-    indexed by a variable. Apart from these 3 functions, none of the classes in this module should be directly 
-    instantiated; they are created by these 3 helper functions.
+This module contains the cornerstone ``boolvar()`` and ``intvar()`` functions, which create (numpy arrays of)
+variables. There is also a helper function ``cpm_array()`` for wrapping standard numpy arrays so they can be
+indexed by a variable. Apart from these 3 functions, none of the classes in this module should be directly
+instantiated; they are created by these 3 helper functions.
 
 
-    ===============
-    List of classes
-    ===============
-    .. autosummary::
-        :nosignatures:
+===============
+List of classes
+===============
+.. autosummary::
+:nosignatures:
 
-        NullShapeError
-        _NumVarImpl
-        _IntVarImpl
-        _BoolVarImpl
-        NegBoolView
-        NDVarArray
+NullShapeError
+_NumVarImpl
+_IntVarImpl
+_BoolVarImpl
+NegBoolView
+NDVarArray
 
-    ==============
-    Module details
-    ==============
+==============
+Module details
+==============
 """
+
 from __future__ import annotations
 
 import math
 from collections.abc import Iterable
-import warnings # for deprecation warning
+import warnings  # for deprecation warning
 from functools import reduce
 from typing import Any, Literal, Optional, overload
 
@@ -70,33 +71,44 @@ from .utils import is_num, is_int, is_boolexpr, get_bounds
 
 _BV_PREFIX = "BV"
 _IV_PREFIX = "IV"
-_VAR_ERR  = f"Variable names starting with {_IV_PREFIX} or {_BV_PREFIX} are reserved for internal use only, chose a different name"
+_VAR_ERR = f"Variable names starting with {_IV_PREFIX} or {_BV_PREFIX} are reserved for internal use only, chose a different name"
+
 
 def BoolVar(shape=1, name=None):
     """
     .. deprecated:: 0.9.0
-          Please use :func:`~cpmpy.expressions.variables.boolvar` instead.
+    Please use :func:`~cpmpy.expressions.variables.boolvar` instead.
     """
-    warnings.warn("Deprecated, use boolvar() instead, will be removed in stable version", DeprecationWarning)
+    warnings.warn(
+        "Deprecated, use boolvar() instead, will be removed in stable version",
+        DeprecationWarning,
+    )
     return boolvar(shape=shape, name=name)
 
 
 @overload
-def boolvar(shape: Literal[1] = 1,  # special case: a shape of =1 returns a single variable
-            name: Optional[str] = None) -> _BoolVarImpl: ...  # implementation below
+def boolvar(
+    shape: Literal[1] = 1,  # special case: a shape of =1 returns a single variable
+    name: Optional[str] = None,
+) -> _BoolVarImpl: ...  # implementation below
 @overload
-def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
-            name: Optional[str|ListLike[str]] = None) -> NDVarArray: ...  # implementation below
+def boolvar(
+    shape: int | np.integer | tuple[int | np.integer, ...] = 1,
+    name: Optional[str | ListLike[str]] = None,
+) -> NDVarArray: ...  # implementation below
 
-def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
-            name: Optional[str|ListLike[str]] = None) -> _BoolVarImpl|NDVarArray:  # the joint implementation
+
+def boolvar(
+    shape: int | np.integer | tuple[int | np.integer, ...] = 1,
+    name: Optional[str | ListLike[str]] = None,
+) -> _BoolVarImpl | NDVarArray:  # the joint implementation
     """
     Create Boolean decision variables that take either the value `True` or `False`.
 
     Arguments:
         shape (int or tuple of int, optional) : The shape of the n-dimensional array of variables. Default is 1.
-    
-        name (str, list of str, tuple of str, or None, optional) : 
+
+        name (str, list of str, tuple of str, or None, optional) :
             Name(s) to assign to the variables. Default is None.
 
             - If `name` is None, a name of the form ``BV<unique number>`` will be assigned to the variables.
@@ -105,23 +117,21 @@ def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
                              and they will be assigned to the variable names accordingly.
 
     Notes:
-
         - If `shape` is not 1, each element of the array will have its specific location appended to its name.
         - Examples:
             - ``boolvar(shape=3, name="x")`` will create the variables ``[x[0], x[1], x[2]]``.
             - ``boolvar(shape=3, name=list("xyz"))`` will create the variables ``[x, y, z]``.
 
     Examples:
-
         Creating a single Boolean variable:
-        
+
         .. code-block:: python
 
             x = boolvar()              # auto name BV<n> (unique counter)
             x = boolvar(name="x")      # user-chosen name
-        
+
         Creating a vector of Boolean variables:
-        
+
         .. code-block:: python
 
             x = boolvar(shape=3, name="x")
@@ -130,12 +140,13 @@ def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
             e, x, a, m, p, l = boolvar(shape=6, name=list("exampl"))
 
         Creating a matrix or higher-order tensor of Boolean variables:
-        
+
         .. code-block:: python
 
             matrix = boolvar(shape=(9, 9), name="matrix")
             matrix2 = boolvar(shape=(2, 2), name=[['a', 'b'], ['c', 'd']])
             tensor = boolvar(shape=(3, 8, 7), name="tensor")
+
     """
     if shape is None or shape == 0:
         raise NullShapeError(shape)
@@ -154,28 +165,44 @@ def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
     data = np.array([_BoolVarImpl(name=n) for n in names])
     # insert into custom ndarray
     r = NDVarArray(shape, dtype=object, buffer=data)
-    r._has_subexpr = False # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
+    r._has_subexpr = False  # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
     return r
 
 
 def IntVar(lb, ub, shape=1, name=None):
     """
     .. deprecated:: 0.9.0
-          Please use :func:`~cpmpy.expressions.variables.intvar` instead.
+    Please use :func:`~cpmpy.expressions.variables.intvar` instead.
     """
-    warnings.warn("Deprecated, use intvar() instead, will be removed in stable version", DeprecationWarning)
+    warnings.warn(
+        "Deprecated, use intvar() instead, will be removed in stable version",
+        DeprecationWarning,
+    )
     return intvar(lb, ub, shape=shape, name=name)
 
 
 @overload
-def intvar(lb: int, ub: int, shape: Literal[1] = 1,  # special case: a shape of =1 returns a single variable
-           name: Optional[str] = None) -> _IntVarImpl: ...  # implementation below
+def intvar(
+    lb: int,
+    ub: int,
+    shape: Literal[1] = 1,  # special case: a shape of =1 returns a single variable
+    name: Optional[str] = None,
+) -> _IntVarImpl: ...  # implementation below
 @overload
-def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 1,
-           name: Optional[str|ListLike[str]] = None) -> NDVarArray: ...  # implementation below
+def intvar(
+    lb: int,
+    ub: int,
+    shape: int | np.integer | tuple[int | np.integer, ...] = 1,
+    name: Optional[str | ListLike[str]] = None,
+) -> NDVarArray: ...  # implementation below
 
-def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 1,
-           name: Optional[str|ListLike[str]] = None) -> _IntVarImpl|NDVarArray:  # the joint implementation
+
+def intvar(
+    lb: int,
+    ub: int,
+    shape: int | np.integer | tuple[int | np.integer, ...] = 1,
+    name: Optional[str | ListLike[str]] = None,
+) -> _IntVarImpl | NDVarArray:  # the joint implementation
     """
     Integer decision variables are constructed by specifying the lowest (lb) value
     the decision variable can take, as well as the highest value (ub).
@@ -193,7 +220,6 @@ def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 
             - If `name` is a list/tuple/array of strings, they will be assigned to the variable names accordingly.
 
     Notes:
-
         The range of values between ``lb..ub`` is called the `domain` of the integer variable.
         All variables in an array start from the same domain.
         Specific values in the domain of individual variables can be forbidden with constraints.
@@ -207,26 +233,25 @@ def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 
         - ``intvar(0, 2, shape=3, name=list("xyz"))`` will create the variables ``[x, y, z]``.
 
     Examples:
-
         Creation of a single (unit-sized or scalar) integer variable with a given lower bound (**lb**) of 3 and upper bound (**ub**) of 8. Variable `x` can thus take values 3, 4, 5, 6, 7, 8 (upper bound included!).
 
         .. code-block:: python
 
-            # creation of a unit integer variable with lowerbound of 3 and upperbound of 8 
+            # creation of a unit integer variable with lowerbound of 3 and upperbound of 8
             x = intvar(3, 8, name="x")
 
         Creation of a vector of integer variables with all having the same given lower bound and upper bound:
 
         .. code-block:: python
 
-            # creation of a vector Boolean of 5 variables with lowerbound of 3 and upperbound of 8 
+            # creation of a vector Boolean of 5 variables with lowerbound of 3 and upperbound of 8
             x = intvar(3, 8, shape=5, name="x")
 
             # Python's unpacking can assign multiple intermediate variables at once
             e, x, a, m, p, l = intvar(3, 8, shape=6, name=list("exampl"))
 
         Creation of a 4D-array/tensor (of dimensions 100 x 100 x 100 x 100) of integer variables.
-        
+
         .. code-block:: python
 
             arrx s= intvar(3, 8, shape=(100, 100, 100, 100), name="arrx")
@@ -246,18 +271,24 @@ def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 
     names = _gen_var_names(name, shape)
 
     # create np.array 'data' representation of the decision variables
-    data = np.array([_IntVarImpl(lb, ub, name=n) for n in names]) # repeat new instances
+    data = np.array(
+        [_IntVarImpl(lb, ub, name=n) for n in names]
+    )  # repeat new instances
     # insert into custom ndarray
     r = NDVarArray(shape, dtype=object, buffer=data)
-    r._has_subexpr = False # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
+    r._has_subexpr = False  # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
     return r
+
 
 def cparray(arr):
     """
     .. deprecated:: 0.9.0
-          Please use :func:`~cpmpy.expressions.variables.cpm_array` instead.
+    Please use :func:`~cpmpy.expressions.variables.cpm_array` instead.
     """
-    warnings.warn("Deprecated, use cpm_array() instead, will be removed in stable version", DeprecationWarning)
+    warnings.warn(
+        "Deprecated, use cpm_array() instead, will be removed in stable version",
+        DeprecationWarning,
+    )
     return cpm_array(arr)
 
 
@@ -282,34 +313,35 @@ def cpm_array(arr: ListLike[ExprLike]) -> NDVarArray:
 
         Model([ data[iv1] == iv2 ])
 
-    As an alternative, you can also write the :class:`~cpmpy.expressions.globalfunctions.Element` constraint directly on `data`: 
-    
+    As an alternative, you can also write the :class:`~cpmpy.expressions.globalfunctions.Element` constraint directly on `data`:
+
     .. code-block:: python
 
         Element(data, iv1) == iv2
     """
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)
-    elif not arr.flags['FORC']:   # Ensure the array is contiguous
+    elif not arr.flags["FORC"]:  # Ensure the array is contiguous
         arr = np.ascontiguousarray(arr)
-    
-    order = 'F' if arr.flags['F_CONTIGUOUS'] else 'C'
+
+    order = "F" if arr.flags["F_CONTIGUOUS"] else "C"
     return NDVarArray(shape=arr.shape, dtype=arr.dtype, buffer=arr, order=order)
 
 
 class NullShapeError(Exception):
-    """
-    Error returned when providing an empty or size 0 shape for numpy arrays of variables
-    """
-    def __init__(self, shape: Optional[int|np.integer|tuple[int|np.integer, ...]], 
-                 message: str = "Shape should be non-zero"
-                ):
+    """Error returned when providing an empty or size 0 shape for numpy arrays of variables"""
+
+    def __init__(
+        self,
+        shape: Optional[int | np.integer | tuple[int | np.integer, ...]],
+        message: str = "Shape should be non-zero",
+    ):
         self.shape = shape
         self.message = message
         super().__init__(self.message)
 
     def __str__(self) -> str:
-        return f'{self.shape}: {self.message}'
+        return f"{self.shape}: {self.message}"
 
 
 class _NumVarImpl(Expression):
@@ -320,38 +352,39 @@ class _NumVarImpl(Expression):
     including bounds checking and value management. It should not be instantiated
     directly, but rather through the helper functions :func:`~cpmpy.expressions.variables.intvar` and :func:`~cpmpy.expressions.variables.boolvar`.
     """
+
     def __init__(self, lb: int, ub: int, name: str):
-        assert (is_num(lb) and is_num(ub))
-        assert (lb <= ub)
+        assert is_num(lb) and is_num(ub)
+        assert lb <= ub
         self.lb = lb
         self.ub = ub
         self.name = name
         self._value: Optional[int] = None
 
     def has_subexpr(self) -> bool:
-        """Does it contains nested Expressions?
-           Is of importance when deciding whether transformation/decomposition is needed.
+        """
+        Does it contains nested Expressions?
+        Is of importance when deciding whether transformation/decomposition is needed.
         """
         return False
 
     def is_bool(self) -> bool:
-        """ is it a Boolean (return type) Operator?
-        """
+        """Is it a Boolean (return type) Operator?"""
         return False
 
     def value(self) -> Optional[int]:
-        """ the value obtained in the last solve call
-            (or 'None')
+        """
+        The value obtained in the last solve call
+        (or 'None')
         """
         return self._value
 
     def get_bounds(self) -> tuple[int, int]:
-        """ the lower and upper bounds"""
+        """The lower and upper bounds"""
         return self.lb, self.ub
 
     def clear(self) -> None:
-        """ clear the value obtained from the last solve call
-        """
+        """Clear the value obtained from the last solve call"""
         self._value = None
 
     def __repr__(self) -> str:
@@ -369,17 +402,22 @@ class _IntVarImpl(_NumVarImpl):
     This class represents integer decision variables with a given domain [lb, ub] (inclusive).
     It should not be instantiated directly, but rather through the :func:`~cpmpy.expressions.variables.intvar` helper function.
     """
+
     counter = 0
 
     def __init__(self, lb: int, ub: int, name: Optional[str] = None):
-        assert is_int(lb), "IntVar lowerbound must be integer {} {}".format(type(lb), lb)
-        assert is_int(ub), "IntVar upperbound must be integer {} {}".format(type(ub), ub)
+        assert is_int(lb), "IntVar lowerbound must be integer {} {}".format(
+            type(lb), lb
+        )
+        assert is_int(ub), "IntVar upperbound must be integer {} {}".format(
+            type(ub), ub
+        )
 
         if name is None:
             name = f"{_IV_PREFIX}{_IntVarImpl.counter}"
-            _IntVarImpl.counter = _IntVarImpl.counter + 1 # static counter
+            _IntVarImpl.counter = _IntVarImpl.counter + 1  # static counter
 
-        super().__init__(int(lb), int(ub), name=name) # explicit cast: can be numpy
+        super().__init__(int(lb), int(ub), name=name)  # explicit cast: can be numpy
 
     # special casing for intvars (and boolvars)
     def __abs__(self) -> Expression:
@@ -396,20 +434,20 @@ class _BoolVarImpl(_IntVarImpl):
     This class represents Boolean decision variables that can take values True/False.
     It should not be instantiated directly, but rather through the :func:`~cpmpy.expressions.variables.boolvar` helper function.
     """
+
     counter = 0
 
-    def __init__(self, lb:int=0, ub:int=1, name:Optional[str]=None):
-        assert(lb == 0 or lb == 1)
-        assert(ub == 0 or ub == 1)
+    def __init__(self, lb: int = 0, ub: int = 1, name: Optional[str] = None):
+        assert lb == 0 or lb == 1
+        assert ub == 0 or ub == 1
 
         if name is None:
             name = f"{_BV_PREFIX}{_BoolVarImpl.counter}"
-            _BoolVarImpl.counter = _BoolVarImpl.counter + 1 # static counter
+            _BoolVarImpl.counter = _BoolVarImpl.counter + 1  # static counter
         _IntVarImpl.__init__(self, lb, ub, name=name)
 
     def is_bool(self) -> bool:
-        """ is it a Boolean (return type) Operator?
-        """
+        """Is it a Boolean (return type) Operator?"""
         return True
 
     def __invert__(self) -> Expression:
@@ -426,23 +464,25 @@ class _BoolVarImpl(_IntVarImpl):
 
 class NegBoolView(_BoolVarImpl):
     """
-        Represents not(`var`), not an actual variable implementation!
+    Represents not(`var`), not an actual variable implementation!
 
-        It stores a link to `var`'s _BoolVarImpl
+    It stores a link to `var`'s _BoolVarImpl
 
-        Do not create this object directly, use the `~` operator instead: `~bv`
+    Do not create this object directly, use the `~` operator instead: `~bv`
     """
+
     def __init__(self, bv: _BoolVarImpl):
-        #assert(isinstance(bv, _BoolVarImpl))
+        # assert(isinstance(bv, _BoolVarImpl))
         self._bv = bv
         # as it is always created using the ~ operator (only available for _BoolVarImpl)
-        # it already comply with the asserts of the __init__ of _BoolVarImpl and can use 
+        # it already comply with the asserts of the __init__ of _BoolVarImpl and can use
         # __init__ from _IntVarImpl
-        _IntVarImpl.__init__(self, 1-bv.ub, 1-bv.lb, name=str(self))
+        _IntVarImpl.__init__(self, 1 - bv.ub, 1 - bv.lb, name=str(self))
 
     def value(self) -> Optional[bool]:
-        """ the negation of the value obtained in the last solve call by the viewed variable
-            (or 'None')
+        """
+        The negation of the value obtained in the last solve call by the viewed variable
+        (or 'None')
         """
         v = self._bv.value()
         if v is None:
@@ -450,8 +490,7 @@ class NegBoolView(_BoolVarImpl):
         return not v
 
     def clear(self) -> None:
-        """ clear, for the viewed variable, the value obtained from the last solve call
-        """
+        """clear, for the viewed variable, the value obtained from the last solve call"""
         self._bv.clear()
 
     def __repr__(self) -> str:
@@ -469,9 +508,14 @@ class NDVarArray(np.ndarray):
 
     ``_has_subexpr`` caches :meth:`has_subexpr` (``None`` = not computed yet; ``True`` / ``False`` = cached).
     """
-    _has_subexpr: Optional[bool] = None  # will be overwritten in instance, here for type hinting
 
-    def __init__(self, shape: int|np.integer|tuple[int|np.integer, ...], **kwargs: Any) -> None:
+    _has_subexpr: Optional[bool] = (
+        None  # will be overwritten in instance, here for type hinting
+    )
+
+    def __init__(
+        self, shape: int | np.integer | tuple[int | np.integer, ...], **kwargs: Any
+    ) -> None:
         # bit ugly, but np.int and np.bool do not play well with > overloading
         if np.issubdtype(self.dtype, np.integer):
             self.astype(int)
@@ -496,18 +540,20 @@ class NDVarArray(np.ndarray):
         return False
 
     def value(self) -> np.ndarray:
-        """ the values, for each of the stored variables, obtained in the last solve call
-            (or 'None')
+        """
+        The values, for each of the stored variables, obtained in the last solve call
+        (or 'None')
         """
         return np.reshape([x.value() for x in self], self.shape)
 
     def clear(self) -> None:
-        """ clear, for each of the stored variables, the value obtained from the last solve call
-        """
+        """clear, for each of the stored variables, the value obtained from the last solve call"""
         for e in self.flat:
             e.clear()
 
-    def __getitem__(self, index):  # TODO: any typing would have to be compatible with supertype "numpy.ndarray"
+    def __getitem__(
+        self, index
+    ):  # TODO: any typing would have to be compatible with supertype "numpy.ndarray"
         # array access, check if variables are used in the indexing
 
         # index is single expression: direct element
@@ -516,28 +562,32 @@ class NDVarArray(np.ndarray):
 
         # multi-dimensional index
         if isinstance(index, tuple) and any(isinstance(el, Expression) for el in index):
-
             if len(index) != self.ndim:
-                raise NotImplementedError("CPMpy does not support returning an array from an Element constraint. Provide an index for each dimension. If you really need this, please report on github.")
+                raise NotImplementedError(
+                    "CPMpy does not support returning an array from an Element constraint. Provide an index for each dimension. If you really need this, please report on github."
+                )
 
             # find dimension of expression in index
-            expr_dim = [dim for dim,idx in enumerate(index) if isinstance(idx, Expression)]
-            if len(expr_dim) == 1: # optimization, only 1 expression, reshape to 1d-element
+            expr_dim = [
+                dim for dim, idx in enumerate(index) if isinstance(idx, Expression)
+            ]
+            if (
+                len(expr_dim) == 1
+            ):  # optimization, only 1 expression, reshape to 1d-element
                 # TODO can we do the same for more than one Expression? Not sure...
-                index  = list(index)
+                index = list(index)
                 index += [index.pop(expr_dim[0])]
 
                 arr = np.moveaxis(self, expr_dim[0], -1)
                 return cp.Element(arr[(*index[:-1],)], index[-1])
 
-
-            arr = self[tuple(index[:expr_dim[0]])] # select remaining dimensions
-            index = index[expr_dim[0]:]
+            arr = self[tuple(index[: expr_dim[0]])]  # select remaining dimensions
+            index = index[expr_dim[0] :]
 
             # calculate index for flat array
             flat_index = index[-1]
             for dim, idx in enumerate(index[:-1]):
-                flat_index += idx * math.prod(arr.shape[dim+1:])
+                flat_index += idx * math.prod(arr.shape[dim + 1 :])
             # using index expression as single var for flat array
             return cp.Element(arr.flatten(), flat_index)
 
@@ -546,13 +596,16 @@ class NDVarArray(np.ndarray):
     """
     make the given array the first dimension in the returned array
     """
+
     def __axis(self, axis):
 
         arr = self
 
         # correct type and value checks
-        if not isinstance(axis,int):
-            raise TypeError("Axis keyword argument in .sum() should always be an integer")
+        if not isinstance(axis, int):
+            raise TypeError(
+                "Axis keyword argument in .sum() should always be an integer"
+            )
         if axis >= arr.ndim:
             raise ValueError("Axis out of range")
 
@@ -569,24 +622,17 @@ class NDVarArray(np.ndarray):
         return arr
 
     def sum(self, axis=None, out=None):
-        """
-            overwrite np.sum(NDVarArray) as people might use it
-        """
-
+        """Overwrite np.sum(NDVarArray) as people might use it"""
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the sum over the whole array
+        if axis is None:  # simple case where we want the sum over the whole array
             return cp.sum(self)
 
         return cpm_array(np.apply_along_axis(cp.sum, axis=axis, arr=self))
 
-
     def prod(self, axis=None, out=None):
-        """
-            overwrite np.prod(NDVarArray) as people might use it
-        """
-
+        """Overwrite np.prod(NDVarArray) as people might use it"""
         if out is not None:
             raise NotImplementedError()
 
@@ -597,51 +643,46 @@ class NDVarArray(np.ndarray):
         return cpm_array(np.multiply.reduce(self, axis=axis))
 
     def max(self, axis=None, out=None):
-        """
-            overwrite np.max(NDVarArray) as people might use it
-        """
+        """Overwrite np.max(NDVarArray) as people might use it"""
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the maximum over the whole array
+        if axis is None:  # simple case where we want the maximum over the whole array
             return cp.max(self)
 
         return cpm_array(np.apply_along_axis(cp.max, axis=axis, arr=self))
 
     def min(self, axis=None, out=None):
-        """
-            overwrite np.min(NDVarArray) as people might use it
-        """
+        """Overwrite np.min(NDVarArray) as people might use it"""
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want the minimum over the whole array
+        if axis is None:  # simple case where we want the minimum over the whole array
             return cp.min(self)
 
         return cpm_array(np.apply_along_axis(cp.min, axis=axis, arr=self))
 
     def any(self, axis=None, out=None):
-        """
-            overwrite np.any(NDVarArray)
-        """
+        """Overwrite np.any(NDVarArray)"""
         if any(not is_boolexpr(x) for x in self.flat):
-            raise TypeError("Cannot call .any() in an array not consisting only of bools")
+            raise TypeError(
+                "Cannot call .any() in an array not consisting only of bools"
+            )
 
         if out is not None:
             raise NotImplementedError()
 
-        if axis is None:    # simple case where we want a disjunction over the whole array
+        if axis is None:  # simple case where we want a disjunction over the whole array
             return cp.any(self)
 
         return cpm_array(np.apply_along_axis(cp.any, axis=axis, arr=self))
 
-
     def all(self, axis=None, out=None):
-        """
-            overwrite np.any(NDVarArray)
-        """
+        """Overwrite np.any(NDVarArray)"""
         if any(not is_boolexpr(x) for x in self.flat):
-            raise TypeError("Cannot call .any() in an array not consisting only of bools")
+            raise TypeError(
+                "Cannot call .any() in an array not consisting only of bools"
+            )
 
         if out is not None:
             raise NotImplementedError()
@@ -652,16 +693,17 @@ class NDVarArray(np.ndarray):
         return cpm_array(np.apply_along_axis(cp.all, axis=axis, arr=self))
 
     def get_bounds(self) -> tuple[np.ndarray, np.ndarray]:
-        if self.size == 0:  # believe it or not, this does happen... e.g. in test_int2bool and an exmaple
+        if (
+            self.size == 0
+        ):  # believe it or not, this does happen... e.g. in test_int2bool and an exmaple
             z = np.empty(self.shape, dtype=np.int64)
             return z, z
 
         lbs, ubs = zip(*[get_bounds(e) for e in self.flat])
-        return np.asarray(lbs).reshape(self.shape), \
-               np.asarray(ubs).reshape(self.shape)
+        return np.asarray(lbs).reshape(self.shape), np.asarray(ubs).reshape(self.shape)
 
     # VECTORIZED master function (delegate)
-    def _vectorized(self, other: ExprLike|Iterable|Any, attr: str) -> NDVarArray:
+    def _vectorized(self, other: ExprLike | Iterable | Any, attr: str) -> NDVarArray:
         """
         Vectorized implementation of the given attribute (e.g. __eq__, __add__, etc.)
 
@@ -672,31 +714,32 @@ class NDVarArray(np.ndarray):
 
         Returns:
             NDVarArray: The vectorized result.
+
         """
         if not isinstance(other, Iterable):
-            other = [other]*len(self)
+            other = [other] * len(self)
         # this is a bit cryptic, but it calls 'attr' on s with o as arg
         # s.__eq__(o) <-> getattr(s, '__eq__')(o)
-        return cpm_array([getattr(s,attr)(o) for s,o in zip(self, other)])
+        return cpm_array([getattr(s, attr)(o) for s, o in zip(self, other)])
 
     # VECTORIZED comparisons
     def __eq__(self, other):
-        return self._vectorized(other, '__eq__')
+        return self._vectorized(other, "__eq__")
 
     def __ne__(self, other):
-        return self._vectorized(other, '__ne__')
+        return self._vectorized(other, "__ne__")
 
     def __lt__(self, other):
-        return self._vectorized(other, '__lt__')
+        return self._vectorized(other, "__lt__")
 
     def __le__(self, other):
-        return self._vectorized(other, '__le__')
+        return self._vectorized(other, "__le__")
 
     def __gt__(self, other):
-        return self._vectorized(other, '__gt__')
+        return self._vectorized(other, "__gt__")
 
     def __ge__(self, other):
-        return self._vectorized(other, '__ge__')
+        return self._vectorized(other, "__ge__")
 
     # VECTORIZED math operators
     # only 'abs' 'neg' and binary ones
@@ -708,85 +751,86 @@ class NDVarArray(np.ndarray):
         return cpm_array([-s for s in self])
 
     def __add__(self, other):
-        return self._vectorized(other, '__add__')
+        return self._vectorized(other, "__add__")
 
     def __radd__(self, other):
-        return self._vectorized(other, '__radd__')
+        return self._vectorized(other, "__radd__")
 
     def __sub__(self, other):
-        return self._vectorized(other, '__sub__')
+        return self._vectorized(other, "__sub__")
 
     def __rsub__(self, other):
-        return self._vectorized(other, '__rsub__')
+        return self._vectorized(other, "__rsub__")
 
     def __mul__(self, other):
-        return self._vectorized(other, '__mul__')
+        return self._vectorized(other, "__mul__")
 
     def __rmul__(self, other):
-        return self._vectorized(other, '__rmul__')
+        return self._vectorized(other, "__rmul__")
 
     def __truediv__(self, other):
-        return self._vectorized(other, '__truediv__')
+        return self._vectorized(other, "__truediv__")
 
     def __rtruediv__(self, other):
-        return self._vectorized(other, '__rtruediv__')
+        return self._vectorized(other, "__rtruediv__")
 
     def __floordiv__(self, other):
-        return self._vectorized(other, '__floordiv__')
+        return self._vectorized(other, "__floordiv__")
 
     def __rfloordiv__(self, other):
-        return self._vectorized(other, '__rfloordiv__')
+        return self._vectorized(other, "__rfloordiv__")
 
     def __mod__(self, other):
-        return self._vectorized(other, '__mod__')
+        return self._vectorized(other, "__mod__")
 
     def __rmod__(self, other):
-        return self._vectorized(other, '__rmod__')
+        return self._vectorized(other, "__rmod__")
 
     def __pow__(self, other, modulo=None):
-        assert (modulo is None), "Power operator: modulo not supported"
-        return self._vectorized(other, '__pow__')
+        assert modulo is None, "Power operator: modulo not supported"
+        return self._vectorized(other, "__pow__")
 
     def __rpow__(self, other, modulo=None):
-        assert (modulo is None), "Power operator: modulo not supported"
-        return self._vectorized(other, '__rpow__')
+        assert modulo is None, "Power operator: modulo not supported"
+        return self._vectorized(other, "__rpow__")
 
     # VECTORIZED Bool operators
     def __invert__(self):
         return cpm_array([~s for s in self])
 
     def __and__(self, other):
-        return self._vectorized(other, '__and__')
+        return self._vectorized(other, "__and__")
 
     def __rand__(self, other):
-        return self._vectorized(other, '__rand__')
+        return self._vectorized(other, "__rand__")
 
     def __or__(self, other):
-        return self._vectorized(other, '__or__')
+        return self._vectorized(other, "__or__")
 
     def __ror__(self, other):
-        return self._vectorized(other, '__ror__')
+        return self._vectorized(other, "__ror__")
 
     def __xor__(self, other):
-        return self._vectorized(other, '__xor__')
+        return self._vectorized(other, "__xor__")
 
     def __rxor__(self, other):
-        return self._vectorized(other, '__rxor__')
+        return self._vectorized(other, "__rxor__")
 
     def implies(self, other):
-        return self._vectorized(other, 'implies')
+        return self._vectorized(other, "implies")
 
-    #in	  __contains__(self, value) 	Check membership
+    # in	  __contains__(self, value) 	Check membership
     # CANNOT meaningfully overwrite, python always returns True/False
     # regardless of what you return in the __contains__ function
 
     # TODO?
-    #object.__matmul__(self, other)
+    # object.__matmul__(self, other)
 
 
-def _gen_var_names(name: Optional[str|ListLike[str]],
-                   shape: int|np.integer|tuple[int|np.integer, ...]
-                  ) -> list[Optional[str]]:
+def _gen_var_names(
+    name: Optional[str | ListLike[str]],
+    shape: int | np.integer | tuple[int | np.integer, ...],
+) -> list[Optional[str]]:
     """
     Helper function to collect the name of all decision variables (in np.ndindex(shape) order)
 
@@ -801,7 +845,9 @@ def _gen_var_names(name: Optional[str|ListLike[str]],
         if isinstance(shape, int):
             shape = (shape,)
         if name_arr.shape != shape:
-            raise ValueError(f"The shape of name sequence {name_arr.shape} does not match {shape}.")
+            raise ValueError(
+                f"The shape of name sequence {name_arr.shape} does not match {shape}."
+            )
         if len(name_arr.flat) != len(np.unique(name_arr)):
             raise ValueError(f"Duplicated names in {name_arr}.")
         if any(_is_invalid_name(n) for n in name_arr.flat):
@@ -811,7 +857,10 @@ def _gen_var_names(name: Optional[str|ListLike[str]],
     else:
         raise TypeError(f"Unsupported type for name: {type(name)}")
 
-def _genname(basename: Optional[str], idxs: tuple[int|np.integer, ...]) -> Optional[str]:
+
+def _genname(
+    basename: Optional[str], idxs: tuple[int | np.integer, ...]
+) -> Optional[str]:
     """
     Helper function to 'name' array variables
     - idxs: list of indices, one for every dimension of the array
@@ -826,11 +875,11 @@ def _genname(basename: Optional[str], idxs: tuple[int|np.integer, ...]) -> Optio
     if _is_invalid_name(basename):
         raise ValueError(_VAR_ERR)
     stridxs = ",".join(map(str, idxs))
-    return f"{basename}[{stridxs}]" # "<name>[<idx0>,<idx1>,...]"
+    return f"{basename}[{stridxs}]"  # "<name>[<idx0>,<idx1>,...]"
+
 
 def _is_invalid_name(name: Any) -> bool:
     if isinstance(name, str):
         return name.startswith(_IV_PREFIX) or name.startswith(_BV_PREFIX)
     # rest invalid indeed
     return True
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,24 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff.lint]
+select = [
+    "D", # pydocstyle
+    "F", # pyflakes
+]
+ignore = [
+    "E501", # Allow for lines beyond line-length
+    "D105", # Missing doc for magic methods
+    "D102", # Missing doc for public method
+    "D103", # Missing docstring in public function
+    "D107", # Missing docstring in __init_
+    "D400", # Allow missing punctuation
+    "D401", # Allow non-impereative mood of docstring
+    "D203", # Ignore
+    "D205", # 1 Blank line required between summary line and description
+    "D415", # Allow missing punctuation in doc
+    "D211", # Allow incorrect blank lines before class
+    "D212", # multi-line-summary-second-line
+    "TD003", # Allow missing issue links for TODO
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,5 @@ ignore = [
     "D211", # Allow incorrect blank lines before class
     "D212", # multi-line-summary-second-line
     "TD003", # Allow missing issue links for TODO
+    "F401", # allow to unused imports in `__init__.py` files -- not sure if we want to keep this
 ]


### PR DESCRIPTION
As discussed offline, I played around with `ruff` a little bit.
You can go very far in configuring its rules, some are quite pedantic imho...

This is just a PR to show how our `expressions/` folder could look like if we were to add autoformatting.
I've enabled the recommended doc-styles and standard pyflakes code formatting, but enabled some rules of it as they were too incompatible with the current code base...

If we decide to go with autoformatting, there is also the question on how to integrate it continuously... Formatting the entire code base at once will destroy our git history, but after chatting with a friend, they suggested me a few options:
1. Only format changed files when pushing new changes
2. Only format changed lines (with git diff) when pushing new changes -- can cause some weirdness as ruff often needs more context for proper formatting
3. Do a big formatting commit, but ignore it in the git blame history ```git config blame.ignoreRevsFile .git-blame-ignore-revs```

We can also setup the autoformatting in the CI of course so we don't all have to do it locally.