### PR TITLE
Print display in solver interface superclass

### DIFF
--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -305,14 +305,7 @@ class CPM_choco(SolverInterface):
                         cpm_var._value = bool(value)
                     else:
                         cpm_var._value = value
-                # print the desired display
-                if isinstance(display, Expression):
-                    print(display.value())
-                elif is_any_list(display):
-                    print(argvals(display))
-                else:
-                    assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    display()  # callback
+                self.print_display(display)
 
         return len(sols)
 

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -617,14 +617,7 @@ class CPM_cplex(SolverInterface):
                 if self.has_objective():
                     self.objective_value_ = sol_obj_val + self._obj_offset
 
-                if display is not None:
-                    if isinstance(display, Expression):
-                        print(display.value())
-                    elif is_any_list(display):
-                        print(argvals(display))
-                    else:
-                        assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                        display()  # callback
+                self.print_display(display)
 
         # Reset pool search mode to default
         self.cplex_model.context.cplex_parameters.mip.limits.populate = 1

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -291,14 +291,7 @@ class CPM_cpo(SolverInterface):
         while ((time_limit is None) or (time_limit > 0)) and self.solve(time_limit=time_limit, **kwargs):
 
             # display if needed
-            if display is not None:
-                if isinstance(display, Expression):
-                    print(display.value())
-                elif is_any_list(display):
-                    print(argvals(display))
-                else:
-                    assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    display()  # callback
+            self.print_display(display)
 
             # count and stop
             solution_count += 1

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -352,14 +352,7 @@ class CPM_exact(SolverInterface):
                 solsfound += 1
                 self.xct_solver.invalidateLastSol() # TODO: pass user vars to this function
                 if display is not None:
-                    self._fillVars()
-                    if isinstance(display, Expression):
-                        print(display.value())
-                    elif is_any_list(display):
-                        print(argvals(display))
-                    else:
-                        assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                        display()  # callback
+                    self.print_display(display)
             elif my_status == "INCONSISTENT": # found inconsistency
                 raise ValueError("Error: inconsistency during solveAll should not happen, please warn the developers of this bug")
             elif my_status == "TIMEOUT": # found timeout

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -352,6 +352,7 @@ class CPM_exact(SolverInterface):
                 solsfound += 1
                 self.xct_solver.invalidateLastSol() # TODO: pass user vars to this function
                 if display is not None:
+                    self._fillVars()
                     self.print_display(display)
             elif my_status == "INCONSISTENT": # found inconsistency
                 raise ValueError("Error: inconsistency during solveAll should not happen, please warn the developers of this bug")

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -312,14 +312,7 @@ class CPM_gcs(SolverInterface):
                     cpm_var._value = bool(solution_map[sol_var])
                 else:
                     cpm_var._value = solution_map[sol_var]
-
-            if isinstance(display, Expression):
-                print(display.value())
-            elif is_any_list(display):
-                print(argvals(display))
-            else:
-                assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                display()  # callback
+            self.print_display(display)
             return
 
         sol_callback = None

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -587,14 +587,7 @@ class CPM_gurobi(SolverInterface):
             if self.has_objective():
                 self.objective_value_ = self.grb_model.PoolObjVal
 
-            if display is not None:
-                if isinstance(display, Expression):
-                    print(display.value())
-                elif is_any_list(display):
-                    print(argvals(display))
-                else:
-                    assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    display()  # callback
+            self.print_display(display)
 
         # Reset pool search mode to default
         self.grb_model.setParam("PoolSearchMode", 0)

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -562,14 +562,7 @@ class HexSolutionPrinter:
                 if self._solver.has_objective():
                     self._solver.objective_value_ = int(hex_sol.get_objective_bound(0))
 
-                # display
-                if isinstance(self._display, Expression):
-                    print(self._display.value())
-                elif is_any_list(self._display):
-                    print(argvals(self._display))
-                else:
-                    assert callable(self._display), f"Expected display argument to be an Expression, list thereof or a function, but got {self._display} of type {type(self._display)}"
-                    self._display()  # callback
+                self._solver.print_display(self._display)
                 
             # update data
             self.__solution_count += 1

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -478,14 +478,7 @@ class CPM_minizinc(SolverInterface):
                     raise ValueError(f"Var {cpm_var} is unknown to the Minizinc solver, this is unexpected - please report on github...")
 
             # display if needed
-            if display is not None:
-                if isinstance(display, Expression):
-                    print(display.value())
-                elif is_any_list(display):
-                    print(argvals(display))
-                else:
-                    assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    display()  # callback
+            self.print_display(display)
 
             # count and stop
             solution_count += 1

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -894,6 +894,7 @@ try:
         def __init__(self, solver, display=None, solution_limit=None, verbose=False):
             super().__init__(verbose)
             self._solution_limit = solution_limit
+            self._solver = solver
             # we only need the cpmpy->solver varmap from the solver
             self._varmap = solver._varmap
             # identify which variables to populate with their values
@@ -918,14 +919,7 @@ try:
                     else:
                         raise NotImplementedError(f"Unexpected variable type {type(cpm_var)}")
 
-                # print the desired display
-                if isinstance(self._display, Expression):
-                    print(self._display.value())
-                elif is_any_list(self._display):
-                    print(argvals(self._display))
-                else:
-                    assert callable(self._display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    self._display()  # callback
+                self._solver.print_display(self._display)
 
             # check for count limit
             if self.solution_count() == self._solution_limit:

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -249,14 +249,7 @@ class CPM_pysdd(SolverInterface):
                 # fill in variable values
                 for i, cpm_var in enumerate(self.user_vars):
                     cpm_var._value = sol[i]
-
-                if isinstance(display, Expression):
-                    print(display.value())
-                elif is_any_list(display):
-                    print(argvals(display))
-                else:
-                    assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    display()  # callback
+                self.print_display(display)
         
         return len(projected_sols)
 

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -185,7 +185,6 @@ class SolverInterface(object):
             return [self.solver_vars(v) for v in cpm_vars]
         return self.solver_var(cpm_vars)
 
-
     def transform(self, cpm_expr):
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
@@ -234,8 +233,26 @@ class SolverInterface(object):
         return self.add(cpm_expr)
 
 
-    # OPTIONAL functions
+    def print_display(self, display: Optional[Callback]) -> None:
+        """
+            Helper function for printing the `display` argument used in `solveAll()`.
 
+            Arguments:
+                display: either a CPMpy Expression, OR a list of expressions,
+                         OR a callback function (no-arg) to call.
+        """
+        if display is None:
+            return
+
+        if isinstance(display, Expression):
+            print(display.value())
+        elif is_any_list(display):
+            print(argvals(display))
+        else:
+            assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
+            display()  # callback
+    
+    # OPTIONAL functions
     def solveAll(self, display:Optional[Callback]=None, time_limit:Optional[float]=None, solution_limit:Optional[int]=None, call_from_model=False, **kwargs):
         """
             Compute all solutions and optionally display the solutions.
@@ -267,14 +284,7 @@ class SolverInterface(object):
         start = time.time()
         while ((time_limit is None) or (time_limit > 0)) and self.solve(time_limit=time_limit, **kwargs):
             # display if needed
-            if display is not None:
-                if isinstance(display, Expression):
-                    print(display.value())
-                elif is_any_list(display):
-                    print(argvals(display))
-                else:
-                    assert callable(display), f"Expected display argument to be an Expression, list thereof or a function, but got {display} of type {type(display)}"
-                    display()  # callback
+            self.print_display(display)
 
             # count and stop
             solution_count += 1


### PR DESCRIPTION
Similar in spirit to the "solve_return" function in the solver interface superclass, I moved the handling of the display argument to `SolverInterface`.
It nicely stores all logic related to printing into one function, and should make #561 simpler to implement, as there is a display to be printed as well.

Not for this PR, but we can also make a new function "fill_variables", which would be used by solve, solveAll after every solution, and during callbacking