### PR TITLE
mzn: fix time_limit deprecation warning

### DIFF
--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -308,7 +308,7 @@ class CPM_minizinc(SolverInterface):
         if time_limit is not None:
             from packaging.version import Version
             # timeout is deprecated from version 0.10.0 onwards, but cpmpy also supports older versions
-            if self.version().split("/")[0] >= Version("0.10.0"):
+            if Version(self.version().split("/")[0]) >= Version("0.10.0"):
                 kwargs['time_limit'] = timedelta(seconds=time_limit)
             else:
                 kwargs['timeout'] = timedelta(seconds=time_limit)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -60,6 +60,7 @@ import sys
 import os
 import json
 from datetime import timedelta  # for mzn's timeout
+from packaging.version import Version
 
 import numpy as np
 
@@ -307,7 +308,6 @@ class CPM_minizinc(SolverInterface):
 
         if time_limit is not None:
             # timeout is deprecated from version 0.10.0 onwards, but cpmpy also supports older versions
-            from packaging.version import Version
             mzn_vers = self.version()
             # should never be an issue here
             assert mzn_vers is not None

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -309,7 +309,7 @@ class CPM_minizinc(SolverInterface):
         if time_limit is not None:
             # timeout is deprecated from version 0.10.0 onwards, but cpmpy also supports older versions
             mzn_vers = self.version()
-            # should never be an issue here
+            # minizinc should always be installed in this part of the code, assert for mypy
             assert mzn_vers is not None
             if Version(mzn_vers.split("/")[0]) >= Version("0.10.0"):
                 kwargs['time_limit'] = timedelta(seconds=time_limit)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -306,7 +306,7 @@ class CPM_minizinc(SolverInterface):
         import minizinc
 
         if time_limit is not None:
-            kwargs['timeout'] = timedelta(seconds=time_limit)
+            kwargs['time_limit'] = timedelta(seconds=time_limit)
 
         # hack, we need to add the objective in a way that it can be changed
         # later, so make copy of the mzn_model

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -306,7 +306,12 @@ class CPM_minizinc(SolverInterface):
         import minizinc
 
         if time_limit is not None:
-            kwargs['time_limit'] = timedelta(seconds=time_limit)
+            from packaging.version import Version
+            # timeout is deprecated from version 0.10.0 onwards, but cpmpy also supports older versions
+            if self.version().split("/")[0] >= Version("0.10.0"):
+                kwargs['time_limit'] = timedelta(seconds=time_limit)
+            else:
+                kwargs['timeout'] = timedelta(seconds=time_limit)
 
         # hack, we need to add the objective in a way that it can be changed
         # later, so make copy of the mzn_model

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -306,9 +306,12 @@ class CPM_minizinc(SolverInterface):
         import minizinc
 
         if time_limit is not None:
-            from packaging.version import Version
             # timeout is deprecated from version 0.10.0 onwards, but cpmpy also supports older versions
-            if Version(self.version().split("/")[0]) >= Version("0.10.0"):
+            from packaging.version import Version
+            mzn_vers = self.version()
+            # should never be an issue here
+            assert mzn_vers is not None
+            if Version(mzn_vers.split("/")[0]) >= Version("0.10.0"):
                 kwargs['time_limit'] = timedelta(seconds=time_limit)
             else:
                 kwargs['timeout'] = timedelta(seconds=time_limit)


### PR DESCRIPTION
its trivial, you can just merge it if the tests pass without that warning