### PR TITLE
MDD global constraint

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -50,6 +50,7 @@ from .globalconstraints import (
     NoOverlap,
     NoOverlapOptional,
     NegativeTable,
+    MDD,
     Regular,
 )
 from .globalfunctions import (
@@ -116,6 +117,7 @@ __all__ = [
     "LexChainLessEq",
     "LexLess",
     "LexLessEq",
+    "MDD",
     "NegativeTable",
     "NoOverlap",
     "NoOverlapOptional",

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -112,6 +112,7 @@
         ShortTable
         NegativeTable
         Regular
+        MDD
         IfThenElse
         InDomain
         Xor
@@ -133,6 +134,7 @@
 
 """
 import warnings
+from collections import defaultdict
 from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
 import numpy as np
 
@@ -141,7 +143,7 @@ import cpmpy as cp
 from ..exceptions import TypeError
 from .core import Expression, BoolVal, ExprLike, ListLike
 from .variables import cpm_array, intvar, boolvar, _BoolVarImpl, _IntVarImpl, NDVarArray
-from .utils import all_pairs, is_int, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies
+from .utils import all_pairs, is_int, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies, argval
 
 if TYPE_CHECKING:
     from cpmpy.solvers.solver_interface import SolverInterface
@@ -824,6 +826,151 @@ class Regular(GlobalConstraint):
             else:
                 return False
         return curr_node in accepting
+
+
+class MDD(GlobalConstraint):
+    """
+    MDD-constraint: an MDD (Multi-valued Decision Diagram) is an acyclic layered graph starting from a single node and
+    ending in one. Each path of the MDD corresponds to a solution.
+    The values of the variables in 'array' correspond to a path in the MDD formed by the transitions in 'transitions'.
+    The root node is the first node used as a start in the first transition (i.e. transitions[0][0])
+    spec:
+        - array: an array of CPMpy expressions (integer variable, global functions,...)
+        - transitions: an array of tuples (nodeID, int, nodeID) where nodeID is some unique identifier for the nodes
+        (int or str are fine)
+    Example:
+        The following transitions depict a 3 layer MDD, starting at 'r' and ending in 't'
+        ("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
+        ("n4", 0, "t"), ("n5", 1, "t")
+        Its graphical representation is:
+                  r
+              0/ |1  \2     X
+            n1   n2   n3
+            2| /2    /O     Y
+             n4     n5
+              0\   /1       Z
+                 t
+        It has 3 paths, corresponding to 3 solution for (X,Y,Z): (0,2,0), (1,2,0) and (2,0,1)
+    """
+
+    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]]):
+        """
+        Arguments:
+            array (ListLike[Expression]): List of expressions representing the input sequence
+            transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
+        """
+        array = flatlist(array)
+        if not all(isinstance(x, Expression) for x in array):
+            raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
+
+        def is_transition(arg):
+            """ test if the argument is a transition, i.e. a 3-elements-tuple specifying a starting state,
+            a transition value and an ending node"""
+            return len(arg) == 3 and \
+                isinstance(arg[0], (int, str)) and is_int(arg[1]) and isinstance(arg[2], (int, str))
+
+
+        if not all(is_transition(transition) for transition in transitions):
+            raise TypeError("The second argument of an MDD constraint should be collection of transitions")
+        super().__init__("mdd", (array, transitions))
+        self.root_node = transitions[0][0]
+        self.mapping = defaultdict(dict)
+        for s, v, e in transitions:
+            self.mapping[s][v] = e
+
+        self.levels = {self.root_node: 0}
+        current_nodes = [self.root_node]
+        for i in range(len(array)):
+            new_nodes = []
+            for n in current_nodes:
+                for v in self.mapping[n]:
+                    new_nodes.append(self.mapping[n][v])
+                    self.levels[self.mapping[n][v]] = i + 1
+            current_nodes = new_nodes
+
+    def _reduce(self):
+        """
+            Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
+        """
+        pass
+
+
+    def decompose(self) -> tuple[list[Expression], list[Expression]]:
+        """
+            Flow decomposition of the MDD global constraint.
+            Enforces that the condition is satisfied.
+
+            Returns:
+                tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        """
+        arr, _ = self.args
+
+        flow = {k: {"in" : [], "out" : []} for k in self.levels.keys()}
+        transition_counter = {(level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub+1)}
+
+        for (src, edges) in self.mapping.items():
+            for (value, dst) in edges.items():
+                transition = (self.levels[src], value)
+                transition_counter[transition] += 1
+                flow[src]["out"].append((transition, transition_counter[transition]))
+                flow[dst]["in"].append((transition, transition_counter[transition]))
+
+        cons = []
+        substitution = {}
+        for key in transition_counter.keys():
+            (level, value) = key
+            if transition_counter[key] == 0:
+                continue
+            elif transition_counter[key] == 1:
+                substitution[(key, 1)] = (arr[level] == value)
+            else:
+                bvs = cp.boolvar(shape=transition_counter[key]) # edge variables must be defined
+                for n in range(1, transition_counter[key] + 1):
+                    substitution[(key, n)] = bvs[n - 1]
+
+        for i, key in enumerate(sorted(flow.keys(), key=lambda k: self.levels[k])):
+
+            if ((len(flow[key]["in"]) == 1) and (len(flow[key]["out"]) == 1) and
+                    transition_counter[flow[key]["in"][0][0]] > 1 and transition_counter[flow[key]["out"][0][0]] > 1):
+                substitution[flow[key]["out"][0]] = substitution[flow[key]["in"][0]] # substitute equivalent edge variables
+
+            elif (len(flow[key]["in"]) > 0) and (len(flow[key]["out"]) > 0):
+                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) ==
+                         cp.sum([substitution[edge] for edge in flow[key]["out"]])]
+
+            elif len(flow[key]["in"]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow[key]["out"]]) == 1]
+
+            elif len(flow[key]["out"]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) == 1]
+
+        for key in transition_counter.keys():
+            if transition_counter[key] > 1:
+                (level, value) = key
+                cons += [cp.sum([substitution[(key, n)] for n in range(1, transition_counter[key] + 1)]) == (arr[level] == value)]
+
+        return cons, []
+
+    def value(self) -> Optional[bool]:
+        """
+        Returns:
+            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        """
+        arr, transitions = self.args
+        arrvals = [argval(a) for a in arr]
+        curr_node = self.root_node
+        for v in arrvals:
+            if v is None:
+                return None
+            if curr_node in self.mapping:
+                if v in self.mapping[curr_node]:
+                    curr_node = self.mapping[curr_node][v]
+                else:
+                    return False
+            else:
+                return False
+        return True # can only have reached end node
+
 
 # syntax of the form 'if b then x == 9 else x == 0' is not supported (no override possible)
 # same semantic as CPLEX IfThenElse constraint

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -894,65 +894,80 @@ class MDD(GlobalConstraint):
         """
         pass
 
-
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-            Flow decomposition of the MDD global constraint.
-            Enforces that the condition is satisfied.
+        Flow decomposition of the MDD global constraint.
+        Enforces that the condition is satisfied.
 
-            Returns:
-                tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        Returns:
+            tuple[list[Expression], list[Expression]]:
+                A tuple containing the constraints representing the constraint value and the defining constraints.
         """
         arr, _ = self.args
 
-        flow_in: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
-        flow_out: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
-        transition_counter = {
-            (level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub + 1)
-        }
+        flow_in: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
+        flow_out: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
+        edge_vars = defaultdict(list)
 
-        for (src, edges) in self.mapping.items():
-            for (value, dst) in edges.items():
-                transition = (self.levels[src], value)
-                transition_counter[transition] += 1
-                flow_out[src].append((transition, transition_counter[transition]))
-                flow_in[dst].append((transition, transition_counter[transition]))
+        for src, edges in self.mapping.items():
+            for value, dst in edges.items():
+                tr = (self.levels[src], value)
+                edge_var = cp.boolvar()
+
+                flow_out[src].append((tr, edge_var))
+                flow_in[dst].append((tr, edge_var))
+                edge_vars[tr].append(edge_var)
 
         cons = []
-        substitution = {}
-        for key in transition_counter.keys():
-            (level, value) = key
-            if transition_counter[key] == 0:
-                continue
-            elif transition_counter[key] == 1:
-                substitution[(key, 1)] = (arr[level] == value)
+        b = cp.boolvar()
+        invalid_edge_vars = []
+
+        # Go over the nodes in the MDD, and enforce flow constraints
+        for node in self.levels.keys():
+            incoming = flow_in[node]
+            outgoing = flow_out[node]
+            missing = []
+
+            if outgoing:
+                valid_transitions = [tr for tr, _ in outgoing]
+                lvl = valid_transitions[0][0]
+
+                # Find all transition values for which there is no valid path, in order to direct them to a dummy node
+                for val in range(arr[lvl].lb, arr[lvl].ub + 1):
+                    tr = (lvl, val)
+
+                    if tr not in valid_transitions:
+                        var = cp.boolvar()
+                        edge_vars[tr].append(var)
+                        invalid_edge_vars.append(var)
+                        missing.append(var)
+
+            if incoming and outgoing:
+                cons += [
+                    cp.sum([e for _, e in incoming]) ==
+                    cp.sum([e for _, e in outgoing]) + cp.sum(missing)
+                ]
+
+            elif outgoing:
+                cons += [
+                    cp.sum([e for _, e in outgoing]) + cp.sum(missing) == 1
+                ]
+
             else:
-                bvs = cp.boolvar(shape=transition_counter[key]) # edge variables must be defined
-                for n in range(1, transition_counter[key] + 1):
-                    substitution[(key, n)] = bvs[n - 1]
+                cons += [
+                    cp.sum([e for _, e in incoming]) == b
+                ]
 
-        for node in sorted(flow_in.keys() | flow_out.keys(), key=lambda k: self.levels[k]):
+        # Link direct encoding variables with edge variables
+        for (level, value), vars_ in edge_vars.items():
+            cons += [
+                cp.sum(set(vars_)) == (arr[level] == value)
+            ]
 
-            if ((len(flow_in[node]) == 1) and (len(flow_out[node]) == 1) and
-                    transition_counter[flow_in[node][0][0]] > 1 and transition_counter[flow_out[node][0][0]] > 1):
-                substitution[flow_out[node][0]] = substitution[flow_in[node][0]] # substitute equivalent edge variables
+        # Ensure that if an invalid edge is taken, the constraint is not satisfied
+        cons += [cp.sum(invalid_edge_vars) == ~b]
 
-            elif (len(flow_in[node]) > 0) and (len(flow_out[node]) > 0):
-                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) ==
-                         cp.sum([substitution[edge] for edge in flow_out[node]])]
-
-            elif len(flow_in[node]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow_out[node]]) == 1]
-
-            elif len(flow_out[node]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) == 1]
-
-        for key in transition_counter.keys():
-            if transition_counter[key] > 1:
-                (level, value) = key
-                cons += [cp.sum([substitution[(key, n)] for n in range(1, transition_counter[key] + 1)]) == (arr[level] == value)]
-
-        return cons, []
+        return [b], cons
 
     def value(self) -> Optional[bool]:
         """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -921,7 +921,7 @@ class MDD(GlobalConstraint):
             tuple[list[Expression], list[Expression]]:
                 A tuple containing the constraints representing the constraint value and the defining constraints.
         """
-        arr, _ = self.args
+        arr, _, _ = self.args
 
         # MDD is extended with invalid edges, which are directed to the sink node
         extended_mapping, invalid_edges_set = self._get_complete_mdd()

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -874,7 +874,7 @@ class MDD(GlobalConstraint):
             raise TypeError("The second argument of an MDD constraint should be collection of transitions")
         super().__init__("mdd", (array, transitions))
         self.root_node = transitions[0][0]
-        self.mapping = defaultdict(dict)
+        self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
             self.mapping[s][v] = e
 
@@ -905,15 +905,18 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        flow = {k: {"in" : [], "out" : []} for k in self.levels.keys()}
-        transition_counter = {(level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub+1)}
+        flow_in: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
+        flow_out: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
+        transition_counter = {
+            (level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub + 1)
+        }
 
         for (src, edges) in self.mapping.items():
             for (value, dst) in edges.items():
                 transition = (self.levels[src], value)
                 transition_counter[transition] += 1
-                flow[src]["out"].append((transition, transition_counter[transition]))
-                flow[dst]["in"].append((transition, transition_counter[transition]))
+                flow_out[src].append((transition, transition_counter[transition]))
+                flow_in[dst].append((transition, transition_counter[transition]))
 
         cons = []
         substitution = {}
@@ -928,21 +931,21 @@ class MDD(GlobalConstraint):
                 for n in range(1, transition_counter[key] + 1):
                     substitution[(key, n)] = bvs[n - 1]
 
-        for i, key in enumerate(sorted(flow.keys(), key=lambda k: self.levels[k])):
+        for node in sorted(flow_in.keys() | flow_out.keys(), key=lambda k: self.levels[k]):
 
-            if ((len(flow[key]["in"]) == 1) and (len(flow[key]["out"]) == 1) and
-                    transition_counter[flow[key]["in"][0][0]] > 1 and transition_counter[flow[key]["out"][0][0]] > 1):
-                substitution[flow[key]["out"][0]] = substitution[flow[key]["in"][0]] # substitute equivalent edge variables
+            if ((len(flow_in[node]) == 1) and (len(flow_out[node]) == 1) and
+                    transition_counter[flow_in[node][0][0]] > 1 and transition_counter[flow_out[node][0][0]] > 1):
+                substitution[flow_out[node][0]] = substitution[flow_in[node][0]] # substitute equivalent edge variables
 
-            elif (len(flow[key]["in"]) > 0) and (len(flow[key]["out"]) > 0):
-                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) ==
-                         cp.sum([substitution[edge] for edge in flow[key]["out"]])]
+            elif (len(flow_in[node]) > 0) and (len(flow_out[node]) > 0):
+                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) ==
+                         cp.sum([substitution[edge] for edge in flow_out[node]])]
 
-            elif len(flow[key]["in"]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow[key]["out"]]) == 1]
+            elif len(flow_in[node]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow_out[node]]) == 1]
 
-            elif len(flow[key]["out"]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) == 1]
+            elif len(flow_out[node]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) == 1]
 
         for key in transition_counter.keys():
             if transition_counter[key] > 1:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -133,6 +133,7 @@
         DirectConstraint
 
 """
+import copy
 import warnings
 from collections import defaultdict
 from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
@@ -863,15 +864,12 @@ class MDD(GlobalConstraint):
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
 
-        def is_transition(arg):
-            """ test if the argument is a transition, i.e. a 3-elements-tuple specifying a starting state,
-            a transition value and an ending node"""
-            return len(arg) == 3 and \
-                isinstance(arg[0], (int, str)) and is_int(arg[1]) and isinstance(arg[2], (int, str))
+        _node_type = type(transitions[0][0])
+        for s, v, e in transitions:
+            if not isinstance(s, _node_type) or not isinstance(e, _node_type) or not isinstance(v, int):
+                raise TypeError(
+                    f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
-
-        if not all(is_transition(transition) for transition in transitions):
-            raise TypeError("The second argument of an MDD constraint should be collection of transitions")
         super().__init__("mdd", (array, transitions))
         self.root_node = transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
@@ -888,6 +886,25 @@ class MDD(GlobalConstraint):
                     self.levels[self.mapping[n][v]] = i + 1
             current_nodes = new_nodes
 
+    def _extend_mdd(self):
+        """
+            Auxiliary function that extends the MDD with edges for all possible values, directing the new edges to the sink node.
+        """
+        invalid_edges = []
+
+        extended_mapping = copy.deepcopy(self.mapping)
+        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
+        for s in self.mapping.keys():
+            level = self.levels[s]
+            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            for v in domain:
+                if v not in self.mapping[s]:
+                    extended_mapping[s][v] = sink_node
+                    invalid_edges.append((s, v))
+        return extended_mapping, invalid_edges
+
+
+
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
@@ -897,7 +914,7 @@ class MDD(GlobalConstraint):
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Flow decomposition of the MDD global constraint.
-        Enforces that the condition is satisfied.
+        Enforces that the condition is satisfied, by ensuring that the flow in equals the flow out for every node.
 
         Returns:
             tuple[list[Expression], list[Expression]]:
@@ -905,69 +922,47 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        flow_in: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
-        flow_out: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
+        extended_mapping, invalid_edges = self._extend_mdd()
+
+        # Represents the ingoing and outgoing flow for a certain node: for every node, the edge variables are listed
+        flow_in: dict[int | str, list[Expression]] = defaultdict(list)
+        flow_out: dict[int | str, list[Expression]] = defaultdict(list)
+
         edge_vars = defaultdict(list)
+        invalid_edge_vars = []
 
-        for src, edges in self.mapping.items():
+        for src, edges in extended_mapping.items():
             for value, dst in edges.items():
-                tr = (self.levels[src], value)
+                level = self.levels[src]
                 edge_var = cp.boolvar()
+                flow_out[src].append(edge_var)
+                flow_in[dst].append(edge_var)
+                edge_vars[(level, value)].append(edge_var)
 
-                flow_out[src].append((tr, edge_var))
-                flow_in[dst].append((tr, edge_var))
-                edge_vars[tr].append(edge_var)
+                if (src, value) in invalid_edges:
+                    invalid_edge_vars.append(edge_var)
 
         cons = []
-        b = cp.boolvar()
-        invalid_edge_vars = []
 
         # Go over the nodes in the MDD, and enforce flow constraints
         for node in self.levels.keys():
             incoming = flow_in[node]
             outgoing = flow_out[node]
-            missing = []
 
-            if outgoing:
-                valid_transitions = [tr for tr, _ in outgoing]
-                lvl = valid_transitions[0][0]
-
-                # Find all transition values for which there is no valid path, in order to direct them to a dummy node
-                for val in range(arr[lvl].lb, arr[lvl].ub + 1):
-                    tr = (lvl, val)
-
-                    if tr not in valid_transitions:
-                        var = cp.boolvar()
-                        edge_vars[tr].append(var)
-                        invalid_edge_vars.append(var)
-                        missing.append(var)
 
             if incoming and outgoing:
-                cons += [
-                    cp.sum([e for _, e in incoming]) ==
-                    cp.sum([e for _, e in outgoing]) + cp.sum(missing)
-                ]
-
+                cons.append(cp.sum(incoming) == cp.sum(outgoing))
             elif outgoing:
-                cons += [
-                    cp.sum([e for _, e in outgoing]) + cp.sum(missing) == 1
-                ]
-
+                cons.append(cp.sum(outgoing) == 1)
             else:
-                cons += [
-                    cp.sum([e for _, e in incoming]) == b
-                ]
+                cons.append(cp.sum(incoming) == 1)
 
         # Link direct encoding variables with edge variables
         for (level, value), vars_ in edge_vars.items():
-            cons += [
-                cp.sum(set(vars_)) == (arr[level] == value)
-            ]
+            cons.append(cp.sum(vars_) == (arr[level] == value))
 
-        # Ensure that if an invalid edge is taken, the constraint is not satisfied
-        cons += [cp.sum(invalid_edge_vars) == ~b]
+        return [cp.sum(invalid_edge_vars) == 0], cons
 
-        return [b], cons
 
     def value(self) -> Optional[bool]:
         """
@@ -980,6 +975,8 @@ class MDD(GlobalConstraint):
         for v in arrvals:
             if v is None:
                 return None
+
+        for v in arrvals:
             if curr_node in self.mapping:
                 if v in self.mapping[curr_node]:
                     curr_node = self.mapping[curr_node][v]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -886,25 +886,6 @@ class MDD(GlobalConstraint):
                     self.levels[self.mapping[n][v]] = i + 1
             current_nodes = new_nodes
 
-    def _extend_mdd(self):
-        """
-            Auxiliary function that extends the MDD with edges for all possible values, directing the new edges to the sink node.
-        """
-        invalid_edges = []
-
-        extended_mapping = copy.deepcopy(self.mapping)
-        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
-        for s in self.mapping.keys():
-            level = self.levels[s]
-            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
-            for v in domain:
-                if v not in self.mapping[s]:
-                    extended_mapping[s][v] = sink_node
-                    invalid_edges.append((s, v))
-        return extended_mapping, invalid_edges
-
-
-
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
@@ -915,6 +896,8 @@ class MDD(GlobalConstraint):
         """
         Flow decomposition of the MDD global constraint.
         Enforces that the condition is satisfied, by ensuring that the flow in equals the flow out for every node.
+        To do this, we introduce auxiliary boolean variables for every edge in the MDD, use them in flow constraints,
+        and link them to all variable assignments in the array.
 
         Returns:
             tuple[list[Expression], list[Expression]]:
@@ -922,15 +905,27 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        extended_mapping, invalid_edges = self._extend_mdd()
+        # MDD is extended with invalid edges, which are directed to the sink node
+        invalid_edges = []
+        extended_mapping = copy.deepcopy(self.mapping)
+        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
+        for s in self.mapping.keys():
+            level = self.levels[s]
+            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            for v in domain:
+                if v not in self.mapping[s]:
+                    extended_mapping[s][v] = sink_node
+                    invalid_edges.append((s, v))
 
         # Represents the ingoing and outgoing flow for a certain node: for every node, the edge variables are listed
         flow_in: dict[int | str, list[Expression]] = defaultdict(list)
         flow_out: dict[int | str, list[Expression]] = defaultdict(list)
 
+        # Used to link edge variables to direct encoding variables in a later step
         edge_vars = defaultdict(list)
         invalid_edge_vars = []
 
+        # Flow in and flow out calculated for every node
         for src, edges in extended_mapping.items():
             for value, dst in edges.items():
                 level = self.levels[src]
@@ -944,11 +939,10 @@ class MDD(GlobalConstraint):
 
         cons = []
 
-        # Go over the nodes in the MDD, and enforce flow constraints
+        # Nodes in the MDD are iterated over, and flow constraints are enforced
         for node in self.levels.keys():
             incoming = flow_in[node]
             outgoing = flow_out[node]
-
 
             if incoming and outgoing:
                 cons.append(cp.sum(incoming) == cp.sum(outgoing))

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -833,8 +833,7 @@ class MDD(GlobalConstraint):
     """
     An MDD of depth n is an acyclic layered graph with a single root node, and one accepting sink node.
     The constraint takes as input an array of n integer variables and a graph representation using a transition table.
-    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node
-    , and ending in the accepting sink node.
+    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node, and ending in the accepting sink node.
 
     The transitions are defined by a list of tuples (id1, value, id2).
     An id is an integer or string representing a state in the automaton, and value is an integer representing the value of the variable in the sequence.
@@ -864,7 +863,7 @@ class MDD(GlobalConstraint):
                 raise TypeError(
                     f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
-        super().__init__("mdd", (array, transitions, start))
+        super().__init__("mdd", (array, transitions))
         self.root_node = start if start is not None else transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
@@ -881,6 +880,10 @@ class MDD(GlobalConstraint):
             current_nodes = new_nodes
         # Check that there is exactly one sink node on level n (with n the number of integer variables)
         assert sum(level == len(array) for node, level in self.levels.items()) == 1
+
+        self.sink_node = next(node for node, level in self.levels.items() if level == len(array))
+        self.nodes = self.levels.keys()
+        self.node_map = {n: (-1 if n == self.sink_node else i) for i, n in enumerate(self.nodes)}
 
     def _reduce(self):
         """
@@ -921,7 +924,7 @@ class MDD(GlobalConstraint):
             tuple[list[Expression], list[Expression]]:
                 A tuple containing the constraints representing the constraint value and the defining constraints.
         """
-        arr, _, _ = self.args
+        arr, _ = self.args
 
         # MDD is extended with invalid edges, which are directed to the sink node
         extended_mapping, invalid_edges_set = self._get_complete_mdd()
@@ -976,7 +979,7 @@ class MDD(GlobalConstraint):
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
-        arr, transitions, _ = self.args
+        arr, transitions = self.args
         argvals = [argval(a) for a in arr]
         curr_node = self.root_node
         if any(v is None for v in argvals):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -831,34 +831,28 @@ class Regular(GlobalConstraint):
 
 class MDD(GlobalConstraint):
     """
-    MDD-constraint: an MDD (Multi-valued Decision Diagram) is an acyclic layered graph starting from a single node and
-    ending in one. Each path of the MDD corresponds to a solution.
-    The values of the variables in 'array' correspond to a path in the MDD formed by the transitions in 'transitions'.
-    The root node is the first node used as a start in the first transition (i.e. transitions[0][0])
-    spec:
-        - array: an array of CPMpy expressions (integer variable, global functions,...)
-        - transitions: an array of tuples (nodeID, int, nodeID) where nodeID is some unique identifier for the nodes
-        (int or str are fine)
-    Example:
-        The following transitions depict a 3 layer MDD, starting at 'r' and ending in 't'
-        ("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
-        ("n4", 0, "t"), ("n5", 1, "t")
-        Its graphical representation is:
-                  r
-              0/ |1  \2     X
-            n1   n2   n3
-            2| /2    /O     Y
-             n4     n5
-              0\   /1       Z
-                 t
-        It has 3 paths, corresponding to 3 solution for (X,Y,Z): (0,2,0), (1,2,0) and (2,0,1)
+    An MDD of depth n is an acyclic layered graph with a single root node, and one accepting sink node.
+    The constraint takes as input an array of n integer variables and a graph representation using a transition table.
+    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node
+    , and ending in the accepting sink node.
+
+    The transitions are defined by a list of tuples (id1, value, id2).
+    An id is an integer or string representing a state in the automaton, and value is an integer representing the value of the variable in the sequence.
+    If not given explicitly, the root node is the first node in the transition table (i.e., transitions[0][0]), and is on level 0.
+    The sink node is the only node on level n.
+
+    Example: the following MDD accepts the solutions [1,1,1], [2,2,1] and [2,3,2] for the three variables x,y,z. The root node is "A" and the sink node is "F".
+    cp.MDD(array=[x,y,z],
+           transitions = [("A", 1, "B"), ("B", 1, "D"), ("D", 1 "F"),
+                          ("A",2,"C"), ("C", 2, "D"), ("C", 3, "E"), ("E", 2, "F")])
     """
 
-    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]]):
+    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]], start: Optional[int|str] = None):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the input sequence
             transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
+            start (Optional[int | str]): Root node id, if None, the root node is assumed to be the first node in the transition table (i.e., transitions[0][0])
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
@@ -871,7 +865,7 @@ class MDD(GlobalConstraint):
                     f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
         super().__init__("mdd", (array, transitions))
-        self.root_node = transitions[0][0]
+        self.root_node = start if start is not None else transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
             self.mapping[s][v] = e
@@ -885,12 +879,36 @@ class MDD(GlobalConstraint):
                     new_nodes.append(self.mapping[n][v])
                     self.levels[self.mapping[n][v]] = i + 1
             current_nodes = new_nodes
+        # Check that there is exactly one sink node on level n (with n the number of integer variables)
+        assert sum(level == len(array) for node, level in self.levels.items()) == 1
 
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
         """
         pass
+
+    def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
+        """
+        Auxiliary function that extends the MDD with invalid edges, which are directed to the sink node.
+
+        Returns:
+            tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
+            A tuple containing the extended mapping of the MDD and a set of invalid edges (source node, transition value) that are added to the MDD.
+        """
+        invalid_edges = set()
+        extended_mapping = copy.deepcopy(self.mapping)
+        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
+        for s in self.mapping.keys():
+            level = self.levels[s]
+            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            for v in domain:
+                if v not in self.mapping[s]:
+                    extended_mapping[s][v] = sink_node
+                    invalid_edges.add((s, v))
+
+        return extended_mapping, invalid_edges
+
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -906,18 +924,11 @@ class MDD(GlobalConstraint):
         arr, _ = self.args
 
         # MDD is extended with invalid edges, which are directed to the sink node
-        invalid_edges = []
-        extended_mapping = copy.deepcopy(self.mapping)
-        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
-        for s in self.mapping.keys():
-            level = self.levels[s]
-            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
-            for v in domain:
-                if v not in self.mapping[s]:
-                    extended_mapping[s][v] = sink_node
-                    invalid_edges.append((s, v))
+        extended_mapping, invalid_edges_set = self._get_complete_mdd()
+        invalid_edges = frozenset(invalid_edges_set)
 
-        # Represents the ingoing and outgoing flow for a certain node: for every node, the edge variables are listed
+        # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
+        # The default is an empty list, representing no ingoing / outgoing flow.
         flow_in: dict[int | str, list[Expression]] = defaultdict(list)
         flow_out: dict[int | str, list[Expression]] = defaultdict(list)
 
@@ -925,7 +936,7 @@ class MDD(GlobalConstraint):
         edge_vars = defaultdict(list)
         invalid_edge_vars = []
 
-        # Flow in and flow out calculated for every node
+        # Determine flow in and flow out for each node
         for src, edges in extended_mapping.items():
             for value, dst in edges.items():
                 level = self.levels[src]
@@ -939,19 +950,21 @@ class MDD(GlobalConstraint):
 
         cons = []
 
-        # Nodes in the MDD are iterated over, and flow constraints are enforced
-        for node in self.levels.keys():
+        # Enforce flow constraints: flow in = flow out, at most one activated in/out edge
+        for node, level in self.levels.items():
             incoming = flow_in[node]
             outgoing = flow_out[node]
 
-            if incoming and outgoing:
-                cons.append(cp.sum(incoming) == cp.sum(outgoing))
-            elif outgoing:
-                cons.append(cp.sum(outgoing) == 1)
+            if level == 0:
+                cons.append(cp.sum(outgoing) == 1) # root
+            elif level == len(arr):
+                cons.append(cp.sum(incoming) == 1) # sink
             else:
-                cons.append(cp.sum(incoming) == 1)
+                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
+                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
+                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
 
-        # Link direct encoding variables with edge variables
+        # Enforce direct encoding variable arr[i] == v if an edge with label v is activated at level i
         for (level, value), vars_ in edge_vars.items():
             cons.append(cp.sum(vars_) == (arr[level] == value))
 
@@ -964,13 +977,12 @@ class MDD(GlobalConstraint):
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
         arr, transitions = self.args
-        arrvals = [argval(a) for a in arr]
+        argvals = [argval(a) for a in arr]
         curr_node = self.root_node
-        for v in arrvals:
-            if v is None:
-                return None
+        if any(v is None for v in argvals):
+            return None
 
-        for v in arrvals:
+        for v in argvals:
             if curr_node in self.mapping:
                 if v in self.mapping[curr_node]:
                     curr_node = self.mapping[curr_node][v]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -864,7 +864,7 @@ class MDD(GlobalConstraint):
                 raise TypeError(
                     f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
-        super().__init__("mdd", (array, transitions))
+        super().__init__("mdd", (array, transitions, start))
         self.root_node = start if start is not None else transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
@@ -976,7 +976,7 @@ class MDD(GlobalConstraint):
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
-        arr, transitions = self.args
+        arr, transitions, _ = self.args
         argvals = [argval(a) for a in arr]
         curr_node = self.root_node
         if any(v is None for v in argvals):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -938,11 +938,11 @@ class MDD(GlobalConstraint):
         edge_vars = defaultdict(list)
         invalid_edge_vars = []
 
-        # Determine flow in and flow out for each node
+        # Determine flow in and flow out for each node, and make a boolvar for each edge
         for id1, edges in extended_mapping.items():
             for value, id2 in edges.items():
-                level = self.levels[id1]
                 edge_var = cp.boolvar()
+                level = self.levels[id1]
                 flow_out[id1].append(edge_var)
                 flow_in[id2].append(edge_var)
                 edge_vars[(level, value)].append(edge_var)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -877,19 +877,22 @@ class MDD(GlobalConstraint):
 
         self.levels = {self.root_node: 0}
         current_nodes = [self.root_node]
-        for i in range(len(array)):
+        for level in range(len(array)):
             new_nodes = []
-            for n in current_nodes:
-                for v in self.mapping[n]:
-                    new_nodes.append(self.mapping[n][v])
-                    self.levels[self.mapping[n][v]] = i + 1
+            for id1 in current_nodes:
+                for _,id2 in self.mapping[id1].items():
+                    new_nodes.append(id2)
+                    self.levels[id2] = level + 1
             current_nodes = new_nodes
-        # Check that there is exactly one sink node on level n (with n the number of integer variables)
-        assert sum(level == len(array) for node, level in self.levels.items()) == 1
 
-        self.sink_node = next(node for node, level in self.levels.items() if level == len(array))
+        # Check that there is exactly one sink node on level n (with n the number of integer variables)
+        sink_nodes = [node for node, level in self.levels.items() if level == len(array)]
+        assert len(sink_nodes) == 1
+        self.sink_node = sink_nodes[0]
+
         self.nodes = self.levels.keys()
-        self.node_map = {n: (-1 if n == self.sink_node else i) for i, n in enumerate(self.nodes)}
+        self.node_map = {n: i for i, n in enumerate(self.nodes)}
+        self.node_map[self.sink_node] = -1
 
     def _reduce(self):
         """
@@ -905,15 +908,15 @@ class MDD(GlobalConstraint):
             tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
             A tuple containing the extended mapping of the MDD and a set of invalid edges (source node, transition value) that are added to the MDD.
         """
+        arr = self.args[0]
         invalid_edges = set()
         extended_mapping = copy.deepcopy(self.mapping)
-        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
         for s in self.mapping.keys():
             level = self.levels[s]
-            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            domain = range(arr[level].lb, arr[level].ub + 1)
             for v in domain:
                 if v not in self.mapping[s]:
-                    extended_mapping[s][v] = sink_node
+                    extended_mapping[s][v] = self.sink_node
                     invalid_edges.add((s, v))
 
         return extended_mapping, invalid_edges
@@ -930,7 +933,7 @@ class MDD(GlobalConstraint):
             tuple[list[Expression], list[Expression]]:
                 A tuple containing the constraints representing the constraint value and the defining constraints.
         """
-        arr, _ = self.args
+        arr = self.args[0]
 
         # MDD is extended with invalid edges, which are directed to the sink node
         extended_mapping, invalid_edges_set = self._get_complete_mdd()
@@ -966,6 +969,7 @@ class MDD(GlobalConstraint):
 
             if level == 0:
                 cons.append(cp.sum(outgoing) == 1) # root
+                cons.append(cp.sum(outgoing) > 0)
             elif level == len(arr):
                 cons.append(cp.sum(incoming) == 1) # sink
             else:
@@ -985,16 +989,16 @@ class MDD(GlobalConstraint):
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
-        arr, transitions = self.args
+        arr = self.args[0]
         argvals = [argval(a) for a in arr]
         curr_node = self.root_node
         if any(v is None for v in argvals):
             return None
 
-        for v in argvals:
+        for curr_v in argvals:
             if curr_node in self.mapping:
-                if v in self.mapping[curr_node]:
-                    curr_node = self.mapping[curr_node][v]
+                if curr_v in self.mapping[curr_node]:
+                    curr_node = self.mapping[curr_node][curr_v]
                 else:
                     return False
             else:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -831,19 +831,25 @@ class Regular(GlobalConstraint):
 
 class MDD(GlobalConstraint):
     """
-    An MDD of depth n is an acyclic layered graph with a single root node, and one accepting sink node.
-    The constraint takes as input an array of n integer variables and a graph representation using a transition table.
-    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node, and ending in the accepting sink node.
+    An MDD is a Multi-valued Decision Diagram, represented as an acyclic layered graph, with a single root node, and a single accepting sink node.
+    The constraint takes as input an array of `n` integer variables and an MDD with `n+1` layers, represented through a table of "(from_node, value, to_node)" entries, one for every arc in the MDD.
+    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node, and where the first variable
+    in the array takes the value of the first edge, the second from the second edge, ending in the accepting sink node.
 
-    The transitions are defined by a list of tuples (id1, value, id2).
-    An id is an integer or string representing a state in the automaton, and value is an integer representing the value of the variable in the sequence.
-    If not given explicitly, the root node is the first node in the transition table (i.e., transitions[0][0]), and is on level 0.
-    The sink node is the only node on level n.
+    The transitions/edges are given in a nx3 matrix, or more precise a list of tuples (node_id1, value, node_id2).
+    A node_id is an integer or string representing a state in the MDD, and value is an integer representing the value of the variable in the sequence.
+    If not given explicitly, the root node is the node_id1 of the first entry in the transition table (i.e., transitions[0][0]).
+    The root node is at level 0, the sink node is the only node on level n.
 
     Example: the following MDD accepts the solutions [1,1,1], [2,2,1] and [2,3,2] for the three variables x,y,z. The root node is "A" and the sink node is "F".
-    cp.MDD(array=[x,y,z],
-           transitions = [("A", 1, "B"), ("B", 1, "D"), ("D", 1 "F"),
-                          ("A",2,"C"), ("C", 2, "D"), ("C", 3, "E"), ("E", 2, "F")])
+    cp.MDD(array = [x,y,z],
+           transitions = [("A", 1, "B"),
+                          ("A", 2, "C"),
+                          ("B", 1, "D"),
+                          ("C", 2, "D"),
+                          ("C", 3, "E"),
+                          ("D", 1, "F"),
+                          ("E", 2, "F")])
     """
 
     def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]], start: Optional[int|str] = None):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -950,7 +950,8 @@ class MDD(GlobalConstraint):
                 if (id1, value) in invalid_edges:
                     invalid_edge_vars.append(edge_var)
 
-        cons = []
+        defining = []
+        constraining = []
 
         # Enforce flow constraints: flow in = flow out, at most one activated in/out edge
         for node, level in self.levels.items():
@@ -958,23 +959,23 @@ class MDD(GlobalConstraint):
             outgoing = flow_out[node]
 
             if level == 0:
-                cons.append(cp.sum(outgoing) == 1) # root
-                cons.append(cp.sum(outgoing) > 0)
+                constraining.append(cp.sum(outgoing) == 1) # root
             elif level == len(arr):
-                cons.append(cp.sum(incoming) == 1) # sink
+                defining.append(cp.sum(incoming) == 1) # sink
             else:
-                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
-                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
-                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
+                defining.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
+                defining.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
+                defining.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
 
         # Enforce that when arr[i] == v, exactly one of the edges at level i with label v is true, otherwise none can be true
         for (level, value), vars_ in edge_vars.items():
-            cons.append(cp.sum(vars_) == (arr[level] == value))
+            defining.append(cp.sum(vars_) == (arr[level] == value))
+
+        constraining.append(cp.sum(invalid_edge_vars) == 0)
 
         # When the MDD is extended to a complete MDD by means of invalid edges, there is always a solution to the flow problem.
-        # As a consequence, all flow constraints and channeling constraints can be top level constraints.
-        # We only need to add as a conditioning constraint that no invalid edge has any flow.
-        return [cp.sum(invalid_edge_vars) == 0], cons
+        # The only constraining constraints are therefore that the root flow is equal to 1, and that no invalid edge has any flow.
+        return constraining, defining
 
 
     def value(self) -> Optional[bool]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -890,12 +890,6 @@ class MDD(GlobalConstraint):
         assert len(sink_nodes) == 1
         self.sink_node = sink_nodes[0]
 
-    def _reduce(self):
-        """
-            Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
-        """
-        pass
-
     def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
         """
         Auxiliary function that extends the MDD with invalid edges, which are directed to the sink node.

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -890,10 +890,6 @@ class MDD(GlobalConstraint):
         assert len(sink_nodes) == 1
         self.sink_node = sink_nodes[0]
 
-        self.nodes = self.levels.keys()
-        self.node_map = {n: i for i, n in enumerate(self.nodes)}
-        self.node_map[self.sink_node] = -1
-
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -911,13 +911,13 @@ class MDD(GlobalConstraint):
         arr = self.args[0]
         invalid_edges = set()
         extended_mapping = copy.deepcopy(self.mapping)
-        for s in self.mapping.keys():
-            level = self.levels[s]
+        for id1 in self.mapping.keys():
+            level = self.levels[id1]
             domain = range(arr[level].lb, arr[level].ub + 1)
             for v in domain:
-                if v not in self.mapping[s]:
-                    extended_mapping[s][v] = self.sink_node
-                    invalid_edges.add((s, v))
+                if v not in self.mapping[id1]:
+                    extended_mapping[id1][v] = self.sink_node
+                    invalid_edges.add((id1, v))
 
         return extended_mapping, invalid_edges
 
@@ -949,15 +949,15 @@ class MDD(GlobalConstraint):
         invalid_edge_vars = []
 
         # Determine flow in and flow out for each node
-        for src, edges in extended_mapping.items():
-            for value, dst in edges.items():
-                level = self.levels[src]
+        for id1, edges in extended_mapping.items():
+            for value, id2 in edges.items():
+                level = self.levels[id1]
                 edge_var = cp.boolvar()
-                flow_out[src].append(edge_var)
-                flow_in[dst].append(edge_var)
+                flow_out[id1].append(edge_var)
+                flow_in[id2].append(edge_var)
                 edge_vars[(level, value)].append(edge_var)
 
-                if (src, value) in invalid_edges:
+                if (id1, value) in invalid_edges:
                     invalid_edge_vars.append(edge_var)
 
         cons = []
@@ -977,10 +977,13 @@ class MDD(GlobalConstraint):
                 cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
                 cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
 
-        # Enforce direct encoding variable arr[i] == v if an edge with label v is activated at level i
+        # Enforce that when arr[i] == v, exactly one of the edges at level i with label v is true, otherwise none can be true
         for (level, value), vars_ in edge_vars.items():
             cons.append(cp.sum(vars_) == (arr[level] == value))
 
+        # When the MDD is extended to a complete MDD by means of invalid edges, there is always a solution to the flow problem.
+        # As a consequence, all flow constraints and channeling constraints can be top level constraints.
+        # We only need to add as a conditioning constraint that no invalid edge has any flow.
         return [cp.sum(invalid_edge_vars) == 0], cons
 
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -834,9 +834,9 @@ class MDD(GlobalConstraint):
     An MDD is a Multi-valued Decision Diagram, represented as an acyclic layered graph, with a single root node, and a single accepting sink node.
     The constraint takes as input an array of `n` integer variables and an MDD with `n+1` layers, represented through a table of "(from_node, value, to_node)" entries, one for every arc in the MDD.
     The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node, and where the first variable
-    in the array takes the value of the first edge, the second from the second edge, ending in the accepting sink node.
+    in the array takes the value of the first edge, the second from the second edge, etc., ending in the accepting sink node.
 
-    The transitions/edges are given in a nx3 matrix, or more precise a list of tuples (node_id1, value, node_id2).
+    The transitions/edges are given by a `n x 3` matrix, or more precisely a list of `n` tuples `(node_id1, value, node_id2)`.
     A node_id is an integer or string representing a state in the MDD, and value is an integer representing the value of the variable in the sequence.
     If not given explicitly, the root node is the node_id1 of the first entry in the transition table (i.e., transitions[0][0]).
     The root node is at level 0, the sink node is the only node on level n.
@@ -856,24 +856,24 @@ class MDD(GlobalConstraint):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the input sequence
-            transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
-            start (Optional[int | str]): Root node id, if None, the root node is assumed to be the first node in the transition table (i.e., transitions[0][0])
+            transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (node_id1, value, node_id2)
+            start (Optional[int | str]): Root node_id, if None, the root node is assumed to be the first node in the transition table (i.e., transitions[0][0])
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
 
         _node_type = type(transitions[0][0])
-        for s, v, e in transitions:
-            if not isinstance(s, _node_type) or not isinstance(e, _node_type) or not isinstance(v, int):
+        for id1, v, id2 in transitions:
+            if not isinstance(id1, _node_type) or not isinstance(v, int) or not isinstance(id2, _node_type):
                 raise TypeError(
-                    f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
+                    f"The second argument of an MDD constraint should be a list of transitions ({_node_type}, int, {_node_type})")
 
         super().__init__("mdd", (array, transitions))
-        self.root_node = start if start is not None else transitions[0][0]
+        self.root_node = transitions[0][0] if start is None else start
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
-        for s, v, e in transitions:
-            self.mapping[s][v] = e
+        for id1, v, id2 in transitions:
+            self.mapping[id1][v] = id2
 
         self.levels = {self.root_node: 0}
         current_nodes = [self.root_node]

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -654,10 +654,13 @@ class CPM_choco(SolverInterface):
 
                 array, transitions = cpm_expr.args
                 transitions_int = [[cpm_expr.node_map[src], val, cpm_expr.node_map[dst]] for src, val, dst in transitions]
-                handle = create_mdd_transitions(make_intvar_array(self._to_vars(array)), make_int_2d_array(transitions_int))
-                mdd = MultivaluedDecisionDiagram.__new__(MultivaluedDecisionDiagram)
-                _HandleWrapper.__init__(mdd, handle)
-                return self.chc_model.mddc(self._to_vars(array), mdd)
+                # currently no user-friendly way to create MDD objects with transitions in Pychoco.
+                # Manually create the required objects using the backend API.
+                # Issue opened on github: https://github.com/chocoteam/pychoco/issues/43
+                chc_handle = create_mdd_transitions(make_intvar_array(self._to_vars(array)), make_int_2d_array(transitions_int))
+                chc_mdd = MultivaluedDecisionDiagram.__new__(MultivaluedDecisionDiagram)
+                _HandleWrapper.__init__(chc_mdd, chc_handle)
+                return self.chc_model.mddc(self._to_vars(array), chc_mdd)
 
             elif cpm_expr.name == 'InDomain':
                 assert len(cpm_expr.args) == 2  # args = [array, list of vals]

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -87,7 +87,7 @@ class CPM_choco(SolverInterface):
                                     "table", 'negative_table', "short_table", "regular", "InDomain",
                                     "cumulative", "no_overlap", "circuit", "gcc", "inverse", "precedence",
                                     "increasing", "decreasing", "strictly_increasing", "strictly_decreasing",
-                                    "lex_lesseq", "lex_less",
+                                    "lex_lesseq", "lex_less", "mdd",
                                     "min", "max", "div", "mod", "pow", "abs", "mul", "count", "element", "nvalue", "among"})
     supported_reified_global_constraints = supported_global_constraints  # choco supports everything reified
 
@@ -646,7 +646,33 @@ class CPM_choco(SolverInterface):
                 automaton.set_initial_state(cpm_expr.node_map[start])
                 automaton.set_final(*[cpm_expr.node_map[a] for a in accepting])
                 return self.chc_model.regular(self._to_vars(array), automaton)
-            
+            elif cpm_expr.name == "mdd":
+                from pychoco.objects.graphs.multivalued_decision_diagram import MultivaluedDecisionDiagram
+                array, transitions, start = cpm_expr.args
+                root = start if start is not None else transitions[0][0]
+
+                from collections import defaultdict
+
+                def transitions_to_tuples(transitions, root, length):
+                    adj = defaultdict(list)
+                    for src, val, dst in transitions:
+                        adj[src].append((val, dst))
+
+                    def depth_first(node, path):
+                        if len(path) == length:
+                            return [tuple(path)]
+                        return [
+                            t
+                            for val, dst in adj.get(node, [])
+                            for t in depth_first(dst, path + [val])
+                        ]
+
+                    return depth_first(root, [])
+                # convert to MultivaluedDecisionDiagram Choco object, requiring list of accepted tuples
+                tuples = transitions_to_tuples(transitions, root, len(array))
+                mdd = MultivaluedDecisionDiagram(self._to_vars(array), tuples)
+                return self.chc_model.mddc(self._to_vars(array), mdd)
+
             elif cpm_expr.name == 'InDomain':
                 assert len(cpm_expr.args) == 2  # args = [array, list of vals]
                 expr, table = self.solver_vars(cpm_expr.args)

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -648,29 +648,15 @@ class CPM_choco(SolverInterface):
                 return self.chc_model.regular(self._to_vars(array), automaton)
             elif cpm_expr.name == "mdd":
                 from pychoco.objects.graphs.multivalued_decision_diagram import MultivaluedDecisionDiagram
-                array, transitions, start = cpm_expr.args
-                root = start if start is not None else transitions[0][0]
+                from pychoco.backend import create_mdd_transitions
+                from pychoco._handle_wrapper import _HandleWrapper
+                from pychoco._utils import make_int_2d_array, make_intvar_array
 
-                from collections import defaultdict
-
-                def transitions_to_tuples(transitions, root, length):
-                    adj = defaultdict(list)
-                    for src, val, dst in transitions:
-                        adj[src].append((val, dst))
-
-                    def depth_first(node, path):
-                        if len(path) == length:
-                            return [tuple(path)]
-                        return [
-                            t
-                            for val, dst in adj.get(node, [])
-                            for t in depth_first(dst, path + [val])
-                        ]
-
-                    return depth_first(root, [])
-                # convert to MultivaluedDecisionDiagram Choco object, requiring list of accepted tuples
-                tuples = transitions_to_tuples(transitions, root, len(array))
-                mdd = MultivaluedDecisionDiagram(self._to_vars(array), tuples)
+                array, transitions = cpm_expr.args
+                transitions_int = [[cpm_expr.node_map[src], val, cpm_expr.node_map[dst]] for src, val, dst in transitions]
+                handle = create_mdd_transitions(make_intvar_array(self._to_vars(array)), make_int_2d_array(transitions_int))
+                mdd = MultivaluedDecisionDiagram.__new__(MultivaluedDecisionDiagram)
+                _HandleWrapper.__init__(mdd, handle)
                 return self.chc_model.mddc(self._to_vars(array), mdd)
 
             elif cpm_expr.name == 'InDomain':

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -646,7 +646,9 @@ class CPM_choco(SolverInterface):
                 from pychoco._utils import make_int_2d_array, make_intvar_array
 
                 array, transitions = cpm_expr.args
-                transitions_int = [[cpm_expr.node_map[src], val, cpm_expr.node_map[dst]] for src, val, dst in transitions]
+                node_map = {n: i for i, n in enumerate(cpm_expr.levels)}
+                node_map[cpm_expr.sink_node] = -1
+                transitions_int = [[node_map[src], val, node_map[dst]] for src, val, dst in transitions]
                 # currently no user-friendly way to create MDD objects with transitions in Pychoco.
                 # Manually create the required objects using the backend API.
                 # Issue opened on github: https://github.com/chocoteam/pychoco/issues/43

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -169,6 +169,7 @@ def global_constraints(solver):
         elif name == "ShortTable":
             yield cp.ShortTable(NUM_ARGS, [[0,"*",2], ["*","*",1]])
         elif name == "MDD":
+            yield cp.MDD(cp.intvar(lb=0, ub=1, shape=3, name="x"), [("r", 0, "n1"), ("n1", 0, "n2"), ("n2", 0, "t")])
             yield cp.MDD(NUM_ARGS, [("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
             ("n4", 0, "t"), ("n5", 1, "t")])
             yield cp.MDD(NUM_ARGS, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -168,6 +168,12 @@ def global_constraints(solver):
             yield cp.NegativeTable(NUM_ARGS, [[0, 1, 2], [1, 2, 0], [1, 0, 2]])
         elif name == "ShortTable":
             yield cp.ShortTable(NUM_ARGS, [[0,"*",2], ["*","*",1]])
+        elif name == "MDD":
+            yield cp.MDD(NUM_ARGS, [("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
+            ("n4", 0, "t"), ("n5", 1, "t")])
+            yield cp.MDD(NUM_ARGS, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),
+                          ("2", 1, "2,1"), ("1", 2, "1,2"), ("4", 3, "1,2"), ("3", 2, "3,2"),
+                          ("2,1", 1, "snk"), ("2,1", 2, "snk"), ("1,2", 3, "snk"), ("3,2", 2, "snk")])
         elif name == "IfThenElse":
             yield cp.IfThenElse(*BOOL_ARGS)
         elif name == "InDomain":

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -252,6 +252,17 @@ class TestTransLinearize:
         assert str(lin_cons[1]) == "sum([1, 1, 3] * [x, y, ~b]) >= 5"
 
 
+    def test_mdd(self):
+
+        x = cp.intvar(1, 4, shape=3, name="x")
+
+        cons = cp.MDD(x, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),
+                          ("2", 1, "2,1"), ("1", 2, "1,2"), ("4", 3, "1,2"), ("3", 2, "3,2"),
+                          ("2,1", 1, "snk"), ("2,1", 2, "snk"), ("1,2", 3, "snk"), ("3,2", 2, "snk")])
+        lin_cons = linearize_constraint(decompose_linear([cons]))
+        print("Lin cons: ", lin_cons)
+        assert len(lin_cons) == 1
+        assert str(lin_cons) == "[sum(sum(x[0] == 2, x[0] == 1, x[0] == 4, x[0] == 3) == 1, (sum(x[0] == 2)) == (sum(x[1] == 1)), (sum(x[0] == 1)) == (sum(BV3)), (sum(x[0] == 4)) == (sum(x[1] == 3)), (sum(x[0] == 3)) == (sum(BV4)), (sum(x[1] == 1)) == ((x[2] == 1) + (BV5)), ((BV3) + (x[1] == 3)) == (sum(x[2] == 3)), sum(x[2] == 1, BV5, x[2] == 3, BV4) == 1, ((BV3) + (BV4)) == (x[1] == 2), ((BV5) + (BV4)) == (x[2] == 2)) >= 10]"
 
 
 

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -251,20 +251,6 @@ class TestTransLinearize:
         assert str(lin_cons[0]) == "sum([1, 1, -15] * [x, y, ~b]) <= 5"
         assert str(lin_cons[1]) == "sum([1, 1, 3] * [x, y, ~b]) >= 5"
 
-    @pytest.mark.skip(reason="solver dependent")
-    def test_mdd(self):
-
-        x = cp.intvar(1, 4, shape=3, name="x")
-
-        cons = cp.MDD(x, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),
-                          ("2", 1, "2,1"), ("1", 2, "1,2"), ("4", 3, "1,2"), ("3", 2, "3,2"),
-                          ("2,1", 1, "snk"), ("2,1", 2, "snk"), ("1,2", 3, "snk"), ("3,2", 2, "snk")])
-        lin_cons = linearize_constraint(decompose_linear([cons]))
-        print("Lin cons: ", lin_cons)
-        assert len(lin_cons) == 1
-        assert str(lin_cons) == "[sum(sum(x[0] == 2, x[0] == 1, x[0] == 4, x[0] == 3) == 1, (sum(x[0] == 2)) == (sum(x[1] == 1)), (sum(x[0] == 1)) == (sum(BV3)), (sum(x[0] == 4)) == (sum(x[1] == 3)), (sum(x[0] == 3)) == (sum(BV4)), (sum(x[1] == 1)) == ((x[2] == 1) + (BV5)), ((BV3) + (x[1] == 3)) == (sum(x[2] == 3)), sum(x[2] == 1, BV5, x[2] == 3, BV4) == 1, ((BV3) + (BV4)) == (x[1] == 2), ((BV5) + (BV4)) == (x[2] == 2)) >= 10]"
-
-
 
 
 class TestConstRhs:

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -251,7 +251,7 @@ class TestTransLinearize:
         assert str(lin_cons[0]) == "sum([1, 1, -15] * [x, y, ~b]) <= 5"
         assert str(lin_cons[1]) == "sum([1, 1, 3] * [x, y, ~b]) >= 5"
 
-
+    @pytest.mark.skip(reason="solver dependent")
     def test_mdd(self):
 
         x = cp.intvar(1, 4, shape=3, name="x")

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -254,6 +254,9 @@ class TestTransLinearize:
 
 
 
+
+
+
 class TestConstRhs:
 
     def test_numvar(self):


### PR DESCRIPTION
Continuing on what was discussed in #891, I added an MDD global constraint, using a flow decomposition which seems to be fully reifiable according to the tests. 

A sidenote: making the flow decomposition fully reifiable did require some adjustments to the original decomposition (which was only positively reifiable), and as a consequence it introduces many additional variables to the decomposition. Another consequence is that some post-processing simplifications are no longer possible. This motivates the approach we discussed earlier, to offer a positive decomposition for certain global constraints where possible.

Next steps will be:
1)	Implement _reduce(), allowing equivalent nodes in the MDD to be merged before decomposition. 
2)	Add the Table linear decomposition using MDD.
3)	Work on positive decompositions.
