### PR TITLE
Custom and typed CSEMap object

### DIFF
--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -27,6 +27,7 @@ from enum import Enum
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, ListLike
 from ..expressions.variables import _NumVarImpl
+from ..transformations.cse import CSEMap
 from ..transformations.get_variables import get_variables
 from ..expressions.utils import is_any_list, argvals
 from ..expressions.python_builtins import any
@@ -87,7 +88,7 @@ class SolverInterface(object):
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
         self._varmap = dict()  # maps cpmpy variables to native solver variables
-        self._csemap = dict()  # maps cpmpy expressions to solver expressions
+        self._csemap = CSEMap()  # maps cpmpy expressions to solver expressions
 
         # rest uses own API
         if cpm_model is not None:

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -88,7 +88,7 @@ class SolverInterface(object):
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
         self._varmap = dict()  # maps cpmpy variables to native solver variables
-        self._csemap = CSEMap()  # maps cpmpy expressions to solver expressions
+        self._csemap = CSEMap()  # maps cpmpy expressions to auxiliary variables
 
         # rest uses own API
         if cpm_model is not None:

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -88,7 +88,7 @@ class SolverInterface(object):
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
         self._varmap = dict()  # maps cpmpy variables to native solver variables
-        self._csemap = CSEMap()  # maps cpmpy expressions to auxiliary variables
+        self._csemap = CSEMap()  # maps cpmpy expressions to previously created expressions (typically auxiliary variables)
 
         # rest uses own API
         if cpm_model is not None:

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -5,8 +5,10 @@ from ..expressions.variables import boolvar, intvar, _IntVarImpl
 
 
 class CSEMap:
-    csemap = dict[Expression, _IntVarImpl]()
-    decomp_map = dict[Expression, Expression]()
+
+    def __init__(self):
+        self.csemap = dict[Expression, _IntVarImpl]()
+        self.decomp_map = dict[Expression, Expression]()
 
     # pass special methods to internal csemap
     def __len__(self):

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -4,13 +4,13 @@ from ..expressions.utils import is_int
 from ..expressions.variables import boolvar, intvar, _IntVarImpl
 
 
-class CSEMap:
+class flat_map:
 
     def __init__(self):
         self.flat_map = dict[Expression, _IntVarImpl]()   # map expression to variable filled during flattening
         self.decomp_map = dict[Expression, Expression]()  # map global constraint/function to its decomposition
 
-    # pass special methods to internal csemap
+    # pass special methods to internal flat_map
     def __len__(self):
         return len(self.flat_map)
 
@@ -18,7 +18,7 @@ class CSEMap:
         return self.flat_map[expr]
 
     def __setitem__(self, attr, val):
-        raise ValueError("__setitem__ is not supported for csemap, use get_or_make_var instead")
+        raise ValueError("__setitem__ is not supported for flat_map, use get_or_make_var instead")
 
     def get(self, expr: Expression) -> Optional[_IntVarImpl]:
         try:
@@ -35,7 +35,7 @@ class CSEMap:
         return self.decomp_map.get(expr)
 
     def get_reified_predicates(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
-        """collect all bv <-> var == val expressions in csemap"""
+        """collect all bv <-> var == val expressions in flat_map"""
         
         var_vals = dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]()  # var: [val, bv]
         for expr, bv in self.flat_map.items():
@@ -49,14 +49,14 @@ class CSEMap:
     def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, Optional[Expression]]:
         """
         Make an auxiliary variable for the given expression
-        
+
         Arguments:
             expr: Expression to make an auxiliary variable for
 
         Returns:
             tuple[_IntVarImpl, Optional[Expression]]: (variable, equality constraint)
             - variable: the auxiliary variable for the expression
-            - equality constraint: the equality constraint between the expression and the variable, or None if the expression is already in the csemap
+            - equality constraint: the equality constraint between the expression and the variable, or None if the expression is already in the flat_map
         """
 
         if isinstance(expr, _IntVarImpl):

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -7,22 +7,22 @@ from ..expressions.variables import boolvar, intvar, _IntVarImpl
 class CSEMap:
 
     def __init__(self):
-        self.csemap = dict[Expression, _IntVarImpl]()
-        self.decomp_map = dict[Expression, Expression]()
+        self.flat_map = dict[Expression, _IntVarImpl]()   # map expression to variable filled during flattening
+        self.decomp_map = dict[Expression, Expression]()  # map global constraint/function to its decomposition
 
     # pass special methods to internal csemap
     def __len__(self):
-        return len(self.csemap)
+        return len(self.flat_map)
 
     def __getitem__(self, expr: Expression) -> _IntVarImpl:
-        return self.csemap[expr]
+        return self.flat_map[expr]
 
     def __setitem__(self, attr, val):
         raise ValueError("__setitem__ is not supported for csemap, use get_or_make_var instead")
 
     def get(self, expr: Expression) -> Optional[_IntVarImpl]:
         try:
-            return self.csemap[expr]
+            return self.flat_map[expr]
         except KeyError:
             return None
 
@@ -34,10 +34,11 @@ class CSEMap:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr)
 
-    def get_reified_equalities(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
+    def get_reified_predicates(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
         """collect all bv <-> var == val expressions in csemap"""
+        
         var_vals = dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]()  # var: [val, bv]
-        for expr, bv in self.csemap.items():
+        for expr, bv in self.flat_map.items():
             if expr.name == "==":
                 var, val = expr.args
                 if isinstance(var, _IntVarImpl) and is_int(val):
@@ -50,14 +51,14 @@ class CSEMap:
         if isinstance(expr, _IntVarImpl):
             return expr, []
 
-        if expr in self.csemap:
-            return self.csemap[expr], []
+        if expr in self.flat_map:
+            return self.flat_map[expr], []
 
         elif expr.is_bool():
             bv = boolvar()
-            self.csemap[expr] = bv
+            self.flat_map[expr] = bv
             return bv, [Comparison("==", expr, bv)]
         else:
             iv = intvar(*expr.get_bounds())
-            self.csemap[expr] = iv
+            self.flat_map[expr] = iv
             return iv, [Comparison("==", expr, iv)]

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Optional, Any, overload, Literal
 from ..expressions.core import Expression, Comparison
 from ..expressions.utils import is_int
 from ..expressions.variables import boolvar, intvar, _IntVarImpl, _BoolVarImpl
@@ -20,6 +20,12 @@ class CSEMap:
     def __setitem__(self, attr, val):
         raise ValueError("__setitem__ is not supported for flat_map, use get_or_make_var instead")
 
+    @overload
+    def get(self, expr: Expression) -> Optional[_IntVarImpl]: ...
+    @overload
+    def get(self, expr: Expression, default: Literal[None]) -> Optional[_IntVarImpl]: ...
+    @overload
+    def get(self, expr: Expression, default: Any) -> Any: ...
     def get(self, expr: Expression, default: Any = None) -> Any:
         return self.flat_map.get(expr, default)
 
@@ -27,9 +33,15 @@ class CSEMap:
         """Save the decomposition of the given global constraint or global function."""
         self.decomp_map[expr] = newexpr
 
-    def get_decomposition(self, expr: Expression) -> Optional[Expression]:
+    @overload   
+    def get_decomposition(self, expr: Expression) -> Optional[Expression]: ...
+    @overload
+    def get_decomposition(self, expr: Expression, default: Literal[None]) -> Optional[Expression]: ...
+    @overload
+    def get_decomposition(self, expr: Expression, default: Any) -> Any: ...
+    def get_decomposition(self, expr: Expression, default: Any = None) -> Any:
         """Get the decomposition of the given global constraint or global function."""
-        return self.decomp_map.get(expr)
+        return self.decomp_map.get(expr, default)
 
     def get_reified_varvals(self) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
         """collect all bv <-> var == val expressions in flat_map"""

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -46,19 +46,30 @@ class CSEMap:
 
         return var_vals
 
-    def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, list[Expression]]:
+    def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, Optional[Expression]]:
+        """
+        Make an auxiliary variable for the given expression
+        
+        Arguments:
+            expr: Expression to make an auxiliary variable for
+
+        Returns:
+            tuple[_IntVarImpl, Optional[Expression]]: (variable, equality constraint)
+            - variable: the auxiliary variable for the expression
+            - equality constraint: the equality constraint between the expression and the variable, or None if the expression is already in the csemap
+        """
 
         if isinstance(expr, _IntVarImpl):
-            return expr, []
+            return expr, None
 
         if expr in self.flat_map:
-            return self.flat_map[expr], []
+            return self.flat_map[expr], None
 
         elif expr.is_bool():
             bv = boolvar()
             self.flat_map[expr] = bv
-            return bv, [Comparison("==", expr, bv)]
+            return bv, Comparison("==", expr, bv)
         else:
             iv = intvar(*expr.get_bounds())
             self.flat_map[expr] = iv
-            return iv, [Comparison("==", expr, iv)]
+            return iv, Comparison("==", expr, iv)

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -1,0 +1,61 @@
+from typing import Optional
+from ..expressions.core import Expression, Comparison
+from ..expressions.utils import is_int
+from ..expressions.variables import boolvar, intvar, _IntVarImpl
+
+
+class CSEMap:
+    csemap = dict[Expression, _IntVarImpl]()
+    decomp_map = dict[Expression, Expression]()
+
+    # pass special methods to internal csemap
+    def __len__(self):
+        return len(self.csemap)
+
+    def __getitem__(self, expr: Expression) -> _IntVarImpl:
+        return self.csemap[expr]
+
+    def __setitem__(self, attr, val):
+        raise ValueError("__setitem__ is not supported for csemap, use get_or_make_var instead")
+
+    def get(self, expr: Expression) -> Optional[_IntVarImpl]:
+        try:
+            return self.csemap[expr]
+        except KeyError:
+            return None
+
+    def save_decomposition(self, expr: Expression, newexpr: Expression):
+        """Save the decomposition of the given global constraint or global function."""
+        self.decomp_map[expr] = newexpr
+
+    def get_decomposition(self, expr: Expression) -> Optional[Expression]:
+        """Get the decomposition of the given global constraint or global function."""
+        return self.decomp_map.get(expr)
+
+    def get_reified_equalities(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
+        """collect all bv <-> var == val expressions in csemap"""
+        var_vals = dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]()  # var: [val, bv]
+        for expr, bv in self.csemap.items():
+            if expr.name == "==":
+                var, val = expr.args
+                if isinstance(var, _IntVarImpl) and is_int(val):
+                    var_vals.setdefault(var, []).append((val, bv))
+
+        return var_vals
+
+    def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, list[Expression]]:
+
+        if isinstance(expr, _IntVarImpl):
+            return expr, []
+
+        if expr in self.csemap:
+            return self.csemap[expr], []
+
+        elif expr.is_bool():
+            bv = boolvar()
+            self.csemap[expr] = bv
+            return bv, [Comparison("==", expr, bv)]
+        else:
+            iv = intvar(*expr.get_bounds())
+            self.csemap[expr] = iv
+            return iv, [Comparison("==", expr, iv)]

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -4,7 +4,7 @@ from ..expressions.utils import is_int
 from ..expressions.variables import boolvar, intvar, _IntVarImpl
 
 
-class flat_map:
+class CSEMap:
 
     def __init__(self):
         self.flat_map = dict[Expression, _IntVarImpl]()   # map expression to variable filled during flattening
@@ -34,7 +34,7 @@ class flat_map:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr)
 
-    def get_reified_predicates(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
+    def get_reified_varvals(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
         """collect all bv <-> var == val expressions in flat_map"""
         
         var_vals = dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]()  # var: [val, bv]

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -1,7 +1,7 @@
-from typing import Optional
+from typing import Optional, Any
 from ..expressions.core import Expression, Comparison
 from ..expressions.utils import is_int
-from ..expressions.variables import boolvar, intvar, _IntVarImpl
+from ..expressions.variables import boolvar, intvar, _IntVarImpl, _BoolVarImpl
 
 
 class CSEMap:
@@ -20,11 +20,8 @@ class CSEMap:
     def __setitem__(self, attr, val):
         raise ValueError("__setitem__ is not supported for flat_map, use get_or_make_var instead")
 
-    def get(self, expr: Expression) -> Optional[_IntVarImpl]:
-        try:
-            return self.flat_map[expr]
-        except KeyError:
-            return None
+    def get(self, expr: Expression, default: Any = None) -> Any:
+        return self.flat_map.get(expr, default)
 
     def save_decomposition(self, expr: Expression, newexpr: Expression):
         """Save the decomposition of the given global constraint or global function."""
@@ -34,10 +31,10 @@ class CSEMap:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr)
 
-    def get_reified_varvals(self) -> dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]:
+    def get_reified_varvals(self) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
         """collect all bv <-> var == val expressions in flat_map"""
         
-        var_vals = dict[_IntVarImpl, list[tuple[int, _IntVarImpl]]]()  # var: [val, bv]
+        var_vals = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var: [val, bv]
         for expr, bv in self.flat_map.items():
             if expr.name == "==":
                 var, val = expr.args

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -212,8 +212,6 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
 
                         if (csemap is not None):
                             csemap.save_decomposition(expr, newexpr)
-                    elif isinstance(decomp, list): # retrieved list of expr from cache above
-                            newexpr = cpm_all(decomp)
                     else: # retrieved expr from cache above
                         newexpr = decomp
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -22,6 +22,7 @@ import copy
 from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
 import numpy as np
 
+from .cse import CSEMap
 from ..expressions.core import Expression, ListLike
 from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
@@ -34,7 +35,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       supported: Optional[AbstractSet[str]] = None,
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
-                      csemap = None,
+                      csemap: Optional[CSEMap] = None,
                       decompose_custom: Optional[Dict[str, Callable]] = None) -> List[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
@@ -81,7 +82,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 def decompose_objective(expr: Expression,
                         supported: Optional[AbstractSet[str]] = None,
                         supported_reified: Optional[AbstractSet[str]] = None,
-                        csemap: Optional[Dict[Expression, Expression]] = None,
+                        csemap: Optional[CSEMap] = None,
                         decompose_custom: Optional[Dict[str, Callable]]=None) -> Tuple[Expression, List[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver
@@ -121,7 +122,7 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
                        supported: AbstractSet[str],
                        supported_reified: AbstractSet[str],
                        is_toplevel: bool,
-                       csemap: Optional[Dict[Expression, Expression]]=None,
+                       csemap: Optional[CSEMap]=None,
                        decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Expression], List[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver, recursive internal version.

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -23,6 +23,8 @@ from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
 import numpy as np
 
 from ..expressions.core import Expression, ListLike
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray
 from ..expressions.utils import is_any_list
 from ..expressions.python_builtins import all as cpm_all
@@ -32,7 +34,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       supported: Optional[AbstractSet[str]] = None,
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
-                      csemap: Optional[Dict[Expression, Expression]] = None,
+                      csemap = None,
                       decompose_custom: Optional[Dict[str, Callable]] = None) -> List[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
@@ -171,40 +173,48 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
                     toplevel.extend(rec_toplevel)
                     changed = True
 
-            if hasattr(expr, "decompose"):  # it is a global function or global constraint
+            if isinstance(expr, (GlobalConstraint, GlobalFunction)):  # it is a global function or global constraint
                 is_supported = expr.name in supported
                 if not is_toplevel and expr.is_bool():
                     # argument to another expression, only possible if supported reified
                     is_supported = expr.name in supported_reified
 
                 if is_supported is False:
-                    if (csemap is not None) and expr in csemap:
-                        # we might have already decomposed it previously
-                        newexpr = csemap[expr]
-                    else:
+
+                    decomp: Optional[Expression | list[Expression]] = None # global constraints return list, global functions return expr
+
+                    if (csemap is not None):
+                        decomp = csemap.get_decomposition(expr)
+                    if decomp is None:
                         if decompose_custom is not None and expr.name in decompose_custom:
-                            newexpr, define = decompose_custom[expr.name](expr)
+                            decomp, define = decompose_custom[expr.name](expr)
                         else:
-                            newexpr, define = expr.decompose()
+                            decomp, define = expr.decompose()
                         toplevel.extend(define)
 
                         # decomposed constraints may introduce new globals
-                        if isinstance(newexpr, list):  # globals return a list instead of a single expression (TODO: change?)
-                            rec_changed, rec_newexpr, rec_toplevel = _decompose_in_tree(newexpr, supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
+                        if isinstance(decomp, list):  # globals return a list instead of a single expression (TODO: change?)
+                            rec_changed, rec_newexpr, rec_toplevel = _decompose_in_tree(decomp, supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
                             if rec_changed:
                                 newexpr_lst = rec_newexpr
                                 toplevel.extend(rec_toplevel)
                             else:
-                                newexpr_lst = newexpr  # for mypy
+                                newexpr_lst = decomp  # for mypy
                             newexpr = cpm_all(newexpr_lst)  # make the list a single expression
                         else:
-                            rec_changed, rec_lst_newexpr, rec_toplevel = _decompose_in_tree((newexpr,), supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
+                            rec_changed, rec_lst_newexpr, rec_toplevel = _decompose_in_tree((decomp,), supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
                             if rec_changed:
                                 newexpr = rec_lst_newexpr[0]
                                 toplevel.extend(rec_toplevel)
+                            else:
+                                newexpr = decomp
 
                         if (csemap is not None):
-                            csemap[expr] = newexpr
+                            csemap.save_decomposition(expr, newexpr)
+                    elif isinstance(decomp, list): # retrieved list of expr from cache above
+                            newexpr = cpm_all(decomp)
+                    else: # retrieved expr from cache above
+                        newexpr = decomp
 
                     newlist.append(newexpr)
                     changed = True

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -92,8 +92,8 @@ import copy
 import math
 import builtins
 import cpmpy as cp
-from .cse import CSEMap
 
+from .cse import CSEMap
 from .normalize import toplevel_list, simplify_boolean
 from ..expressions.core import Expression, Comparison, Operator
 from ..expressions.core import _wsum_should, _wsum_make

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -336,41 +336,32 @@ def get_or_make_var(expr, csemap=None):
     if is_any_list(expr):
         raise Exception(f"Expected single variable, not a list for: {expr}")
 
-    if csemap is not None and expr in csemap:
-        return csemap[expr], []
+    new_var = None
+    if (csemap is not None):
+        new_var = csemap.get(expr)
+    if new_var is not None:
+        return (new_var, [])
 
+    # need to recursively flatten new_cons
     if expr.is_bool():
-        # normalize expr into a boolexpr LHS, reify LHS == bvar
-        (flatexpr, flatcons) = normalized_boolexpr(expr, csemap=csemap)
-
-        if isinstance(flatexpr,_BoolVarImpl):
+        flatexpr, flatcons = normalized_boolexpr(expr, csemap=csemap)
+        if isinstance(flatexpr, _BoolVarImpl):
             # avoids unnecessary bv == bv or bv == ~bv assignments
-            return flatexpr,flatcons
-        bvar = _BoolVarImpl()
-
-        # save expr in dict
-        if csemap is not None:
-            csemap[expr] = bvar
-        return bvar, [flatexpr == bvar] + flatcons
-
+            return flatexpr, flatcons
     else:
-        # normalize expr into a numexpr LHS,
-        # then compute bounds and return (newintvar, LHS == newintvar)
-        (flatexpr, flatcons) = normalized_numexpr(expr, csemap=csemap)
+        flatexpr, flatcons = normalized_numexpr(expr, csemap=csemap)
 
-        lb, ub = flatexpr.get_bounds()
-        if not is_int(lb) or not is_int(ub):
-            warnings.warn(f"CPMpy only uses integer variables, but found expression ({expr}) with domain {lb}({type(lb)}"
-                          f" - {ub}({type(ub)}. CPMpy will rewrite this constriants with integer bounds instead.")
-            lb, ub = math.floor(lb), math.ceil(ub)
-        ivar = _IntVarImpl(lb, ub)
+    if csemap is None:
+        # this will have some overhead, but it nicely stores all logic in the csemap object
+        new_var, _new_cons = CSEMap().get_or_make_var(expr)
+    else:
+        new_var, _new_cons = csemap.get_or_make_var(expr)
 
-        # save expr in dict
-        if csemap is not None:
-            csemap[expr] = ivar
-        return ivar, [flatexpr == ivar] + flatcons
+    # TODO: this seems weird, we are dismissing the `new_var == expr` made by the csemap
+    #   can be fixed by doing the normalization in the main flatten loop instead of here
+    return new_var, [flatexpr == new_var] + flatcons
 
-def get_or_make_var_or_list(expr, csemap=None):
+def get_or_make_var_or_list(expr, csemap = None):
     """ Like get_or_make_var() but also accepts and recursively transforms lists
         Used to convert arguments of globals
     """

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -358,7 +358,7 @@ def get_or_make_var(expr, csemap=None):
         # save both original expression and flattened expression to the csemap
         # maybe the flattened expression is already in the map?
         new_var = csemap.get(flatexpr)
-        expr_eq_var = []
+        expr_eq_var = None
         if new_var is None: # it's not in the map
             new_var, expr_eq_var = csemap.get_or_make_var(flatexpr)
         if flatexpr is not expr: # avoid additional hash call if expr was flat already
@@ -366,9 +366,12 @@ def get_or_make_var(expr, csemap=None):
 
     else:
         # this will have some overhead, but it nicely stores all logic in the csemap object
-        new_var, expr_eq_var = CSEMap().get_or_make_var(flatexpr) # some ove
+        new_var, expr_eq_var = CSEMap().get_or_make_var(flatexpr)
 
-    return new_var, expr_eq_var + flatcons
+    if expr_eq_var is not None:
+        flatcons.append(expr_eq_var)
+
+    return new_var, flatcons
 
 def get_or_make_var_or_list(expr, csemap = None):
     """ Like get_or_make_var() but also accepts and recursively transforms lists

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -92,6 +92,7 @@ import copy
 import math
 import builtins
 import cpmpy as cp
+from .cse import CSEMap
 
 from .normalize import toplevel_list, simplify_boolean
 from ..expressions.core import Expression, Comparison, Operator

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -336,14 +336,16 @@ def get_or_make_var(expr, csemap=None):
 
     if is_any_list(expr):
         raise Exception(f"Expected single variable, not a list for: {expr}")
-
+    
+    # check if the expression is already in the csemap
     new_var = None
     if (csemap is not None):
         new_var = csemap.get(expr)
     if new_var is not None:
         return (new_var, [])
 
-    # need to recursively flatten new_cons
+    # expression is not in the csemap
+    # need to recursively flatten
     if expr.is_bool():
         flatexpr, flatcons = normalized_boolexpr(expr, csemap=csemap)
         if isinstance(flatexpr, _BoolVarImpl):
@@ -352,15 +354,21 @@ def get_or_make_var(expr, csemap=None):
     else:
         flatexpr, flatcons = normalized_numexpr(expr, csemap=csemap)
 
-    if csemap is None:
-        # this will have some overhead, but it nicely stores all logic in the csemap object
-        new_var, _new_cons = CSEMap().get_or_make_var(expr)
-    else:
-        new_var, _new_cons = csemap.get_or_make_var(expr)
+    if csemap is not None:
+        # save both original expression and flattened expression to the csemap
+        # maybe the flattened expression is already in the map?
+        new_var = csemap.get(flatexpr)
+        expr_eq_var = []
+        if new_var is None: # it's not in the map
+            new_var, expr_eq_var = csemap.get_or_make_var(flatexpr)
+        if flatexpr is not expr: # avoid additional hash call if expr was flat already
+            csemap.flat_map[expr] = new_var
 
-    # TODO: this seems weird, we are dismissing the `new_var == expr` made by the csemap
-    #   can be fixed by doing the normalization in the main flatten loop instead of here
-    return new_var, [flatexpr == new_var] + flatcons
+    else:
+        # this will have some overhead, but it nicely stores all logic in the csemap object
+        new_var, expr_eq_var = CSEMap().get_or_make_var(flatexpr) # some ove
+
+    return new_var, expr_eq_var + flatcons
 
 def get_or_make_var_or_list(expr, csemap = None):
     """ Like get_or_make_var() but also accepts and recursively transforms lists

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -354,7 +354,10 @@ def get_or_make_var(expr, csemap=None):
     else:
         flatexpr, flatcons = normalized_numexpr(expr, csemap=csemap)
 
-    if csemap is not None:
+    if csemap is None:
+        # this will have some overhead, but it nicely stores all logic in the csemap object
+        new_var, expr_eq_var = CSEMap().get_or_make_var(flatexpr)
+    else:
         # save both original expression and flattened expression to the csemap
         # maybe the flattened expression is already in the map?
         new_var = csemap.get(flatexpr)
@@ -364,9 +367,6 @@ def get_or_make_var(expr, csemap=None):
         if flatexpr is not expr: # avoid additional hash call if expr was flat already
             csemap.flat_map[expr] = new_var
 
-    else:
-        # this will have some overhead, but it nicely stores all logic in the csemap object
-        new_var, expr_eq_var = CSEMap().get_or_make_var(flatexpr)
 
     if expr_eq_var is not None:
         flatcons.append(expr_eq_var)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -645,7 +645,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     if csemap is None:
         return constraints
 
-    var_vals = csemap.get_reified_equalities()
+    var_vals = csemap.get_reified_predicates()
     
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -68,6 +68,7 @@ from typing import AbstractSet, Sequence, Optional
 
 import cpmpy as cp
 from cpmpy.transformations.get_variables import get_variables
+from .cse import CSEMap
 
 from .flatten_model import flatten_constraint, get_or_make_var
 from .decompose_global import decompose_in_tree, decompose_objective
@@ -576,7 +577,7 @@ def only_positive_coefficients(lst_of_expr):
 def decompose_linear(lst_of_expr: Sequence[Expression],
                      supported: Optional[AbstractSet[str]] = None,
                      supported_reified: Optional[AbstractSet[str]] = None,
-                     csemap: Optional[dict[Expression, Expression]] = None):
+                     csemap: Optional[CSEMap] = None):
     """
         Decompose unsupported global constraints in a linear-friendly way using (var == val) in sums.
 
@@ -601,7 +602,7 @@ def decompose_linear(lst_of_expr: Sequence[Expression],
 def decompose_linear_objective(obj: Expression,
                                supported: Optional[AbstractSet[str]] = None,
                                supported_reified: Optional[AbstractSet[str]] = None,
-                               csemap: Optional[dict[Expression, Expression]] = None):
+                               csemap: Optional[CSEMap] = None):
     """Decompose objective using linear-friendly (var == val) decompositions."""
     if supported is None:
         supported = frozenset[str]()

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -644,13 +644,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     if csemap is None:
         return constraints
 
-    # Collect bv -> (var == val)'s in csemap
-    var_vals = {}  # var: [val, bv]
-    for expr, bv in csemap.items():
-        if expr.name == '==':
-            var,val = expr.args
-            if isinstance(var, _NumVarImpl) and is_int(val):
-                var_vals.setdefault(var, []).append((val, bv))
+    var_vals = csemap.get_reified_equalities()
     
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -645,7 +645,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     if csemap is None:
         return constraints
 
-    var_vals = csemap.get_reified_predicates()
+    var_vals = csemap.get_reified_varvals()
     
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -97,7 +97,7 @@ class TestCSE:
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
 
         cons = cp.max([x,y,z]) <= 42
-        csemap = dict()
+        csemap = CSEMap()
         eq_cons = only_numexpr_equality([cons], csemap=csemap)
         
         assert set([str(c) for c in eq_cons]) == {"(max(x,y,z)) == (IV0)", "IV0 <= 42"}
@@ -114,7 +114,7 @@ class TestCSE:
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
         
         cons = cp.max(x,y) < z
-        csemap = dict()
+        csemap = CSEMap()
         lin_cons = linearize_constraint([cons], supported={"max"}, csemap=csemap)
         
         assert len(lin_cons) == 2
@@ -130,19 +130,20 @@ class TestCSE:
 
         obj = cp.max(x+y,z) - cp.min(x+y,z)
 
-        csemap = dict()
+        csemap = CSEMap()
         flat_obj, cons = flatten_objective(obj, csemap=csemap)
         assert len(cons) == 3
         assert len(csemap) == 3
-        assert set(csemap.keys()) == \
+        assert set(csemap.csemap.keys()) == \
                             {cp.max(x+y,z), cp.min(x+y,z), x+y}
 
         # assume we did some transformations before
-        csemap = {cp.max(x+y,z) : cp.intvar(0,20, name="aux")}
+        csemap = CSEMap()
+        csemap.csemap = {cp.max(x+y,z) : cp.intvar(0,20, name="aux")}
         flat_obj, cons = flatten_objective(obj, csemap=csemap)
         assert len(cons) == 2# just replaced max with aux var
         assert len(csemap) == 3
-        assert set(csemap.keys()) == \
+        assert set(csemap.csemap.keys()) == \
                             {cp.max(x + y, z), cp.min(x + y, z), x + y}
 
 

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -1,6 +1,7 @@
 import cpmpy as cp
 
 from cpmpy.transformations.comparison import only_numexpr_equality
+from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective
 from cpmpy.transformations.decompose_global import decompose_in_tree
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
@@ -21,7 +22,7 @@ class TestCSE:
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
        
         nested_alldiff = cp.AllDifferent(x,y+y,z)      
-        csemap = dict()
+        csemap = CSEMap()
 
         flat_cons = flatten_constraint(nested_alldiff, csemap=csemap)
 
@@ -66,7 +67,7 @@ class TestCSE:
 
         b = cp.boolvar(name="b")
         nested_cons = b == ((cp.max([x,y,z]) + q) <= 10)
-        csemap = dict()
+        csemap = CSEMap()
         decomp = decompose_in_tree([nested_cons], csemap=csemap)
     
         assert len(decomp) == 5

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -31,7 +31,7 @@ class TestCSE:
         assert str(fc) == "alldifferent(x,IV0,z)"
         assert len(csemap) == 1
 
-        assert str(next(iter(csemap.csemap.keys()))) == "(y) + (y)"
+        assert str(next(iter(csemap.flat_map.keys()))) == "(y) + (y)"
         assert str(csemap[y + y]) == "IV0"
 
         # next time we use y + y, it should replace it IV0
@@ -133,18 +133,24 @@ class TestCSE:
         csemap = CSEMap()
         flat_obj, cons = flatten_objective(obj, csemap=csemap)
         assert len(cons) == 3
-        assert len(csemap) == 3
-        assert set(csemap.csemap.keys()) == \
-                            {cp.max(x+y,z), cp.min(x+y,z), x+y}
+        assert len(csemap) == 5 # also stored flat constraints
+        csemap_should = {'(x) + (y)': 'IV0', # flat expr
+                         'max((x) + (y),z)': 'IV1', # orig expr
+                         'max(IV0,z)': 'IV1', # flat expr
+                         'min((x) + (y),z)': 'IV2', # orig expr
+                         'min(IV0,z)': 'IV2'} # flat expr
+        assert {str(key) : str(val) for key, val in csemap.flat_map.items()} == csemap_should
 
         # assume we did some transformations before
         csemap = CSEMap()
-        csemap.csemap = {cp.max(x+y,z) : cp.intvar(0,20, name="aux")}
+        csemap.flat_map = {cp.max(x+y,z) : cp.intvar(0,20, name="aux")}
         flat_obj, cons = flatten_objective(obj, csemap=csemap)
         assert len(cons) == 2# just replaced max with aux var
-        assert len(csemap) == 3
-        assert set(csemap.csemap.keys()) == \
-                            {cp.max(x + y, z), cp.min(x + y, z), x + y}
-
+        assert len(csemap) == 4 # also store flat constraints
+        csemap_should = {'max((x) + (y),z)': 'aux', # the one we put in
+                         'min((x) + (y),z)': 'IV4', # orig expr
+                         'min(IV3,z)': 'IV4', # flat expr
+                         '(x) + (y)': 'IV3'} # flat expr
+        assert {str(key): str(val) for key, val in csemap.flat_map.items()} == csemap_should
 
     ### other transformations only use csemap as argument to flatten_constraint internally, not sure how to easily test them

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -31,7 +31,7 @@ class TestCSE:
         assert str(fc) == "alldifferent(x,IV0,z)"
         assert len(csemap) == 1
 
-        assert str(next(iter(csemap.keys()))) == "(y) + (y)"
+        assert str(next(iter(csemap.csemap.keys()))) == "(y) + (y)"
         assert str(csemap[y + y]) == "IV0"
 
         # next time we use y + y, it should replace it IV0

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -90,48 +90,163 @@ class TestFlattenExpr:
         (a,b,c,d,e) = self.ivars[:5]
         (x,y,z) = self.bvars[:3]
 
-        assert  str(get_or_make_var(x)) == "(BV0, [])"
-        assert  str(get_or_make_var(~x)) == "(~BV0, [])"
+        v, cons = get_or_make_var(x)
+        assert str(v) == "BV0"
+        assert {str(c) for c in cons} == set()
 
-        assert  str(get_or_make_var(x == y)) == "(BV3, [((BV0) == (BV1)) == (BV3)])"
-        assert  str(get_or_make_var(x != y)) == "(BV4, [((BV0) == (~BV1)) == (BV4)])"
-        assert  str(get_or_make_var(x > y)) == "(BV5, [((BV0) > (BV1)) == (BV5)])"
-        assert  str(get_or_make_var(x <= y)) == "(BV6, [((BV0) <= (BV1)) == (BV6)])"
+        v, cons = get_or_make_var(~x)
+        assert str(v) == "~BV0"
+        assert {str(c) for c in cons} == set()
 
-        assert  str(get_or_make_var((a > 10) == x)) == "(BV8, [((BV7) == (BV0)) == (BV8), (IV0 > 10) == (BV7)])"
-        assert  str(get_or_make_var( (a > 10) == (d > 5) )) == "(BV11, [((BV10) == (BV9)) == (BV11), (IV0 > 10) == (BV10), (IV3 > 5) == (BV9)])"
-        assert  str(get_or_make_var( a > c )) == "(BV12, [((IV0) > (IV2)) == (BV12)])"
-        assert  str(get_or_make_var( a + b > c )) == "(BV13, [(((IV0) + (IV1)) > (IV2)) == (BV13)])"
+        v, cons = get_or_make_var(x == y)
+        assert str(v) == "BV3"
+        assert {str(c) for c in cons} == {"((BV0) == (BV1)) == (BV3)"}
+
+        v, cons = get_or_make_var(x != y)
+        assert str(v) == "BV4"
+        assert {str(c) for c in cons} == {"((BV0) == (~BV1)) == (BV4)"}
+
+        v, cons = get_or_make_var(x > y)
+        assert str(v) == "BV5"
+        assert {str(c) for c in cons} == {"((BV0) > (BV1)) == (BV5)"}
+
+        v, cons = get_or_make_var(x <= y)
+        assert str(v) == "BV6"
+        assert {str(c) for c in cons} == {"((BV0) <= (BV1)) == (BV6)"}
+
+        v, cons = get_or_make_var((a > 10) == x)
+        assert str(v) == "BV8"
+        assert {str(c) for c in cons} == {
+            "((BV7) == (BV0)) == (BV8)",
+            "(IV0 > 10) == (BV7)",
+        }
+
+        v, cons = get_or_make_var((a > 10) == (d > 5))
+        assert str(v) == "BV11"
+        assert {str(c) for c in cons} == {
+            "((BV10) == (BV9)) == (BV11)",
+            "(IV0 > 10) == (BV10)",
+            "(IV3 > 5) == (BV9)",
+        }
+
+        v, cons = get_or_make_var(a > c)
+        assert str(v) == "BV12"
+        assert {str(c) for c in cons} == {"((IV0) > (IV2)) == (BV12)"}
+
+        v, cons = get_or_make_var(a + b > c)
+        assert str(v) == "BV13"
+        assert {str(c) for c in cons} == {"(((IV0) + (IV1)) > (IV2)) == (BV13)"}
         cp.intvar(0,2) # increase counter
 
-        assert  str(get_or_make_var( (a>b).implies(x) )) == "(BV15, [((~BV14) or (BV0)) == (BV15), ((IV0) > (IV1)) == (BV14)])"
-        assert  str(get_or_make_var( x&y )) == "(BV16, [((BV0) and (BV1)) == (BV16)])"
-        assert  str(get_or_make_var( x|y )) == "(BV17, [((BV0) or (BV1)) == (BV17)])"
-        assert  str(get_or_make_var( x.implies(y) )) == "(BV18, [((~BV0) or (BV1)) == (BV18)])"
-        assert  str(get_or_make_var( x.implies(y|z) )) == "(BV20, [((~BV0) or (BV19)) == (BV20), ((BV1) or (BV2)) == (BV19)])"
-        assert  str(get_or_make_var( (x&y).implies(y&z) )) == "(BV23, [((~BV21) or (BV22)) == (BV23), ((BV0) and (BV1)) == (BV21), ((BV1) and (BV2)) == (BV22)])"
-        assert  str(get_or_make_var( x.implies(y.implies(z)) )) == "(BV25, [((~BV0) or (BV24)) == (BV25), ((~BV1) or (BV2)) == (BV24)])"
+        v, cons = get_or_make_var((a > b).implies(x))
+        assert str(v) == "BV15"
+        assert {str(c) for c in cons} == {
+            "((~BV14) or (BV0)) == (BV15)",
+            "((IV0) > (IV1)) == (BV14)",
+        }
 
-        assert  str(get_or_make_var( (a > 10) )) == "(BV26, [(IV0 > 10) == (BV26)])"
-        assert  str(get_or_make_var( (a > 10)&x&y )) == "(BV28, [(and(BV27, BV0, BV1)) == (BV28), (IV0 > 10) == (BV27)])"
+        v, cons = get_or_make_var(x & y)
+        assert str(v) == "BV16"
+        assert {str(c) for c in cons} == {"((BV0) and (BV1)) == (BV16)"}
 
-        assert  str(get_or_make_var(Operator('not', [x]) == y)) == '(BV29, [((~BV0) == (BV1)) == (BV29)])'
+        v, cons = get_or_make_var(x | y)
+        assert str(v) == "BV17"
+        assert {str(c) for c in cons} == {"((BV0) or (BV1)) == (BV17)"}
+
+        v, cons = get_or_make_var(x.implies(y))
+        assert str(v) == "BV18"
+        assert {str(c) for c in cons} == {"((~BV0) or (BV1)) == (BV18)"}
+
+        v, cons = get_or_make_var(x.implies(y | z))
+        assert str(v) == "BV20"
+        assert {str(c) for c in cons} == {
+            "((~BV0) or (BV19)) == (BV20)",
+            "((BV1) or (BV2)) == (BV19)",
+        }
+
+        v, cons = get_or_make_var((x & y).implies(y & z))
+        assert str(v) == "BV23"
+        assert {str(c) for c in cons} == {
+            "((~BV21) or (BV22)) == (BV23)",
+            "((BV0) and (BV1)) == (BV21)",
+            "((BV1) and (BV2)) == (BV22)",
+        }
+
+        v, cons = get_or_make_var(x.implies(y.implies(z)))
+        assert str(v) == "BV25"
+        assert {str(c) for c in cons} == {
+            "((~BV0) or (BV24)) == (BV25)",
+            "((~BV1) or (BV2)) == (BV24)",
+        }
+
+        v, cons = get_or_make_var(a > 10)
+        assert str(v) == "BV26"
+        assert {str(c) for c in cons} == {"(IV0 > 10) == (BV26)"}
+
+        v, cons = get_or_make_var((a > 10) & x & y)
+        assert str(v) == "BV28"
+        assert {str(c) for c in cons} == {
+            "(and(BV27, BV0, BV1)) == (BV28)",
+            "(IV0 > 10) == (BV27)",
+        }
+
+        v, cons = get_or_make_var(Operator('not', [x]) == y)
+        assert str(v) == "BV29"
+        assert {str(c) for c in cons} == {"((~BV0) == (BV1)) == (BV29)"}
 
     def test_get_or_make_var__num(self):
         (a,b,c,d,e) = self.ivars[:5]
 
-        assert  str(get_or_make_var( a+b )) == "(IV5, [((IV0) + (IV1)) == (IV5)])"
-        assert  str(get_or_make_var( a+b+c )) == "(IV6, [(sum(IV0, IV1, IV2)) == (IV6)])"
-        assert  str(get_or_make_var( 2*a )) == "(IV7, [(sum([2] * [IV0])) == (IV7)])"
-        assert  str(get_or_make_var( a*b )) == "(IV8, [((IV0) * (IV1)) == (IV8)])"
-        assert  str(get_or_make_var( a//b )) == "(IV9, [((IV0) div (IV1)) == (IV9)])"
-        assert  str(get_or_make_var( 1//b )) == "(IV10, [(1 div (IV1)) == (IV10)])"
-        assert  str(get_or_make_var( a//1 )) == "(IV0, [])"
-        assert  str(get_or_make_var( abs(cp.intvar(-5,5, name="x")) )) == "(IV11, [(abs(x)) == (IV11)])"
-        assert  str(get_or_make_var( 1*a + 2*b + 3*c )) == "(IV12, [(sum([1, 2, 3] * [IV0, IV1, IV2])) == (IV12)])"
-        assert  str(get_or_make_var( cp.cpm_array([1,2,3])[a] )) == "(IV13, [([1 2 3][IV0]) == (IV13)])"
-        assert  str(get_or_make_var( cp.cpm_array([b+c,2,3])[a] )) == "(IV15, [((IV14, 2, 3)[IV0]) == (IV15), ((IV1) + (IV2)) == (IV14)])"
-        assert  str(get_or_make_var( a*2 )) == "(IV16, [(sum([2] * [IV0])) == (IV16)])"
+        v, cons = get_or_make_var(a + b)
+        assert str(v) == "IV5"
+        assert {str(c) for c in cons} == {"((IV0) + (IV1)) == (IV5)"}
+
+        v, cons = get_or_make_var(a + b + c)
+        assert str(v) == "IV6"
+        assert {str(c) for c in cons} == {"(sum(IV0, IV1, IV2)) == (IV6)"}
+
+        v, cons = get_or_make_var(2 * a)
+        assert str(v) == "IV7"
+        assert {str(c) for c in cons} == {"(sum([2] * [IV0])) == (IV7)"}
+
+        v, cons = get_or_make_var(a * b)
+        assert str(v) == "IV8"
+        assert {str(c) for c in cons} == {"((IV0) * (IV1)) == (IV8)"}
+
+        v, cons = get_or_make_var(a // b)
+        assert str(v) == "IV9"
+        assert {str(c) for c in cons} == {"((IV0) div (IV1)) == (IV9)"}
+
+        v, cons = get_or_make_var(1 // b)
+        assert str(v) == "IV10"
+        assert {str(c) for c in cons} == {"(1 div (IV1)) == (IV10)"}
+
+        v, cons = get_or_make_var(a // 1)
+        assert str(v) == "IV0"
+        assert {str(c) for c in cons} == set()
+
+        v, cons = get_or_make_var(abs(cp.intvar(-5, 5, name="x")))
+        assert str(v) == "IV11"
+        assert {str(c) for c in cons} == {"(abs(x)) == (IV11)"}
+
+        v, cons = get_or_make_var(1 * a + 2 * b + 3 * c)
+        assert str(v) == "IV12"
+        assert {str(c) for c in cons} == {"(sum([1, 2, 3] * [IV0, IV1, IV2])) == (IV12)"}
+
+        v, cons = get_or_make_var(cp.cpm_array([1, 2, 3])[a])
+        assert str(v) == "IV13"
+        assert {str(c) for c in cons} == {"([1 2 3][IV0]) == (IV13)"}
+
+        v, cons = get_or_make_var(cp.cpm_array([b + c, 2, 3])[a])
+        assert str(v) == "IV15"
+        assert {str(c) for c in cons} == {
+            "((IV14, 2, 3)[IV0]) == (IV15)",
+            "((IV1) + (IV2)) == (IV14)",
+        }
+
+        v, cons = get_or_make_var(a * 2)
+        assert str(v) == "IV16"
+        assert {str(c) for c in cons} == {"(sum([2] * [IV0])) == (IV16)"}
 
     def test_objective(self):
         (a,b,c,d,e) = self.ivars[:5]

--- a/tests/test_int2bool.py
+++ b/tests/test_int2bool.py
@@ -8,6 +8,7 @@ from cpmpy import SolverLookup
 from cpmpy.expressions.core import BoolVal, Comparison, Expression, Operator
 from cpmpy.expressions.utils import argvals
 from cpmpy.expressions.variables import _BoolVarImpl, _IntVarImpl, boolvar, intvar
+from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.flatten_model import flatten_constraint
 from cpmpy.transformations.get_variables import get_variables
 from cpmpy.transformations.int2bool import int2bool, IntVarEnc
@@ -103,7 +104,7 @@ class TestTransInt2Bool:
     def test_transforms(self, solver, constraint, encoding, setup):
         user_vars = tuple(get_variables(constraint))
         ivarmap = dict()
-        csemap = dict()
+        csemap = CSEMap()
         flat = int2bool(flatten_constraint(constraint), ivarmap=ivarmap, encoding=encoding, csemap=csemap)
 
         cons_sols = []

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -3,6 +3,7 @@ import pytest
 import cpmpy as cp
 from cpmpy.expressions import boolvar, intvar
 from cpmpy.expressions.core import Operator
+from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective
 from cpmpy.transformations.linearize import linearize_constraint, linearize_reified_variables, decompose_linear, canonical_comparison, only_positive_bv, only_positive_coefficients, only_positive_bv_wsum_const, only_positive_bv_wsum
 from cpmpy.transformations.decompose_global import decompose_in_tree
@@ -596,7 +597,7 @@ class TestLinearizeReifiedVariablesThreshold:
         _IntVarImpl.counter = 0
         _BoolVarImpl.counter = 0
 
-        self.csemap = {}
+        self.csemap = CSEMap()
         self.ivarmap = {}
         a = cp.intvar(1, 3, name="a")
         self.a = a


### PR DESCRIPTION
Implementation of a custom CSEMap object, with proper typing.
For now, there is no normalization happening yet (e.g., we probably want to save `bv <-> var != val`  as `~bv <-> var == val` as it allows us to extract the "predicate" and linearize it using the domain encoding).
Not sure if that should be part of this PR as well, or if we should focus on getting the "bare" object properly typed and up and running.

For typing: I was not able to properly type the csemap passed around in the transformations; there seemed to be a lot of issues popping up (e.g., where it was unclear if the returned expression is Boolean or not). 
For now, decompose_in_tree and friends have the argument `Optional[CSEMap] = None`, for the others, it is untyped.
Do we want complete typing in this PR for all transformations? I would be open to that at the risk of becoming a mega PR...

After discussions in #837, we decided that decompose_in_tree does something special with the csemap as it maps a global to its decomposition.
I ran some small tests on xcsp3 whether this is indeed useful, and apparently it is : ) There are quite a few repeated global functions (e.g., div/mul) used in intention constraints, for which no explicit auxiliary variable is made. Hence, we decompose it multiple times if the solver does not support it.
So there is now a special interface for saving global constraints and functions to their decompositions.