### PR TITLE
Fix error when analyzing CSVs with empty time metrics

### DIFF
--- a/cpmpy/tools/xcsp3/analyze.py
+++ b/cpmpy/tools/xcsp3/analyze.py
@@ -174,9 +174,11 @@ def xcsp3_objective_performance_profile(df):
 def xcsp3_stats(df):
 
     for phase in ['parse', 'model', 'post']:
-        slowest_idx = df[f'time_{phase}'].idxmax()
-        if slowest_idx is not None and not pd.isna(slowest_idx):
-            print(f"Slowest {phase}: {df.loc[slowest_idx, f'time_{phase}']}s ({df.loc[slowest_idx, 'instance']}, {df.loc[slowest_idx, 'solver']})")
+        try:
+            slowest_idx = df[f'time_{phase}'].idxmax()
+        except ValueError:
+            continue
+        print(f"Slowest {phase}: {df.loc[slowest_idx, f'time_{phase}']}s ({df.loc[slowest_idx, 'instance']}, {df.loc[slowest_idx, 'solver']})")
 
     for solver in df['solver'].unique():
         solver_total = df[df['solver'] == solver]['time_total'].sum()


### PR DESCRIPTION
If you analyze a CSV file with an empty `time_*` metric (which happens for me currently, only total_time is recorded for gurobi, which may be a different issue), the following error occurs:

```
> python cpmpy/tools/xcsp3/analyze.py results/expr.csv/xcsp3_2025_COP25_gurobi_20260416_185126.csv --time_limit 600  --output analysis/
Traceback (most recent call last):
  File "/cw/dtailocal/henk/Projects/cpmpy-master/cpmpy/tools/xcsp3/analyze.py", line 235, in <module>
    main()
  File "/cw/dtailocal/henk/Projects/cpmpy-master/cpmpy/tools/xcsp3/analyze.py", line 220, in main
    xcsp3_stats(merged_df)
  File "/cw/dtailocal/henk/Projects/cpmpy-master/cpmpy/tools/xcsp3/analyze.py", line 177, in xcsp3_stats
    slowest_idx = df[f'time_{phase}'].idxmax()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cw/dtailocal/henk/miniforge3/envs/cpmpy/lib/python3.12/site-packages/pandas/core/series.py", line 2545, in idxmax
    iloc = self.argmax(axis, skipna, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cw/dtailocal/henk/miniforge3/envs/cpmpy/lib/python3.12/site-packages/pandas/core/base.py", line 814, in argmax
    result = nanops.nanargmax(delegate, skipna=skipna)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cw/dtailocal/henk/miniforge3/envs/cpmpy/lib/python3.12/site-packages/pandas/core/nanops.py", line 1158, in nanargmax
    result = _maybe_arg_null_out(result, axis, mask, skipna)  # type: ignore[arg-type]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cw/dtailocal/henk/miniforge3/envs/cpmpy/lib/python3.12/site-packages/pandas/core/nanops.py", line 1473, in _maybe_arg_null_out
    raise ValueError("Encountered all NA values")
ValueError: Encountered all NA values
```

This PR fixes this error.
