### PR TITLE
Upgrade pindakaas -> 4.2

### DIFF
--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -114,8 +114,6 @@ class CPM_pindakaas(SolverInterface):
         self.ivarmap = dict()  # for the integer to boolean encoders
         self.encoding = "auto"
         self.pdk_solver = pdk.solver.CaDiCaL()
-        # TODO workaround for upstream issue https://github.com/pindakaashq/pindakaas/issues/189
-        self.pdk_solver._set_option("factor", 0)
         self.unsatisfiable = False  # `pindakaas` might determine unsat before solving
         self.core = None  # latest UNSAT core
         super().__init__(name=name, cpm_model=cpm_model)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ solver_dependencies = {
     "gcs": ["gcspy>=0.1.9"], # first version to pass all tests
     "cpo": ["docplex>=2.28.240"],
     "pumpkin": ["pumpkin-solver>=0.3.0"], # CPMpy requires features only available from Pumpkin version >=0.3.0
-    "pindakaas": ["pindakaas>=0.4.1"],
+    "pindakaas": ["pindakaas>=0.4.2"],
     "cplex": ["docplex>=2.28.240", "cplex>=20.1.0.4"],
 }
 solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 


### PR DESCRIPTION
In the upcoming version of pindakaas, the crash wrt to cadical + BVA should be fixed, meaning we can re-enable BVA again running Cadical with default parameters. Lower bound is increased because older versions of pindakaas are not safe when solving incrementally.

- **Re-enable BVA**
- **Upgrade to anticipated version**
