### PR TITLE
Loop optimisations

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -387,7 +387,7 @@ class AllEqualExceptN(GlobalConstraint):
         constraints = []
         for x, y in all_pairs(arr):
             # x and y are equal, or one of them is equal to an excluded value
-            constraints += [cp.any(x == a for a in n) | (x == y) | cp.any(y == a for a in n)]
+            constraints.append(cp.any(x == a for a in n) | (x == y) | cp.any(y == a for a in n))
         return constraints, []
 
     def value(self) -> Optional[bool]:
@@ -1426,7 +1426,7 @@ class NoOverlap(GlobalConstraint):
             cons += [s + d == e for s,d,e in zip(start, dur, end)]
             
         for (s1, e1), (s2, e2) in all_pairs(zip(start, end)):
-            cons += [(e1 <= s2) | (e2 <= s1)]
+            cons.append((e1 <= s2) | (e2 <= s1))
         return cons, []
 
     def value(self) -> Optional[bool]:
@@ -1578,7 +1578,7 @@ class Precedence(GlobalConstraint):
                 lhs = args[j] == t
                 if is_bool(lhs):  # args[j] and t could both be constants
                     lhs = BoolVal(lhs)
-                constraints += [lhs.implies(cp.any(args[:j] == s))]
+                constraints.append(lhs.implies(cp.any(args[:j] == s)))
         return constraints, []
 
     def value(self) -> Optional[bool]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -915,8 +915,8 @@ class InDomain(GlobalConstraint):
         """
         expr, arr = self.args
         lb, ub = expr.get_bounds()
-        
-        return [expr != val for val in range(lb, ub + 1) if val not in arr], []
+        arr_set = frozenset(arr)
+        return [expr != val for val in range(lb, ub + 1) if val not in arr_set], []
 
     def value(self) -> Optional[bool]:
         """
@@ -938,7 +938,8 @@ class InDomain(GlobalConstraint):
         lb, ub = expr.get_bounds()
 
         # complement of arr
-        return InDomain(expr, [v for v in range(lb,ub+1) if v not in arr])
+        arr_set = frozenset(arr)
+        return InDomain(expr, [v for v in range(lb,ub+1) if v not in arr_set])
 
 
 class Xor(GlobalConstraint):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1117,12 +1117,13 @@ class Cumulative(GlobalConstraint):
         # tasks are uninterruptible, so we only need to check each starting point of each task
         # I.e., for each task, we check if it can be started, given the tasks that are already running.
         for t in range(len(start)):
+            st = start[t]
             demand_at_start_of_t = []
             for j in range(len(start)):
                 if t != j:
-                    demand_at_start_of_t += [demand[j] * ((start[j] <= start[t]) & (end[j] > start[t]))]
+                    demand_at_start_of_t.append(demand[j] * ((start[j] <= st) & (end[j] > st)))
 
-            cons += [(demand[t] + sum(demand_at_start_of_t)) <= capacity]
+            cons.append((demand[t] + sum(demand_at_start_of_t)) <= capacity)
 
         return cons, []
 
@@ -1314,12 +1315,13 @@ class CumulativeOptional(GlobalConstraint):
         # tasks are uninterruptible, so we only need to check each starting point of each task
         # I.e., for each task, we check if it can be started, given the tasks that are already running.
         for t in range(len(start)):
+            st = start[t]
             demand_at_start_of_t = []
             for j in range(len(start)):
                 if t != j:
-                    demand_at_start_of_t += [demand[j] * (is_present[j] & (start[j] <= start[t]) & (end[j] > start[t]))]
+                    demand_at_start_of_t.append(demand[j] * (is_present[j] & (start[j] <= st) & (end[j] > st)))
 
-            cons += [implies(is_present[t], (demand[t] + sum(demand_at_start_of_t)) <= capacity)]
+            cons.append(implies(is_present[t], (demand[t] + sum(demand_at_start_of_t)) <= capacity))
 
         return cons, []
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -525,7 +525,7 @@ class NDVarArray(np.ndarray):
             if len(expr_dim) == 1: # optimization, only 1 expression, reshape to 1d-element
                 # TODO can we do the same for more than one Expression? Not sure...
                 index  = list(index)
-                index += [index.pop(expr_dim[0])]
+                index.append(index.pop(expr_dim[0]))
 
                 arr = np.moveaxis(self, expr_dim[0], -1)
                 return cp.Element(arr[(*index[:-1],)], index[-1])

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -348,7 +348,7 @@ class CPM_pumpkin(SolverInterface):
         obj_var, obj_cons = get_or_make_var(obj) # do not pass csemap here, we will still transform obj_var == obj...
         if expr.is_bool():
             ivar = intvar(0,1)
-            obj_cons += [ivar == obj_var]
+            obj_cons.append(ivar == obj_var)
             obj_var = ivar
 
         self.add(safe_cons + decomp_cons + obj_cons)

--- a/cpmpy/tools/xcsp3/benchmark.py
+++ b/cpmpy/tools/xcsp3/benchmark.py
@@ -229,7 +229,7 @@ def execute_instance(args: Tuple[str, dict, str, int, int, int, str, bool, bool,
                 obj = int(line[2:].strip())
                 if result['intermediate'] is None:
                     result['intermediate'] = []
-                result['intermediate'] += [(sol_time, obj)]
+                result['intermediate'].append((sol_time, obj))
                 result['objective_value'] = obj
                 obj = None
             elif line.startswith('c Solution'):

--- a/cpmpy/tools/xcsp3/globals.py
+++ b/cpmpy/tools/xcsp3/globals.py
@@ -942,7 +942,7 @@ class DynamicCumulative(GlobalConstraint):
         if version == "time":
             # set duration of tasks
             for t in range(len(start)):
-                cons += [start[t] + duration[t] == end[t]]
+                cons.append(start[t] + duration[t] == end[t])
 
             # demand doesn't exceed capacity
             for t in range(lb,ub+1):
@@ -953,16 +953,18 @@ class DynamicCumulative(GlobalConstraint):
                     else:
                         demand_at_t += demand[job] * ((start[job] <= t) & (t < end[job]))
 
-                cons += [demand_at_t <= capacity]
+                cons.append(demand_at_t <= capacity)
                 
         elif version == "task":
 
             # set duration of tasks
+            ends = [start[t] + duration[t] for t in range(num_tasks)]
             for t in range(num_tasks):
-                cons += [start[t] + duration[t] == end[t]]
+                cons.append(ends[t] == end[t])
 
             for j in range(num_tasks):
-                cons += [capacity >= demand[j] + cp.sum([(start[i] <= start[j]) & (start[j] < start[i] + duration[i]) for i in range(num_tasks) if i != j])]
+                sj = start[j]
+                cons.append(capacity >= demand[j] + cp.sum([(start[i] <= sj) & (sj < ends[i]) for i in range(num_tasks) if i != j]))
 
         return cons, []
 

--- a/cpmpy/tools/xcsp3/globals.py
+++ b/cpmpy/tools/xcsp3/globals.py
@@ -81,7 +81,7 @@ class AllDifferentLists(GlobalConstraint):
         """
         constraints = []
         for lst1, lst2 in all_pairs(self.args):
-            constraints += [cpm_any(var1 != var2 for var1, var2 in zip(lst1, lst2))]
+            constraints.append(cpm_any(var1 != var2 for var1, var2 in zip(lst1, lst2)))
         return constraints, []
 
     def value(self):
@@ -112,7 +112,7 @@ class AllDifferentListsExceptN(GlobalConstraint):
         """
         constraints = []
         for lst1, lst2 in all_pairs(self.args[0]):
-            constraints += [cpm_all(var1 == var2 for var1, var2 in zip(lst1, lst2)).implies(NonReifiedTable(lst1, self.args[1]))]
+            constraints.append(cpm_all(var1 == var2 for var1, var2 in zip(lst1, lst2)).implies(NonReifiedTable(lst1, self.args[1])))
         return constraints, []
 
     def value(self):
@@ -163,23 +163,23 @@ class SubCircuit(GlobalConstraint):
 
         # Constraining
         constraining = []
-        constraining += [AllDifferent(succ)] # All stops should have a unique successor.
+        constraining.append(AllDifferent(succ)) # All stops should have a unique successor.
         constraining += list( is_part_of_circuit.implies(succ < len(succ)) ) # Successor values should remain within domain.
         for i in range(0, n):
             # If a stop is on the subcircuit and it is not the last one, than its successor should have +1 as index.
-            constraining += [(is_part_of_circuit[i] & (i != end_node)).implies(
+            constraining.append((is_part_of_circuit[i] & (i != end_node)).implies(
                 index_within_subcircuit[succ[i]] == (index_within_subcircuit[i] + 1)
-            )]
+            ))
         constraining += list( is_part_of_circuit == (succ != np.arange(n)) ) # When a node is part of the subcircuit it should not self loop, if it is not part it should self loop.
 
         # Defining
         defining = []
-        defining += [ empty == cpm_all(succ == np.arange(n)) ] # Definition of empty subcircuit (all nodes self-loop)
-        defining += [ empty.implies(cpm_all(index_within_subcircuit == cpm_array([0]*n))) ] # If the subcircuit is empty, default all index values to 0
-        defining += [ empty.implies(start_node == 0) ] # If the subcircuit is empty, any node could be a start of a 0-length circuit. Default to node 0 as symmetry breaking.
-        defining += [succ[end_node] == start_node] # Definition of the last node. As the successor we should cycle back to the start.
-        defining += [ index_within_subcircuit[start_node] == 0 ] # The ordering starts at the start_node.
-        defining += [ ( empty | (is_part_of_circuit[start_node] == True) ) ] # The start node can only NOT belong to the subcircuit when the subcircuit is empty.
+        defining.append(empty == cpm_all(succ == np.arange(n))) # Definition of empty subcircuit (all nodes self-loop)
+        defining.append(empty.implies(cpm_all(index_within_subcircuit == cpm_array([0]*n)))) # If the subcircuit is empty, default all index values to 0
+        defining.append(empty.implies(start_node == 0)) # If the subcircuit is empty, any node could be a start of a 0-length circuit. Default to node 0 as symmetry breaking.
+        defining.append(succ[end_node] == start_node) # Definition of the last node. As the successor we should cycle back to the start.
+        defining.append(index_within_subcircuit[start_node] == 0) # The ordering starts at the start_node.
+        defining.append((empty | (is_part_of_circuit[start_node] == True))) # The start node can only NOT belong to the subcircuit when the subcircuit is empty.
         # Nodes which are not part of the subcircuit get an index fixed to +1 the index of "end_node", which equals the length of the subcircuit.
         # Nodes part of the subcircuit must have an index <= index_within_subcircuit[end_node].
         # The case of an empty subcircuit is an exception, since "end_node" itself is not part of the subcircuit
@@ -187,11 +187,11 @@ class SubCircuit(GlobalConstraint):
         # In a subcircuit any of the visited nodes can be the "start node", resulting in symmetrical solutions -> Symmetry breaking
         # Part of the formulation from the following is used: https://sofdem.github.io/gccat/gccat/Ccycle.html#uid18336
         subcircuit_visits = intvar(0, n-1, shape=n) # The visited nodes in sequence of length n, with possible repeated stops. e.g. subcircuit [0, 2, 1] -> [0, 2, 1, 0, 2, 1]
-        defining += [subcircuit_visits[0] == start_node] # The start nodes is the first stop
+        defining.append(subcircuit_visits[0] == start_node) # The start nodes is the first stop
         defining += [subcircuit_visits[i+1] == succ[subcircuit_visits[i]] for i in range(n-1)] # We follow the successor values
         # The free "start_node" could be any of the values of aux_subcircuit_visits (the actually visited nodes), resulting in degenerate solutions.
         # By enforcing "start_node" to take the smallest value, symmetry breaking is ensured.
-        defining += [start_node == cpm_min(subcircuit_visits)]
+        defining.append(start_node == cpm_min(subcircuit_visits))
 
         return constraining, defining
 
@@ -283,8 +283,8 @@ class SubCircuitWithStart(GlobalConstraint):
         succ = cpm_array(self.args[:-1]) # Successor variables
 
         constraining = []
-        constraining += [SubCircuit(succ)] # The successor variables should form a subcircuit.
-        constraining += [succ[start_index] != start_index] # The start_index should be inside the subcircuit.
+        constraining.append(SubCircuit(succ)) # The successor variables should form a subcircuit.
+        constraining.append(succ[start_index] != start_index) # The start_index should be inside the subcircuit.
 
         defining = []
 
@@ -831,8 +831,8 @@ class NoOverlap2d(GlobalConstraint):
         cons += [s + d == e for s,d,e in zip(start_y, dur_y, end_y)]
 
         for i,j in all_pairs(list(range(n))):
-            cons += [cpm_any([end_x[i] <= start_x[j], end_x[j] <= start_x[i],
-                              end_y[i] <= start_y[j], end_y[j] <= start_y[i]])]
+            cons.append(cpm_any([end_x[i] <= start_x[j], end_x[j] <= start_x[i],
+                                 end_y[i] <= start_y[j], end_y[j] <= start_y[i]]))
         return cons,[]
     def value(self):
         start_x, dur_x, end_x,  start_y, dur_y, end_y = argvals(self.args)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -311,7 +311,7 @@ def only_positive_bv(lst_of_expr, csemap=None):
                         if nbv:
                             aux = cp.boolvar()
                             new_args.append(aux)
-                            new_cons += [aux + lhs.args[i]._bv == 1]  # aux == 1 - arg._bv
+                            new_cons.append(aux + lhs.args[i]._bv == 1)  # aux == 1 - arg._bv
                         else:
                             new_args.append(lhs.args[i])
 


### PR DESCRIPTION
the first commit cuts 16 seconds (64 -> 48) from decompose in the dev/time_transf script

the second applies the append pattern in other places

the third is more a gimmick, precomputing a frozenset in InDomain