### PR TITLE
refactoring decompose in typed pattern

### DIFF
--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -184,22 +184,25 @@ def _decompose_in_tree_args(args: ListLike[Any],
                     continue
                 else:
                     # nested global function, decompose
-                    if decompose_custom is not None and arg.name in decompose_custom:
-                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
-                    else:
-                        newarg, toplevel_exprs = arg.decompose()
-
                     orig_for_csemap = arg
-                    arg = newarg
-                    if len(toplevel_exprs) > 0:
-                        toplevel.extend(toplevel_exprs)
+                    # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
+                    while isinstance(arg, GlobalFunction) and arg.name not in supported:
+                        if decompose_custom is not None and arg.name in decompose_custom:
+                            newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                        else:
+                            newarg, toplevel_exprs = arg.decompose()
+                        arg = newarg
+                        if len(toplevel_exprs) > 0:
+                            toplevel.extend(toplevel_exprs)
 
-                    # TODO: violates type!!!
-                    # apparently in #630 we decided that decompose may return an int (e.g. for element)...
-                    # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
+                        # TODO: violates type!!!
+                        # apparently in #630 we decided that decompose may return an int (e.g. for element)...
+                        # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
+                        if isinstance(arg, int):
+                            # no need to recurse further, stop here
+                            newargs.append(arg)
+                            break
                     if isinstance(arg, int):
-                        # no need to recurse further, stop here
-                        newargs.append(arg)
                         continue
             
             # if it has subexprs, decompose its arguments too

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -22,10 +22,10 @@ import copy
 from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
 import numpy as np
 
-from ..expressions.core import Expression, ListLike
-from ..expressions.variables import NDVarArray
-from ..expressions.utils import is_any_list
-from ..expressions.python_builtins import all as cpm_all
+from ..expressions.core import Expression, ListLike, BoolVal, Operator
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalfunctions import GlobalFunction
+from ..expressions.variables import NDVarArray, cpm_array
 
 
 def decompose_in_tree(lst_of_expr: list[Expression],
@@ -58,22 +58,38 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    changed, newlst_of_expr, todo_toplevel = _decompose_in_tree(lst_of_expr, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom)
-    if not changed:
-        return lst_of_expr
+    newlist: List[Expression] = []
+    todolist: List[Expression] = []  # these still need to be decomposed
+    for expr in lst_of_expr:
+        if isinstance(expr, GlobalConstraint) and expr.name not in supported:
+            # toplevel/positive global constraint, decompose
+            if decompose_custom is not None and expr.name in decompose_custom:
+                exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
+            else:
+                exprs, toplevel_exprs = expr.decompose()
+            # both might contain globals too
+            todolist.extend(exprs)
+            if len(toplevel_exprs) > 0:
+                todolist.extend(toplevel_exprs)
+        elif isinstance(expr, bool):
+            # TODO: violates type!!!
+            newlist.append(BoolVal(expr))
+        elif expr.has_subexpr():
+            # decompose its arguments
+            changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+            if changed:
+                expr = copy.copy(expr)
+                expr.update_args(newargs)
+                if len(rec_toplevel) > 0:
+                    todolist.extend(rec_toplevel)
+            newlist.append(expr)
+        else:
+            newlist.append(expr)
 
-    # new toplevel constraints may need to be decomposed too
-    while len(todo_toplevel):
-        changed, decomp, next_toplevel = _decompose_in_tree(todo_toplevel, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom)
-        if not changed:
-            newlst_of_expr.extend(todo_toplevel)
-            break
-
-        # changed, loop again
-        newlst_of_expr.extend(decomp)
-        todo_toplevel = next_toplevel # decompositions may have introduced nested lists or ands
-
-    return newlst_of_expr
+    # recurse on any newly generated toplevel expressions
+    if len(todolist) == 0:
+        return newlist
+    return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
 
 
 def decompose_objective(expr: Expression,
@@ -107,21 +123,20 @@ def decompose_objective(expr: Expression,
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    changed, newexpr, todo_toplevel = _decompose_in_tree((expr,), supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
-    if not changed:
+    changed, newexprs, todo_toplevel = _decompose_in_tree_args((expr,), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    if changed:
+        assert len(newexprs) == 1, "decompose_objective: expected a single expression as decomposed objective but got {newexprs}"
+        return newexprs[0], todo_toplevel
+    else:
         return expr, []
 
-    assert len(newexpr) == 1, "decompose_objective: expected a single expression as decomposed objective but got {newexpr}"
-    return newexpr[0], todo_toplevel
-
-
-def _decompose_in_tree(lst_of_expr: ListLike[Any],
-                       supported: AbstractSet[str],
-                       supported_reified: AbstractSet[str],
-                       is_toplevel: bool,
-                       csemap: Optional[Dict[Expression, Expression]]=None,
-                       decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Expression], List[Expression]]:
+def _decompose_in_tree_args(args: ListLike[Any],
+                            supported: AbstractSet[str],
+                            supported_reified: AbstractSet[str],
+                            csemap: Optional[Dict[Expression, Expression]]=None,
+                            decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Any], List[Expression]]:
     """
+    TODO: OUTDATED DOC!!
     Decompose any global constraint or global function not supported by the solver, recursive internal version.
 
     INTERNAL function, not guaranteed to remain backward compatible.
@@ -130,8 +145,6 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
         or other sequence of expressions that may use global constraints or global functions.
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
-    :param is_toplevel: whether ``lst_of_expr`` is the toplevel list of constraints.
-        If False, ``lst_of_expr`` is an argument to another expression and its global constraints must support reification.
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
 
     :returns: ``(changed, newexpr, toplevel)`` where:
@@ -140,78 +153,96 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
     changed = False
-    newlist: List[Any] = []  # TODO: because of is_any_list, can be many things...
     toplevel: List[Expression] = []
+    newargs: List[Any] = []
+    for arg in args:
+        if isinstance(arg, Expression):
+            orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
 
-    for expr in lst_of_expr:
-        if is_any_list(expr):
-            assert not is_toplevel, "Lists in lists is only allowed for arguments (e.g. of global constrainst)." \
-                                    "Make sure to run func:`cpmpy.transformations.normalize.toplevel_list` first."
-
-            if isinstance(expr, NDVarArray) and not expr.has_subexpr():
-                pass  # no subexpressions, nothing to do
-            elif isinstance(expr, np.ndarray) and expr.dtype != object:
-                pass  # only constants, nothing to do
-            else:
-                rec_changed, rec_expr, rec_toplevel = _decompose_in_tree(expr, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    expr = rec_expr
-                    toplevel.extend(rec_toplevel)
-                    changed = True
-            newlist.append(expr)
-            continue
-
-        if isinstance(expr, Expression):
-            # if an expression, decompose its arguments first
-            if expr.has_subexpr():
-                rec_changed, newargs, rec_toplevel = _decompose_in_tree(expr.args, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    expr = copy.copy(expr)
-                    expr.update_args(newargs)
-                    toplevel.extend(rec_toplevel)
-                    changed = True
-
-            if hasattr(expr, "decompose"):  # it is a global function or global constraint
-                is_supported = expr.name in supported
-                if not is_toplevel and expr.is_bool():
-                    # argument to another expression, only possible if supported reified
-                    is_supported = expr.name in supported_reified
-
-                if is_supported is False:
-                    if (csemap is not None) and expr in csemap:
-                        # we might have already decomposed it previously
-                        newexpr = csemap[expr]
-                    else:
-                        if decompose_custom is not None and expr.name in decompose_custom:
-                            newexpr, define = decompose_custom[expr.name](expr)
-                        else:
-                            newexpr, define = expr.decompose()
-                        toplevel.extend(define)
-
-                        # decomposed constraints may introduce new globals
-                        if isinstance(newexpr, list):  # globals return a list instead of a single expression (TODO: change?)
-                            rec_changed, rec_newexpr, rec_toplevel = _decompose_in_tree(newexpr, supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
-                            if rec_changed:
-                                newexpr_lst = rec_newexpr
-                                toplevel.extend(rec_toplevel)
-                            else:
-                                newexpr_lst = newexpr  # for mypy
-                            newexpr = cpm_all(newexpr_lst)  # make the list a single expression
-                        else:
-                            rec_changed, rec_lst_newexpr, rec_toplevel = _decompose_in_tree((newexpr,), supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
-                            if rec_changed:
-                                newexpr = rec_lst_newexpr[0]
-                                toplevel.extend(rec_toplevel)
-
-                        if (csemap is not None):
-                            csemap[expr] = newexpr
-
-                    newlist.append(newexpr)
-                    changed = True
+            # a nested expression (its inside an args)
+            if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
+                changed = True
+                if (csemap is not None) and arg in csemap:  # have we decomposed it before?
+                    newargs.append(csemap[arg])
                     continue
+                else:
+                    # nested global constraint, decompose
+                    if decompose_custom is not None and arg.name in decompose_custom:
+                        exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
+                    else:
+                        exprs, toplevel_exprs = arg.decompose()
 
-        # constants, variables, other expressions are left as is
-        newlist.append(expr)
+                    # replace arg by conjunction of decompose
+                    orig_for_csemap = arg
+                    arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
+                    if len(toplevel_exprs) > 0:
+                        toplevel.extend(toplevel_exprs)
+            elif isinstance(arg, GlobalFunction) and arg.name not in supported:
+                changed = True
+                if (csemap is not None) and arg in csemap:  # have we decomposed it before?
+                    newargs.append(csemap[arg])
+                    continue
+                else:
+                    # nested global function, decompose
+                    if decompose_custom is not None and arg.name in decompose_custom:
+                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                    else:
+                        newarg, toplevel_exprs = arg.decompose()
 
-    assert is_toplevel or len(newlist) == len(lst_of_expr), f"Nested decomposition should not change the number of expressions\n{lst_of_expr}\n{newlist}"
-    return (changed, newlist, toplevel)
+                    orig_for_csemap = arg
+                    arg = newarg
+                    if len(toplevel_exprs) > 0:
+                        toplevel.extend(toplevel_exprs)
+
+                    # TODO: violates type!!!
+                    # apparently in #630 we decided that decompose may return an int (e.g. for element)...
+                    # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
+                    if isinstance(arg, int):
+                        # no need to recurse further, stop here
+                        newargs.append(arg)
+                        continue
+            
+            # if it has subexprs, decompose its arguments too
+            if arg.has_subexpr():
+                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if rec_changed:
+                    changed = True
+                    arg = copy.copy(arg)
+                    arg.update_args(rec_newargs)
+                    if len(rec_toplevel) > 0:
+                        toplevel.extend(rec_toplevel)
+
+            # very special case: "and" with single argument (from simple glob.decomp)
+            if arg.name == "and" and len(arg.args) == 1:
+                arg = cast(Expression, arg.args[0])
+
+            if orig_for_csemap is not None and csemap is not None:
+                csemap[orig_for_csemap] = arg
+            newargs.append(arg)
+        
+        elif isinstance(arg, np.ndarray) and arg.dtype == object:
+            if isinstance(arg, NDVarArray):
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
+                    else:
+                        newargs.append(arg)
+                else:
+                    newargs.append(arg)
+            else:  # regular np.array
+                if arg.dtype == object:
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(np.array(rec_newargs).reshape(arg.shape))
+                    else:
+                        newargs.append(arg)
+                else:
+                    newargs.append(arg)
+        else:
+            # constants, variables, other expressions are left as is
+            newargs.append(arg)
+
+    return (changed, newargs, toplevel)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -71,7 +71,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
-        elif isinstance(expr, bool):
+        elif isinstance(expr, (bool, np.bool_)):
             # TODO: violates type!!!
             newlist.append(BoolVal(expr))
         elif expr.has_subexpr():

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -79,11 +79,12 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                 exprs, toplevel_exprs = expr.decompose()
             # we merge the list toplevel rather than create an 'and'
             # we add them to todolist because both might contain globals
-            todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
-            if csemap is not None:
-                csemap.save_decomposition(expr, Operator("and", exprs))
+            if len(exprs) > 0:
+                todolist.extend(exprs)
+                if csemap is not None:
+                    csemap.save_decomposition(expr, Operator("and", exprs))
         elif isinstance(expr, (bool, np.bool_)):
             # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
             changed = True

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -19,11 +19,11 @@ This allows to post the decomposed expression tree to the solver if it supports 
 """
 
 import copy
-from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
+from typing import AbstractSet, Optional, Dict, Any, Callable, cast
 import numpy as np
 
 from .cse import CSEMap
-from ..expressions.core import Expression, ListLike, BoolVal, Operator
+from ..expressions.core import Expression, BoolVal, Operator
 from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray, cpm_array
@@ -34,7 +34,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
-                      decompose_custom: Optional[Dict[str, Callable]] = None) -> List[Expression]:
+                      decompose_custom: Optional[Dict[str, Callable]] = None) -> list[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -59,8 +59,8 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    newlist: List[Expression] = []
-    todolist: List[Expression] = []  # these still need to be decomposed
+    todolist: list[Expression] = []  # these still need to be decomposed
+    newlist: list[Expression] = []
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
@@ -72,7 +72,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                 continue
             # else, global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
-                exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
+                exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
             else:
                 exprs, toplevel_exprs = expr.decompose()
             # both might contain globals too
@@ -104,7 +104,7 @@ def decompose_objective(expr: Expression,
                         supported: Optional[AbstractSet[str]] = None,
                         supported_reified: Optional[AbstractSet[str]] = None,
                         csemap: Optional[CSEMap] = None,
-                        decompose_custom: Optional[Dict[str, Callable]]=None) -> Tuple[Expression, List[Expression]]:
+                        decompose_custom: Optional[Dict[str, Callable]]=None) -> tuple[Expression, list[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver
     in the objective function expression (numeric or global).
@@ -138,31 +138,31 @@ def decompose_objective(expr: Expression,
     else:
         return expr, []
 
-def _decompose_in_tree_args(args: ListLike[Any],
+def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                             supported: AbstractSet[str],
                             supported_reified: AbstractSet[str],
                             csemap: Optional[CSEMap]=None,
-                            decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Any], List[Expression]]:
+                            decompose_custom:Optional[Dict[str, Callable]]=None) -> tuple[bool, list[Any]|tuple[Any], list[Expression]]:
     """
-    TODO: OUTDATED DOC!!
-    Decompose any global constraint or global function not supported by the solver, recursive internal version.
+    Well-typed recursive helper function to decompose unsupported global constraints
+    and global functions in the arguments of an Expression.  
 
     INTERNAL function, not guaranteed to remain backward compatible.
 
-    :param lst_of_expr: list, tuple, :class:`~cpmpy.expressions.variables.NDVarArray`,
-        or other sequence of expressions that may use global constraints or global functions.
+    :param args: list of Expressions arguments (list[Any] | tuple[Any, ...])
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
 
-    :returns: ``(changed, newexpr, toplevel)`` where:
+    Returns:  
+        tuple[bool, list[Any], list[Expression]]: (changed, newargs, toplevel)  
         - ``changed`` is True if a decomposition was done (or a recursive call changed something).
-        - ``newexpr`` is the decomposed sequence (same length as ``lst_of_expr``).
+        - ``newargs`` is the decomposed sequence (same length as ``args``).
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
     changed = False
-    toplevel: List[Expression] = []
-    newargs: List[Any] = []
+    toplevel: list[Expression] = []
+    newargs: list[Any] = []
     for arg in args:
         if isinstance(arg, Expression):
             orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
@@ -178,7 +178,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
                     continue
                 # else, global constraint, decompose
                 if decompose_custom is not None and arg.name in decompose_custom:
-                    exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
+                    exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[arg.name](arg))
                 else:
                     exprs, toplevel_exprs = arg.decompose()
 
@@ -201,7 +201,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
                 # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
                 while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
-                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                        newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
                     else:
                         newarg, toplevel_exprs = arg.decompose()
                     arg = newarg
@@ -237,7 +237,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
                 csemap.save_decomposition(orig_for_csemap, arg)
             newargs.append(arg)
         
-        elif isinstance(arg, list):
+        elif isinstance(arg, (list, tuple)):
             rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg, supported=supported,
                                                                              supported_reified=supported_reified,
                                                                              csemap=csemap,
@@ -250,7 +250,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
         elif (isinstance(arg, np.ndarray) and arg.dtype == object):
             if isinstance(arg, NDVarArray):
                 if arg.has_subexpr():
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                     if rec_changed:
                         changed = True
                         newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
@@ -260,7 +260,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
                     newargs.append(arg)
             else:  # regular np.array
                 if arg.dtype == object:
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                     if rec_changed:
                         changed = True
                         newargs.append(np.array(rec_newargs).reshape(arg.shape))

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -19,11 +19,11 @@ This allows to post the decomposed expression tree to the solver if it supports 
 """
 
 import copy
-from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
+from typing import AbstractSet, Optional, Dict, Any, Callable, cast
 import numpy as np
 
 from .cse import CSEMap
-from ..expressions.core import Expression, ListLike, BoolVal, Operator
+from ..expressions.core import Expression, BoolVal, Operator
 from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray, cpm_array
@@ -34,7 +34,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
-                      decompose_custom: Optional[Dict[str, Callable]] = None) -> List[Expression]:
+                      decompose_custom: Optional[Dict[str, Callable]] = None) -> list[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -59,8 +59,8 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    todolist: List[Expression] = []  # these still need to be decomposed
-    newlist: List[Expression] = []
+    todolist: list[Expression] = []  # these still need to be decomposed
+    newlist: list[Expression] = []
     changed = False
     for expr in lst_of_expr:
         if isinstance(expr, (bool, np.bool_)):
@@ -91,7 +91,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 
             # toplevel/positive global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
-                exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
+                exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
             else:
                 exprs, toplevel_exprs = expr.decompose()
             # both might contain globals too
@@ -114,7 +114,7 @@ def decompose_objective(expr: Expression,
                         supported: Optional[AbstractSet[str]] = None,
                         supported_reified: Optional[AbstractSet[str]] = None,
                         csemap: Optional[CSEMap] = None,
-                        decompose_custom: Optional[Dict[str, Callable]]=None) -> Tuple[Expression, List[Expression]]:
+                        decompose_custom: Optional[Dict[str, Callable]]=None) -> tuple[Expression, list[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver
     in the objective function expression (numeric or global).
@@ -148,31 +148,31 @@ def decompose_objective(expr: Expression,
     else:
         return expr, []
 
-def _decompose_in_tree_args(args: ListLike[Any],
+def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                             supported: AbstractSet[str],
                             supported_reified: AbstractSet[str],
                             csemap: Optional[CSEMap]=None,
-                            decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Any], List[Expression]]:
+                            decompose_custom:Optional[Dict[str, Callable]]=None) -> tuple[bool, list[Any]|tuple[Any], list[Expression]]:
     """
-    TODO: OUTDATED DOC!!
-    Decompose any global constraint or global function not supported by the solver, recursive internal version.
+    Well-typed recursive helper function to decompose unsupported global constraints
+    and global functions in the arguments of an Expression.  
 
     INTERNAL function, not guaranteed to remain backward compatible.
 
-    :param lst_of_expr: list, tuple, :class:`~cpmpy.expressions.variables.NDVarArray`,
-        or other sequence of expressions that may use global constraints or global functions.
+    :param args: list of Expressions arguments (list[Any] | tuple[Any, ...])
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
 
-    :returns: ``(changed, newexpr, toplevel)`` where:
+    Returns:  
+        tuple[bool, list[Any], list[Expression]]: (changed, newargs, toplevel)  
         - ``changed`` is True if a decomposition was done (or a recursive call changed something).
-        - ``newexpr`` is the decomposed sequence (same length as ``lst_of_expr``).
+        - ``newargs`` is the decomposed sequence (same length as ``args``).
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
+    toplevel: list[Expression] = []
+    newargs: list[Any] = []
     changed = False
-    toplevel: List[Expression] = []
-    newargs: List[Any] = []
     for arg in args:
         if isinstance(arg, Expression):
             orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
@@ -180,15 +180,14 @@ def _decompose_in_tree_args(args: ListLike[Any],
             # a nested expression (its inside an args)
             if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
                 changed = True
-                decomp = None
                 if (csemap is not None):
                     decomp = csemap.get_decomposition(arg)
-                if decomp is not None:
-                    newargs.append(decomp)
-                    continue
+                    if decomp is not None:
+                        newargs.append(decomp)
+                        continue
                 # else, global constraint, decompose
                 if decompose_custom is not None and arg.name in decompose_custom:
-                    exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
+                    exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[arg.name](arg))
                 else:
                     exprs, toplevel_exprs = arg.decompose()
 
@@ -200,18 +199,17 @@ def _decompose_in_tree_args(args: ListLike[Any],
             
             elif isinstance(arg, GlobalFunction) and arg.name not in supported:
                 changed = True
-                decomp = None
                 if (csemap is not None):
                     decomp = csemap.get_decomposition(arg)
-                if decomp is not None:
-                    newargs.append(decomp)
-                    continue
+                    if decomp is not None:
+                        newargs.append(decomp)
+                        continue
                 # else nested global function, decompose
                 orig_for_csemap = arg
                 # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
                 while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
-                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                        newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
                     else:
                         newarg, toplevel_exprs = arg.decompose()
                     arg = newarg
@@ -223,10 +221,10 @@ def _decompose_in_tree_args(args: ListLike[Any],
                     # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
                     if isinstance(arg, int):
                         # no need to recurse further, stop here
-                        newargs.append(arg)
                         break
                             
                 if isinstance(arg, int):
+                    newargs.append(arg)
                     continue
             
             # if it has subexprs, decompose its arguments too
@@ -246,8 +244,28 @@ def _decompose_in_tree_args(args: ListLike[Any],
             if orig_for_csemap is not None and csemap is not None:
                 csemap.save_decomposition(orig_for_csemap, arg)
             newargs.append(arg)
+            continue
+
+        elif isinstance(arg, np.ndarray) and arg.dtype == object:
+            if isinstance(arg, NDVarArray):
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
+                        if len(rec_toplevel) > 0:
+                            toplevel.extend(toplevel_exprs)
+                        continue
+            else:  # regular np.array
+                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if rec_changed:
+                    changed = True
+                    newargs.append(np.array(rec_newargs).reshape(arg.shape))
+                    if len(rec_toplevel) > 0:
+                        toplevel.extend(toplevel_exprs)
+                    continue
         
-        elif isinstance(arg, list):
+        elif isinstance(arg, (list, tuple)):
             rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg, supported=supported,
                                                                              supported_reified=supported_reified,
                                                                              csemap=csemap,
@@ -255,31 +273,11 @@ def _decompose_in_tree_args(args: ListLike[Any],
             if rec_changed:
                 changed = True
                 newargs.append(rec_newargs)
-            else:
-                newargs.append(arg)
-        elif (isinstance(arg, np.ndarray) and arg.dtype == object):
-            if isinstance(arg, NDVarArray):
-                if arg.has_subexpr():
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                    if rec_changed:
-                        changed = True
-                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
-                    else:
-                        newargs.append(arg)
-                else:
-                    newargs.append(arg)
-            else:  # regular np.array
-                if arg.dtype == object:
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                    if rec_changed:
-                        changed = True
-                        newargs.append(np.array(rec_newargs).reshape(arg.shape))
-                    else:
-                        newargs.append(arg)
-                else:
-                    newargs.append(arg)
-        else:
-            # constants, variables, other expressions are left as is
-            newargs.append(arg)
+                if len(rec_toplevel) > 0:
+                    toplevel.extend(toplevel_exprs)
+                continue
+        
+        # all the rest: not allowed to contain expressions
+        newargs.append(arg)
 
     return (changed, newargs, toplevel)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -19,7 +19,7 @@ This allows to post the decomposed expression tree to the solver if it supports 
 """
 
 import copy
-from typing import AbstractSet, Optional, Dict, Any, Callable, TypeAlias, cast
+from typing import AbstractSet, Optional, Dict, Any, Callable, Protocol, cast, overload
 import numpy as np
 
 from .cse import CSEMap
@@ -28,14 +28,18 @@ from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray, cpm_array
 
-CustomDecompose: TypeAlias = Callable[[GlobalConstraint|GlobalFunction], tuple[list[Expression], list[Expression]]]
+class CustomDecomp(Protocol):
+    @overload
+    def __call__(self, expr: GlobalConstraint, /) -> tuple[list[Expression], list[Expression]]: ...
+    @overload
+    def __call__(self, expr: GlobalFunction, /) -> tuple[Expression, list[Expression]]: ...
 
 def decompose_in_tree(lst_of_expr: list[Expression],
                       supported: Optional[AbstractSet[str]] = None,
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
-                      decompose_custom: Optional[Dict[str, CustomDecompose]] = None) -> list[Expression]:
+                      decompose_custom: Optional[Dict[str, CustomDecomp]] = None) -> list[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -116,7 +120,7 @@ def decompose_objective(expr: Expression,
                         supported: Optional[AbstractSet[str]] = None,
                         supported_reified: Optional[AbstractSet[str]] = None,
                         csemap: Optional[CSEMap] = None,
-                        decompose_custom: Optional[Dict[str, Callable]]=None) -> tuple[Expression, list[Expression]]:
+                        decompose_custom: Optional[Dict[str, CustomDecomp]]=None) -> tuple[Expression, list[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver
     in the objective function expression (numeric or global).
@@ -154,7 +158,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                             supported: AbstractSet[str],
                             supported_reified: AbstractSet[str],
                             csemap: Optional[CSEMap]=None,
-                            decompose_custom:Optional[Dict[str, Callable]]=None) -> tuple[bool, list[Any]|tuple[Any], list[Expression]]:
+                            decompose_custom:Optional[Dict[str, CustomDecomp]]=None) -> tuple[bool, list[Any]|tuple[Any], list[Expression]]:
     """
     Well-typed recursive helper function to decompose unsupported global constraints
     and global functions in the arguments of an Expression.  

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -161,17 +161,13 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
         - ``newargs`` is the decomposed sequence (same length as ``args``).
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
-    _Expression = Expression
-    _GlobalConstraint = GlobalConstraint
-    _GlobalFunction = GlobalFunction
-
     toplevel: list[Expression] = []
     newargs: list[Any] = []
     changed = False
     for arg in args:
-        if isinstance(arg, _Expression):
+        if isinstance(arg, Expression):
             # a nested expression (its inside an args)
-            if isinstance(arg, _GlobalConstraint) and arg.name not in supported_reified:
+            if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
                 changed = True
                 if csemap is not None:
                     decomp = csemap.get_decomposition(arg)
@@ -208,7 +204,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 newargs.append(arg)
                 continue
             
-            elif isinstance(arg, _GlobalFunction) and arg.name not in supported:
+            elif isinstance(arg, GlobalFunction) and arg.name not in supported:
                 changed = True
                 if csemap is not None:
                     decomp = csemap.get_decomposition(arg)
@@ -218,7 +214,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 arg_orig2 = arg
 
                 # a decomposition may consist of a new GlobFunc to decompose...
-                while isinstance(arg, _GlobalFunction) and arg.name not in supported:
+                while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
                         newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
                     else:

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -161,13 +161,17 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
         - ``newargs`` is the decomposed sequence (same length as ``args``).
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
+    _Expression = Expression
+    _GlobalConstraint = GlobalConstraint
+    _GlobalFunction = GlobalFunction
+
     toplevel: list[Expression] = []
     newargs: list[Any] = []
     changed = False
     for arg in args:
-        if isinstance(arg, Expression):
+        if isinstance(arg, _Expression):
             # a nested expression (its inside an args)
-            if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
+            if isinstance(arg, _GlobalConstraint) and arg.name not in supported_reified:
                 changed = True
                 if csemap is not None:
                     decomp = csemap.get_decomposition(arg)
@@ -204,7 +208,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 newargs.append(arg)
                 continue
             
-            elif isinstance(arg, GlobalFunction) and arg.name not in supported:
+            elif isinstance(arg, _GlobalFunction) and arg.name not in supported:
                 changed = True
                 if csemap is not None:
                     decomp = csemap.get_decomposition(arg)
@@ -214,7 +218,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 arg_orig2 = arg
 
                 # a decomposition may consist of a new GlobFunc to decompose...
-                while isinstance(arg, GlobalFunction) and arg.name not in supported:
+                while isinstance(arg, _GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
                         newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
                     else:
@@ -268,7 +272,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                         # we reconstruct it as a cpm_array here
                         newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
                         if len(rec_toplevel) > 0:
-                            toplevel.extend(toplevel_exprs)
+                            toplevel.extend(rec_toplevel)
                         continue
             else:  # regular np.array
                 rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
@@ -277,7 +281,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     # we reconstruct it as a np.array here
                     newargs.append(np.array(rec_newargs).reshape(arg.shape))
                     if len(rec_toplevel) > 0:
-                        toplevel.extend(toplevel_exprs)
+                        toplevel.extend(rec_toplevel)
                     continue
         
         elif isinstance(arg, (list, tuple)):

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -19,11 +19,11 @@ This allows to post the decomposed expression tree to the solver if it supports 
 """
 
 import copy
-from typing import AbstractSet, Optional, Dict, Any, Callable, cast
+from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
 import numpy as np
 
 from .cse import CSEMap
-from ..expressions.core import Expression, BoolVal, Operator
+from ..expressions.core import Expression, ListLike, BoolVal, Operator
 from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray, cpm_array
@@ -34,7 +34,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
-                      decompose_custom: Optional[Dict[str, Callable]] = None) -> list[Expression]:
+                      decompose_custom: Optional[Dict[str, Callable]] = None) -> List[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -59,55 +59,52 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    todolist: list[Expression] = []  # these still need to be decomposed
-    newlist: list[Expression] = []
-    changed = False
+    newlist: List[Expression] = []
+    todolist: List[Expression] = []  # these still need to be decomposed
     for expr in lst_of_expr:
-        if isinstance(expr, (bool, np.bool_)):
-            # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
-            changed = True
-            newlist.append(BoolVal(expr))
-            continue
-
-        # decompose arguments if needed
-        if expr.has_subexpr():
-            args_changed, args_new, args_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-            if args_changed:
-                changed = True
-                expr = copy.copy(expr)
-                expr.update_args(args_new)
-                if len(args_toplevel) > 0:
-                    todolist.extend(args_toplevel)
-
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
-            changed = True
             # toplevel/positive global constraint, decompose
+            decomp = None
+            if (csemap is not None):
+                decomp = csemap.get_decomposition(expr)
+            if decomp is not None:
+                newlist.append(decomp)
+                continue
+            # else, global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
-                exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
+                exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
             else:
                 exprs, toplevel_exprs = expr.decompose()
-            # we merge the list toplevel rather than create an 'and', also means we can not store it in csemap
-            # both might contain globals and need to be checked
+            # both might contain globals too
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
+        elif isinstance(expr, (bool, np.bool_)):
+            # TODO: violates type!!!
+            newlist.append(BoolVal(expr))
+        elif expr.has_subexpr():
+            # decompose its arguments
+            changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+            if changed:
+                expr = copy.copy(expr)
+                expr.update_args(newargs)
+                if len(rec_toplevel) > 0:
+                    todolist.extend(rec_toplevel)
+            newlist.append(expr)
         else:
             newlist.append(expr)
 
     # recurse on any newly generated toplevel expressions
-    if len(todolist) > 0:
-        return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-    elif changed:
+    if len(todolist) == 0:
         return newlist
-    else:  # not changed
-        return lst_of_expr
+    return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
 
 
 def decompose_objective(expr: Expression,
                         supported: Optional[AbstractSet[str]] = None,
                         supported_reified: Optional[AbstractSet[str]] = None,
                         csemap: Optional[CSEMap] = None,
-                        decompose_custom: Optional[Dict[str, Callable]]=None) -> tuple[Expression, list[Expression]]:
+                        decompose_custom: Optional[Dict[str, Callable]]=None) -> Tuple[Expression, List[Expression]]:
     """
     Decompose any global constraint or global function not supported by the solver
     in the objective function expression (numeric or global).
@@ -141,91 +138,70 @@ def decompose_objective(expr: Expression,
     else:
         return expr, []
 
-def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
+def _decompose_in_tree_args(args: ListLike[Any],
                             supported: AbstractSet[str],
                             supported_reified: AbstractSet[str],
                             csemap: Optional[CSEMap]=None,
-                            decompose_custom:Optional[Dict[str, Callable]]=None) -> tuple[bool, list[Any]|tuple[Any], list[Expression]]:
+                            decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Any], List[Expression]]:
     """
-    Well-typed recursive helper function to decompose unsupported global constraints
-    and global functions in the arguments of an Expression.  
+    TODO: OUTDATED DOC!!
+    Decompose any global constraint or global function not supported by the solver, recursive internal version.
 
     INTERNAL function, not guaranteed to remain backward compatible.
 
-    :param args: list of Expressions arguments (list[Any] | tuple[Any, ...])
+    :param lst_of_expr: list, tuple, :class:`~cpmpy.expressions.variables.NDVarArray`,
+        or other sequence of expressions that may use global constraints or global functions.
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
 
-    Returns:  
-        tuple[bool, list[Any], list[Expression]]: (changed, newargs, toplevel)  
+    :returns: ``(changed, newexpr, toplevel)`` where:
         - ``changed`` is True if a decomposition was done (or a recursive call changed something).
-        - ``newargs`` is the decomposed sequence (same length as ``args``).
+        - ``newexpr`` is the decomposed sequence (same length as ``lst_of_expr``).
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
-    toplevel: list[Expression] = []
-    newargs: list[Any] = []
     changed = False
+    toplevel: List[Expression] = []
+    newargs: List[Any] = []
     for arg in args:
         if isinstance(arg, Expression):
-            unsupported_globalcons = False
-            unsupported_globalfunc = False
-            if isinstance(arg, GlobalConstraint):
-                unsupported_globalcons = arg.name not in supported_reified  # as an argumented = nested
-            elif isinstance(arg, GlobalFunction):
-                unsupported_globalfunc = arg.name not in supported
+            orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
 
-            # csemap needs to check & store the expression before recursing over the arguments
-            arg_orig: Optional[Expression] = None
-            if csemap is not None and (unsupported_globalcons or unsupported_globalfunc):
-                # shortcut, already computed
-                decomp = csemap.get_decomposition(arg)
+            # a nested expression (its inside an args)
+            if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
+                changed = True
+                decomp = None
+                if (csemap is not None):
+                    decomp = csemap.get_decomposition(arg)
                 if decomp is not None:
-                    changed = True
                     newargs.append(decomp)
                     continue
-                arg_orig = arg
-
-            # if it has subexprs, decompose its arguments first
-            if arg.has_subexpr():
-                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    changed = True
-                    arg = copy.copy(arg)
-                    arg.update_args(rec_newargs)
-                    if len(rec_toplevel) > 0:
-                        toplevel.extend(rec_toplevel)
-
-            if unsupported_globalcons:
-                changed = True
+                # else, global constraint, decompose
                 if decompose_custom is not None and arg.name in decompose_custom:
-                    exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[arg.name](arg))
+                    exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
                 else:
-                    exprs, toplevel_exprs = cast(GlobalConstraint, arg).decompose()
+                    exprs, toplevel_exprs = arg.decompose()
+
+                # replace arg by conjunction of decompose
+                orig_for_csemap = arg
+                arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
                 if len(toplevel_exprs) > 0:
                     toplevel.extend(toplevel_exprs)
-
-                # the decomp may itself contain globals
-                rec_changed, rec_exprs, rec_toplevel = _decompose_in_tree_args(exprs, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    exprs = cast(list[Expression], rec_exprs)
-                    if len(rec_toplevel) > 0:
-                        toplevel.extend(rec_toplevel)
-
-                if len(exprs) == 1:
-                    arg = exprs[0]
-                else:
-                    # replace arg by conjunction of decompose
-                    arg = Operator("and", exprs)
-                if arg_orig is not None and csemap is not None:
-                    csemap.save_decomposition(arg_orig, arg)
             
-            elif unsupported_globalfunc:
+            elif isinstance(arg, GlobalFunction) and arg.name not in supported:
                 changed = True
+                decomp = None
+                if (csemap is not None):
+                    decomp = csemap.get_decomposition(arg)
+                if decomp is not None:
+                    newargs.append(decomp)
+                    continue
+                # else nested global function, decompose
+                orig_for_csemap = arg
                 # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
                 while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
-                        newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
+                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
                     else:
                         newarg, toplevel_exprs = arg.decompose()
                     arg = newarg
@@ -237,46 +213,31 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
                     if isinstance(arg, int):
                         # no need to recurse further, stop here
+                        newargs.append(arg)
                         break
+                            
                 if isinstance(arg, int):
-                    if arg_orig is not None and csemap is not None:
-                        csemap.save_decomposition(arg_orig, arg)
-                    newargs.append(arg)
                     continue
-
-                # the decomp may itself contain globals
-                rec_changed, rec_arg, rec_toplevel = _decompose_in_tree_args((arg,), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    assert len(rec_arg) == 1, "decompose_in_tree_args: expected a single expression as decomposed global function but got {rec_arg}"
-                    arg = rec_arg[0]
-                    if len(rec_toplevel) > 0:
-                        toplevel.extend(rec_toplevel)
-                if arg_orig is not None and csemap is not None:
-                    csemap.save_decomposition(arg_orig, arg)
-
-            newargs.append(arg)
-            continue
-
-        elif isinstance(arg, np.ndarray) and arg.dtype == object:
-            if isinstance(arg, NDVarArray):
-                if arg.has_subexpr():
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                    if rec_changed:
-                        changed = True
-                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
-                        if len(rec_toplevel) > 0:
-                            toplevel.extend(toplevel_exprs)
-                        continue
-            else:  # regular np.array
-                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+            
+            # if it has subexprs, decompose its arguments too
+            if arg.has_subexpr():
+                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                 if rec_changed:
                     changed = True
-                    newargs.append(np.array(rec_newargs).reshape(arg.shape))
+                    arg = copy.copy(arg)
+                    arg.update_args(rec_newargs)
                     if len(rec_toplevel) > 0:
-                        toplevel.extend(toplevel_exprs)
-                    continue
+                        toplevel.extend(rec_toplevel)
+
+            # very special case: "and" with single argument (from simple glob.decomp)
+            if arg.name == "and" and len(arg.args) == 1:
+                arg = cast(Expression, arg.args[0])
+
+            if orig_for_csemap is not None and csemap is not None:
+                csemap.save_decomposition(orig_for_csemap, arg)
+            newargs.append(arg)
         
-        elif isinstance(arg, (list, tuple)):
+        elif isinstance(arg, list):
             rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg, supported=supported,
                                                                              supported_reified=supported_reified,
                                                                              csemap=csemap,
@@ -284,11 +245,31 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
             if rec_changed:
                 changed = True
                 newargs.append(rec_newargs)
-                if len(rec_toplevel) > 0:
-                    toplevel.extend(toplevel_exprs)
-                continue
-        
-        # all the rest: not allowed to contain expressions
-        newargs.append(arg)
+            else:
+                newargs.append(arg)
+        elif (isinstance(arg, np.ndarray) and arg.dtype == object):
+            if isinstance(arg, NDVarArray):
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
+                    else:
+                        newargs.append(arg)
+                else:
+                    newargs.append(arg)
+            else:  # regular np.array
+                if arg.dtype == object:
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(np.array(rec_newargs).reshape(arg.shape))
+                    else:
+                        newargs.append(arg)
+                else:
+                    newargs.append(arg)
+        else:
+            # constants, variables, other expressions are left as is
+            newargs.append(arg)
 
     return (changed, newargs, toplevel)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -265,6 +265,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                     if rec_changed:
                         changed = True
+                        # we reconstruct it as a cpm_array here
                         newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
                         if len(rec_toplevel) > 0:
                             toplevel.extend(toplevel_exprs)
@@ -273,6 +274,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                 if rec_changed:
                     changed = True
+                    # we reconstruct it as a np.array here
                     newargs.append(np.array(rec_newargs).reshape(arg.shape))
                     if len(rec_toplevel) > 0:
                         toplevel.extend(toplevel_exprs)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -208,7 +208,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 # the decomp may itself contain globals
                 rec_changed, rec_exprs, rec_toplevel = _decompose_in_tree_args(exprs, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                 if rec_changed:
-                    exprs = rec_exprs
+                    exprs = cast(list[Expression], rec_exprs)
                     if len(rec_toplevel) > 0:
                         toplevel.extend(rec_toplevel)
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -66,15 +66,24 @@ def decompose_in_tree(lst_of_expr: list[Expression],
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
             changed = True
+            if csemap is not None:
+                decomp = csemap.get_decomposition(expr)
+                if decomp is not None:
+                    print("YYYYYYYYYYY")
+                    newlist.append(decomp)
+                    continue
+
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
             else:
                 exprs, toplevel_exprs = expr.decompose()
-            # we merge the list toplevel rather than create an 'and', also means we can not store it in csemap
+            # we merge the list toplevel rather than create an 'and'
             # we add them to todolist because both might contain globals
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
+            if csemap is not None:
+                csemap.save_decomposition(expr, Operator("and", exprs))
         elif isinstance(expr, (bool, np.bool_)):
             # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
             changed = True

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -59,18 +59,37 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    newlist: List[Expression] = []
     todolist: List[Expression] = []  # these still need to be decomposed
+    newlist: List[Expression] = []
+    changed = False
     for expr in lst_of_expr:
+        if isinstance(expr, (bool, np.bool_)):
+            # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
+            changed = True
+            newlist.append(BoolVal(expr))
+            continue
+
+        # decompose arguments first (if needed)
+        if expr.has_subexpr():
+            args_changed, args_new, args_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+            if args_changed:
+                changed = True
+                expr = copy.copy(expr)
+                expr.update_args(args_new)
+                if len(args_toplevel) > 0:
+                    todolist.extend(args_toplevel)
+
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
-            # toplevel/positive global constraint, decompose
-            decomp = None
+            changed = True
+
+            # decomposed before?
             if (csemap is not None):
                 decomp = csemap.get_decomposition(expr)
-            if decomp is not None:
-                newlist.append(decomp)
-                continue
-            # else, global constraint, decompose
+                if decomp is not None:
+                    newlist.append(decomp)
+                    continue
+
+            # toplevel/positive global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
             else:
@@ -79,25 +98,16 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
-        elif isinstance(expr, (bool, np.bool_)):
-            # TODO: violates type!!!
-            newlist.append(BoolVal(expr))
-        elif expr.has_subexpr():
-            # decompose its arguments
-            changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-            if changed:
-                expr = copy.copy(expr)
-                expr.update_args(newargs)
-                if len(rec_toplevel) > 0:
-                    todolist.extend(rec_toplevel)
-            newlist.append(expr)
         else:
             newlist.append(expr)
 
     # recurse on any newly generated toplevel expressions
-    if len(todolist) == 0:
+    if len(todolist) > 0:
+        return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    elif changed:
         return newlist
-    return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    else:  # not changed
+        return lst_of_expr
 
 
 def decompose_objective(expr: Expression,

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -19,7 +19,7 @@ This allows to post the decomposed expression tree to the solver if it supports 
 """
 
 import copy
-from typing import AbstractSet, Optional, Dict, Any, Callable, cast
+from typing import AbstractSet, Optional, Dict, Any, Callable, TypeAlias, cast
 import numpy as np
 
 from .cse import CSEMap
@@ -28,13 +28,14 @@ from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray, cpm_array
 
+CustomDecompose: TypeAlias = Callable[[GlobalConstraint|GlobalFunction], tuple[list[Expression], list[Expression]]]
 
 def decompose_in_tree(lst_of_expr: list[Expression],
                       supported: Optional[AbstractSet[str]] = None,
                       supported_reified: Optional[AbstractSet[str]] = None,
                       _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
-                      decompose_custom: Optional[Dict[str, Callable]] = None) -> list[Expression]:
+                      decompose_custom: Optional[Dict[str, CustomDecompose]] = None) -> list[Expression]:
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -74,7 +75,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                     continue
 
             if decompose_custom is not None and expr.name in decompose_custom:
-                exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
+                exprs, toplevel_exprs = decompose_custom[expr.name](expr)
             else:
                 exprs, toplevel_exprs = expr.decompose()
             # we merge the list toplevel rather than create an 'and'
@@ -188,7 +189,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
 
                 # new global constraint, decompose
                 if decompose_custom is not None and arg.name in decompose_custom:
-                    exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[arg.name](arg))
+                    exprs, toplevel_exprs = decompose_custom[arg.name](arg)
                 else:
                     exprs, toplevel_exprs = arg.decompose()
                 if len(toplevel_exprs) > 0:
@@ -226,7 +227,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                 # a decomposition may consist of a new GlobFunc to decompose...
                 while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
-                        newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
+                        newarg, toplevel_exprs = decompose_custom[arg.name](arg)
                     else:
                         newarg, toplevel_exprs = arg.decompose()
                     arg = newarg

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -61,43 +61,44 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 
     todolist: list[Expression] = []  # these still need to be decomposed
     newlist: list[Expression] = []
+    changed = False
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
-            decomp = None
-            if (csemap is not None):
-                decomp = csemap.get_decomposition(expr)
-            if decomp is not None:
-                newlist.append(decomp)
-                continue
-            # else, global constraint, decompose
+            changed = True
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
             else:
                 exprs, toplevel_exprs = expr.decompose()
-            # both might contain globals too
+            # we merge the list toplevel rather than create an 'and', also means we can not store it in csemap
+            # we add them to todolist because both might contain globals
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
         elif isinstance(expr, (bool, np.bool_)):
-            # TODO: violates type!!!
+            # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
+            changed = True
             newlist.append(BoolVal(expr))
         elif expr.has_subexpr():
             # decompose its arguments
-            changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-            if changed:
+            arg_changed, arg_newargs, arg_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+            if arg_changed:
+                changed = True
                 expr = copy.copy(expr)
-                expr.update_args(newargs)
-                if len(rec_toplevel) > 0:
-                    todolist.extend(rec_toplevel)
+                expr.update_args(arg_newargs)
+                if len(arg_toplevel) > 0:
+                    todolist.extend(arg_toplevel)
             newlist.append(expr)
         else:
             newlist.append(expr)
 
     # recurse on any newly generated toplevel expressions
-    if len(todolist) == 0:
+    if len(todolist) > 0:
+        return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    elif changed:
         return newlist
-    return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    else:  # not changed
+        return lst_of_expr
 
 
 def decompose_objective(expr: Expression,
@@ -160,9 +161,9 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
         - ``newargs`` is the decomposed sequence (same length as ``args``).
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
-    changed = False
     toplevel: list[Expression] = []
     newargs: list[Any] = []
+    changed = False
     for arg in args:
         if isinstance(arg, Expression):
             orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -166,40 +166,54 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
     changed = False
     for arg in args:
         if isinstance(arg, Expression):
-            orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
-
             # a nested expression (its inside an args)
             if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
                 changed = True
-                decomp = None
-                if (csemap is not None):
+                if csemap is not None:
                     decomp = csemap.get_decomposition(arg)
-                if decomp is not None:
-                    newargs.append(decomp)
-                    continue
-                # else, global constraint, decompose
+                    if decomp is not None:
+                        newargs.append(decomp)
+                        continue
+                arg_orig = arg
+
+                # new global constraint, decompose
                 if decompose_custom is not None and arg.name in decompose_custom:
                     exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[arg.name](arg))
                 else:
                     exprs, toplevel_exprs = arg.decompose()
-
-                # replace arg by conjunction of decompose
-                orig_for_csemap = arg
-                arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
                 if len(toplevel_exprs) > 0:
                     toplevel.extend(toplevel_exprs)
             
+                # a decomposition may contain globals, recurse into the exprs
+                # we have to do this here anyway, hence we do not recurse into the args upfront
+                # (the csemap catches duplicate effort anyway)
+                rec_changed, rec_newexprs, rec_toplevel = _decompose_in_tree_args(exprs, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if rec_changed:
+                    exprs = cast(list[Expression], rec_newexprs)
+                    if len(rec_toplevel) > 0:
+                        toplevel.extend(rec_toplevel)
+
+                if len(exprs) == 1:
+                    arg = exprs[0]
+                else:
+                    # replace arg by conjunction of decompose
+                    arg = Operator("and", exprs)
+
+                if csemap is not None:
+                    csemap.save_decomposition(arg_orig, arg)
+                newargs.append(arg)
+                continue
+            
             elif isinstance(arg, GlobalFunction) and arg.name not in supported:
                 changed = True
-                decomp = None
-                if (csemap is not None):
+                if csemap is not None:
                     decomp = csemap.get_decomposition(arg)
-                if decomp is not None:
-                    newargs.append(decomp)
-                    continue
-                # else nested global function, decompose
-                orig_for_csemap = arg
-                # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
+                    if decomp is not None:
+                        newargs.append(decomp)
+                        continue
+                arg_orig2 = arg
+
+                # a decomposition may consist of a new GlobFunc to decompose...
                 while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
                         newarg, toplevel_exprs = cast(tuple[Expression, list[Expression]], decompose_custom[arg.name](arg))
@@ -208,35 +222,61 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     arg = newarg
                     if len(toplevel_exprs) > 0:
                         toplevel.extend(toplevel_exprs)
-
-                    # TODO: violates type!!!
-                    # apparently in #630 we decided that decompose may return an int (e.g. for element)...
-                    # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
-                    if isinstance(arg, int):
-                        # no need to recurse further, stop here
-                        newargs.append(arg)
-                        break
                             
+                # TODO: violates type!!!
+                # apparently in #630 we decided that decompose may return an int (e.g. for element)...
+                # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
                 if isinstance(arg, int):
+                    # can't store ints in csemap
+                    newargs.append(arg)
                     continue
             
-            # if it has subexprs, decompose its arguments too
-            if arg.has_subexpr():
-                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                # if the new decomposed arg has subexprs, decompose its arguments too
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        # XXX exception! here we know 'arg' is a new expression, so we don't need to copy
+                        arg.update_args(rec_newargs)
+                        if len(rec_toplevel) > 0:
+                            toplevel.extend(rec_toplevel)
+
+                if csemap is not None:
+                    csemap.save_decomposition(arg_orig2, arg)
+                newargs.append(arg)
+                continue
+
+            else:  # any other expression
+                # if it has subexprs, decompose its arguments
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        arg = copy.copy(arg)
+                        arg.update_args(rec_newargs)
+                        if len(rec_toplevel) > 0:
+                            toplevel.extend(rec_toplevel)
+                    newargs.append(arg)
+                    continue
+        
+        elif isinstance(arg, np.ndarray) and arg.dtype == object:
+            if isinstance(arg, NDVarArray):
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
+                        if len(rec_toplevel) > 0:
+                            toplevel.extend(toplevel_exprs)
+                        continue
+            else:  # regular np.array
+                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                 if rec_changed:
                     changed = True
-                    arg = copy.copy(arg)
-                    arg.update_args(rec_newargs)
+                    newargs.append(np.array(rec_newargs).reshape(arg.shape))
                     if len(rec_toplevel) > 0:
-                        toplevel.extend(rec_toplevel)
-
-            # very special case: "and" with single argument (from simple glob.decomp)
-            if arg.name == "and" and len(arg.args) == 1:
-                arg = cast(Expression, arg.args[0])
-
-            if orig_for_csemap is not None and csemap is not None:
-                csemap.save_decomposition(orig_for_csemap, arg)
-            newargs.append(arg)
+                        toplevel.extend(toplevel_exprs)
+                    continue
         
         elif isinstance(arg, (list, tuple)):
             rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg, supported=supported,
@@ -246,31 +286,11 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
             if rec_changed:
                 changed = True
                 newargs.append(rec_newargs)
-            else:
-                newargs.append(arg)
-        elif (isinstance(arg, np.ndarray) and arg.dtype == object):
-            if isinstance(arg, NDVarArray):
-                if arg.has_subexpr():
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                    if rec_changed:
-                        changed = True
-                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
-                    else:
-                        newargs.append(arg)
-                else:
-                    newargs.append(arg)
-            else:  # regular np.array
-                if arg.dtype == object:
-                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(tuple(arg.flat), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-                    if rec_changed:
-                        changed = True
-                        newargs.append(np.array(rec_newargs).reshape(arg.shape))
-                    else:
-                        newargs.append(arg)
-                else:
-                    newargs.append(arg)
-        else:
-            # constants, variables, other expressions are left as is
-            newargs.append(arg)
+                if len(rec_toplevel) > 0:
+                    toplevel.extend(rec_toplevel)
+                continue
+        
+        # all the rest: not allowed to contain expressions so just append
+        newargs.append(arg)
 
     return (changed, newargs, toplevel)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -69,7 +69,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             newlist.append(BoolVal(expr))
             continue
 
-        # decompose arguments first (if needed)
+        # decompose arguments if needed
         if expr.has_subexpr():
             args_changed, args_new, args_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
             if args_changed:
@@ -81,20 +81,13 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             changed = True
-
-            # decomposed before?
-            if (csemap is not None):
-                decomp = csemap.get_decomposition(expr)
-                if decomp is not None:
-                    newlist.append(decomp)
-                    continue
-
             # toplevel/positive global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[expr.name](expr))
             else:
                 exprs, toplevel_exprs = expr.decompose()
-            # both might contain globals too
+            # we merge the list toplevel rather than create an 'and', also means we can not store it in csemap
+            # both might contain globals and need to be checked
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
@@ -175,37 +168,60 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
     changed = False
     for arg in args:
         if isinstance(arg, Expression):
-            orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
+            unsupported_globalcons = False
+            unsupported_globalfunc = False
+            if isinstance(arg, GlobalConstraint):
+                unsupported_globalcons = arg.name not in supported_reified  # as an argumented = nested
+            elif isinstance(arg, GlobalFunction):
+                unsupported_globalfunc = arg.name not in supported
 
-            # a nested expression (its inside an args)
-            if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
+            # csemap needs to check & store the expression before recursing over the arguments
+            arg_orig: Optional[Expression] = None
+            if csemap is not None and (unsupported_globalcons or unsupported_globalfunc):
+                # shortcut, already computed
+                decomp = csemap.get_decomposition(arg)
+                if decomp is not None:
+                    changed = True
+                    newargs.append(decomp)
+                    continue
+                arg_orig = arg
+
+            # if it has subexprs, decompose its arguments first
+            if arg.has_subexpr():
+                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if rec_changed:
+                    changed = True
+                    arg = copy.copy(arg)
+                    arg.update_args(rec_newargs)
+                    if len(rec_toplevel) > 0:
+                        toplevel.extend(rec_toplevel)
+
+            if unsupported_globalcons:
                 changed = True
-                if (csemap is not None):
-                    decomp = csemap.get_decomposition(arg)
-                    if decomp is not None:
-                        newargs.append(decomp)
-                        continue
-                # else, global constraint, decompose
                 if decompose_custom is not None and arg.name in decompose_custom:
                     exprs, toplevel_exprs = cast(tuple[list[Expression], list[Expression]], decompose_custom[arg.name](arg))
                 else:
-                    exprs, toplevel_exprs = arg.decompose()
-
-                # replace arg by conjunction of decompose
-                orig_for_csemap = arg
-                arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
+                    exprs, toplevel_exprs = cast(GlobalConstraint, arg).decompose()
                 if len(toplevel_exprs) > 0:
                     toplevel.extend(toplevel_exprs)
+
+                # the decomp may itself contain globals
+                rec_changed, rec_exprs, rec_toplevel = _decompose_in_tree_args(exprs, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if rec_changed:
+                    exprs = rec_exprs
+                    if len(rec_toplevel) > 0:
+                        toplevel.extend(rec_toplevel)
+
+                if len(exprs) == 1:
+                    arg = exprs[0]
+                else:
+                    # replace arg by conjunction of decompose
+                    arg = Operator("and", exprs)
+                if arg_orig is not None and csemap is not None:
+                    csemap.save_decomposition(arg_orig, arg)
             
-            elif isinstance(arg, GlobalFunction) and arg.name not in supported:
+            elif unsupported_globalfunc:
                 changed = True
-                if (csemap is not None):
-                    decomp = csemap.get_decomposition(arg)
-                    if decomp is not None:
-                        newargs.append(decomp)
-                        continue
-                # else nested global function, decompose
-                orig_for_csemap = arg
                 # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
                 while isinstance(arg, GlobalFunction) and arg.name not in supported:
                     if decompose_custom is not None and arg.name in decompose_custom:
@@ -222,27 +238,22 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     if isinstance(arg, int):
                         # no need to recurse further, stop here
                         break
-                            
                 if isinstance(arg, int):
+                    if arg_orig is not None and csemap is not None:
+                        csemap.save_decomposition(arg_orig, arg)
                     newargs.append(arg)
                     continue
-            
-            # if it has subexprs, decompose its arguments too
-            if arg.has_subexpr():
-                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+
+                # the decomp may itself contain globals
+                rec_changed, rec_arg, rec_toplevel = _decompose_in_tree_args((arg,), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                 if rec_changed:
-                    changed = True
-                    arg = copy.copy(arg)
-                    arg.update_args(rec_newargs)
+                    assert len(rec_arg) == 1, "decompose_in_tree_args: expected a single expression as decomposed global function but got {rec_arg}"
+                    arg = rec_arg[0]
                     if len(rec_toplevel) > 0:
                         toplevel.extend(rec_toplevel)
+                if arg_orig is not None and csemap is not None:
+                    csemap.save_decomposition(arg_orig, arg)
 
-            # very special case: "and" with single argument (from simple glob.decomp)
-            if arg.name == "and" and len(arg.args) == 1:
-                arg = cast(Expression, arg.args[0])
-
-            if orig_for_csemap is not None and csemap is not None:
-                csemap.save_decomposition(orig_for_csemap, arg)
             newargs.append(arg)
             continue
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -237,7 +237,17 @@ def _decompose_in_tree_args(args: ListLike[Any],
                 csemap.save_decomposition(orig_for_csemap, arg)
             newargs.append(arg)
         
-        elif isinstance(arg, np.ndarray) and arg.dtype == object:
+        elif isinstance(arg, list):
+            rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg, supported=supported,
+                                                                             supported_reified=supported_reified,
+                                                                             csemap=csemap,
+                                                                             decompose_custom=decompose_custom)
+            if rec_changed:
+                changed = True
+                newargs.append(rec_newargs)
+            else:
+                newargs.append(arg)
+        elif (isinstance(arg, np.ndarray) and arg.dtype == object):
             if isinstance(arg, NDVarArray):
                 if arg.has_subexpr():
                     rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -64,6 +64,13 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
+            decomp = None
+            if (csemap is not None):
+                decomp = csemap.get_decomposition(expr)
+            if decomp is not None:
+                newlist.append(decomp)
+                continue
+            # else, global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
             else:
@@ -163,48 +170,54 @@ def _decompose_in_tree_args(args: ListLike[Any],
             # a nested expression (its inside an args)
             if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
                 changed = True
-                if (csemap is not None) and arg in csemap:  # have we decomposed it before?
-                    newargs.append(csemap[arg])
+                decomp = None
+                if (csemap is not None):
+                    decomp = csemap.get_decomposition(arg)
+                if decomp is not None:
+                    newargs.append(decomp)
                     continue
+                # else, global constraint, decompose
+                if decompose_custom is not None and arg.name in decompose_custom:
+                    exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
                 else:
-                    # nested global constraint, decompose
-                    if decompose_custom is not None and arg.name in decompose_custom:
-                        exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
-                    else:
-                        exprs, toplevel_exprs = arg.decompose()
+                    exprs, toplevel_exprs = arg.decompose()
 
-                    # replace arg by conjunction of decompose
-                    orig_for_csemap = arg
-                    arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
-                    if len(toplevel_exprs) > 0:
-                        toplevel.extend(toplevel_exprs)
+                # replace arg by conjunction of decompose
+                orig_for_csemap = arg
+                arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
+                if len(toplevel_exprs) > 0:
+                    toplevel.extend(toplevel_exprs)
+            
             elif isinstance(arg, GlobalFunction) and arg.name not in supported:
                 changed = True
-                if (csemap is not None) and arg in csemap:  # have we decomposed it before?
-                    newargs.append(csemap[arg])
+                decomp = None
+                if (csemap is not None):
+                    decomp = csemap.get_decomposition(arg)
+                if decomp is not None:
+                    newargs.append(decomp)
                     continue
-                else:
-                    # nested global function, decompose
-                    orig_for_csemap = arg
-                    # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
-                    while isinstance(arg, GlobalFunction) and arg.name not in supported:
-                        if decompose_custom is not None and arg.name in decompose_custom:
-                            newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
-                        else:
-                            newarg, toplevel_exprs = arg.decompose()
-                        arg = newarg
-                        if len(toplevel_exprs) > 0:
-                            toplevel.extend(toplevel_exprs)
+                # else nested global function, decompose
+                orig_for_csemap = arg
+                # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
+                while isinstance(arg, GlobalFunction) and arg.name not in supported:
+                    if decompose_custom is not None and arg.name in decompose_custom:
+                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                    else:
+                        newarg, toplevel_exprs = arg.decompose()
+                    arg = newarg
+                    if len(toplevel_exprs) > 0:
+                        toplevel.extend(toplevel_exprs)
 
-                        # TODO: violates type!!!
-                        # apparently in #630 we decided that decompose may return an int (e.g. for element)...
-                        # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
-                        if isinstance(arg, int):
-                            # no need to recurse further, stop here
-                            newargs.append(arg)
-                            break
+                    # TODO: violates type!!!
+                    # apparently in #630 we decided that decompose may return an int (e.g. for element)...
+                    # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
                     if isinstance(arg, int):
-                        continue
+                        # no need to recurse further, stop here
+                        newargs.append(arg)
+                        break
+                            
+                if isinstance(arg, int):
+                    continue
             
             # if it has subexprs, decompose its arguments too
             if arg.has_subexpr():
@@ -221,7 +234,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
                 arg = cast(Expression, arg.args[0])
 
             if orig_for_csemap is not None and csemap is not None:
-                csemap[orig_for_csemap] = arg
+                csemap.save_decomposition(orig_for_csemap, arg)
             newargs.append(arg)
         
         elif isinstance(arg, np.ndarray) and arg.dtype == object:

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -69,8 +69,8 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             if csemap is not None:
                 decomp = csemap.get_decomposition(expr)
                 if decomp is not None:
-                    print("YYYYYYYYYYY")
-                    newlist.append(decomp)
+                    assert decomp.name == "and", "decompose_in_tree: expected a conjunction but got {decomp}"
+                    newlist.extend(decomp.args)
                     continue
 
             if decompose_custom is not None and expr.name in decompose_custom:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -269,9 +269,9 @@ class TestArrayExpressions:
             res *= v.value()
         assert y.value() == res
         # with axis arg
-        x = intvar(0,5,shape=(10,10), name="x")
+        x = intvar(0,5,shape=(10,4), name="x")
         y = intvar(0, 1000, shape=10, name="y")
-        model = cp.Model(y == x.prod(axis=0))
+        model = cp.Model(y == x.prod(axis=1))  # y[i] = product(x[i,:])
         model.solve()
         for i,vv in enumerate(x):
             res = 1

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -1,4 +1,3 @@
-import unittest
 import cpmpy as cp
 from cpmpy.expressions.globalconstraints import GlobalConstraint
 from cpmpy.expressions.globalfunctions import GlobalFunction
@@ -19,7 +18,7 @@ class TestTransfDecomp:
         bv = cp.boolvar(name="bv")
 
         cons = [cp.AllDifferent(ivs)]
-        assert str(decompose_in_tree(cons)) == "[and((x) != (y), (x) != (z), (y) != (z))]"
+        assert str(decompose_in_tree(cons)) == "[(x) != (y), (x) != (z), (y) != (z)]"
         assert str(decompose_in_tree(cons, supported={"alldifferent"})) == str(cons)
 
         # reified
@@ -137,13 +136,16 @@ class TestTransfDecomp:
 
         cons = MyGlobal1([x])
         assert set(map(str,decompose_in_tree([cons], supported={"myglobalfunc","max"}))) == \
-                            {'((myglobalfunc(x[0],x[1])) + 5 <= 0) and (max(x[0],x[1]) == 1)',
+                            {'(myglobalfunc(x[0],x[1])) + 5 <= 0',
+                             'max(x[0],x[1]) == 1',
                              '(x[0]) + (x[1]) >= 3'}
 
         # decompose all
         assert set(map(str, decompose_in_tree([cons], supported={"max"}))) == \
-                            {'(((x[0]) + (x[1])) + 5 <= 0) and (max(x[0],x[1]) == 1)',
-                             '(x[0]) + (x[1]) >= 3','x[0] != 0'}
+                            {'((x[0]) + (x[1])) + 5 <= 0',
+                             'max(x[0],x[1]) == 1',
+                             '(x[0]) + (x[1]) >= 3',
+                             'x[0] != 0'}
 
         # nested case
         bv = cp.boolvar(name="bv")
@@ -155,7 +157,8 @@ class TestTransfDecomp:
 
         assert set(map(str, decompose_in_tree([cons], supported={"max"}))) == \
                             {'(bv) == ((((x[0]) + (x[1])) + 5 <= 0) and (max(x[0],x[1]) == 1))',
-                             '(x[0]) + (x[1]) >= 3', 'x[0] != 0'}
+                             '(x[0]) + (x[1]) >= 3',
+                             'x[0] != 0'}
 
 
     def test_decompose_linear(self):
@@ -165,10 +168,14 @@ class TestTransfDecomp:
 
         cons = cp.AllDifferent(x)
         assert set(map(str, decompose_linear([cons]))) == \
-                            {"and((a == 1) + (b == 1) <= 1, (a == 2) + (b == 2) <= 1, (a == 3) + (b == 3) <= 1)"}
+                            {'(a == 1) + (b == 1) <= 1',
+                             '(a == 2) + (b == 2) <= 1',
+                             '(a == 3) + (b == 3) <= 1'}
         # second call gives same result (no ivarmap state)
         assert set(map(str, decompose_linear([cons]))) == \
-                            {"and((a == 1) + (b == 1) <= 1, (a == 2) + (b == 2) <= 1, (a == 3) + (b == 3) <= 1)"}
+                            {'(a == 1) + (b == 1) <= 1',
+                             '(a == 2) + (b == 2) <= 1',
+                             '(a == 3) + (b == 3) <= 1'}
 
         # nested
         cons = bv == cp.AllDifferent(x)
@@ -202,9 +209,9 @@ class TestTransfDecomp:
 
         cons = cp.AllDifferent(arr)
         assert set(map(str, decompose_linear([cons]))) == \
-                            {'and(sum(a == 1, b == 1, False) <= 1, '
-                             'sum(a == 2, b == 2, True) <= 1, '
-                             'sum(a == 3, b == 3, False) <= 1)'}
+                            {'sum(a == 1, b == 1, False) <= 1',
+                             'sum(a == 2, b == 2, True) <= 1',
+                             'sum(a == 3, b == 3, False) <= 1'}
 
         # also test full transformation stack
         if "gurobi" in cp.SolverLookup.solvernames():  # otherwise, not supported


### PR DESCRIPTION
a better-typed decompose (inspired by the new pattern in negate).

It does show we need to continue typing our expressions #913 :
[ ] Element decompose can return int (even in our test suite there is a case for element), to be changed (see inline comment)
[ ] global constraint decompose can return bool, should only return Expressions

and this one should probably go after the CSEMAP #917  

This typed version should be a good basis for the positive-decompose, e.g. we only want to support that in the for loop in `decompose_in_tree` (which can also check `if expr.name == "->" and expr.args[1] isinstance GlobalConstraint`... for the halfreified positives)