### PR TITLE
Fix self += pattern

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -69,9 +69,9 @@ class Model(object):
         if is_any_list(args):
             # add (and type-check) one by one
             for a in args:
-                self += a
+                self.add(a)
         else:
-            self += args
+            self.add(args)
 
         # store objective if present
         if maximize is not None:

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -330,7 +330,7 @@ class CPM_exact(SolverInterface):
                 return 0
             else:
                 assert my_status == "SAT", "Unexpected status from Exact"
-            self += self.objective_ == objval # fix obj val
+            self.add(self.objective_ == objval) # fix obj val
             end = time.time()
             timelim = self._update_time(timelim, start, end) # update remaining time
 

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -581,10 +581,10 @@ class CPM_gcs(SolverInterface):
                             # lt == x < y
                             # gt == x > y
                             lt_bool, gt_bool = boolvar(shape=2)
-                            self += (lhs < rhs) == lt_bool
-                            self += (lhs > rhs) == gt_bool
+                            self.add((lhs < rhs) == lt_bool)
+                            self.add((lhs > rhs) == gt_bool)
                             if fully_reify:
-                                self += (~bool_lhs).implies(lhs == rhs)
+                                self.add((~bool_lhs).implies(lhs == rhs))
                             self.gcs.post_or_reif(self.solver_vars([lt_bool, gt_bool]), reif_var, False)
                         else:
                             raise NotImplementedError("Not currently supported by Glasgow Constraint Solver API '{}' {}".format)
@@ -695,7 +695,7 @@ class CPM_gcs(SolverInterface):
             elif isinstance(cpm_expr, GlobalConstraint):
                 # GCS also has SmartTable, Regular Language Membership, Knapsack constraints
                 # which could be added in future. 
-                self += cpm_expr.decompose()  # assumes a decomposition exists...
+                self.add(cpm_expr.decompose())  # assumes a decomposition exists...
             else:
                 # Hopefully we don't end up here.
                 raise NotImplementedError(cpm_expr)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -493,7 +493,7 @@ class CPM_minizinc(SolverInterface):
                 break
 
             # add nogood on the user variables
-            self += cpm_any([v != v.value() for v in self.user_vars])
+            self.add(cpm_any([v != v.value() for v in self.user_vars]))
 
         if solution_count == 0:
             # clear user vars if no solution found

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -547,7 +547,7 @@ class CPM_ortools(SolverInterface):
                     x,y = lhs.args
                     if get_bounds(y)[0] <= 0: # not supported, but result of modulo is agnositic to sign of second arg
                         y, link = get_or_make_var(-lhs.args[1], csemap=self._csemap)
-                        self += link
+                        self.add(link)
                     return self.ort_model.AddModuloEquality(ortrhs, *self.solver_vars([x,y]))
                 elif lhs.name == 'pow':
                     # only `POW(b,2) == IV` supported, post as b*b == IV
@@ -561,7 +561,7 @@ class CPM_ortools(SolverInterface):
                         new_lhs = 1
                         for exp in range(n):
                             new_lhs, new_cons = get_or_make_var(b * new_lhs, csemap=self._csemap)
-                            self += new_cons
+                            self.add(new_cons)
                         return self.ort_model.Add(eval_comparison("==", self.solver_var(new_lhs), ortrhs))
 
 
@@ -657,7 +657,7 @@ class CPM_ortools(SolverInterface):
                 N = len(x)
                 arcvars = boolvar(shape=(N,N))
                 # post channeling constraints from int to bool
-                self += [b == (x[i] == j) for (i,j),b in np.ndenumerate(arcvars)]
+                self.add([b == (x[i] == j) for (i,j),b in np.ndenumerate(arcvars)])
                 # post the global constraint
                 # when posting arcs on diagonal (i==j), it would do subcircuit
                 ort_arcs = [(i,j,self.solver_var(b)) for (i,j),b in np.ndenumerate(arcvars) if i != j]

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -224,7 +224,7 @@ class CPM_pindakaas(SolverInterface):
         elif isinstance(cpm_var, _IntVarImpl):  # intvar
             if cpm_var.name not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
-                self += cons
+                self.add(cons)
             else:
                 enc = self.ivarmap[cpm_var.name]
             return self.solver_vars(enc.vars())

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -333,7 +333,7 @@ class CPM_pysat(SolverInterface):
         elif isinstance(cpm_var, _IntVarImpl):  # intvar
             if cpm_var.name not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
-                self += cons
+                self.add(cons)
             else:
                 enc = self.ivarmap[cpm_var.name]
             return self.solver_vars(enc.vars())

--- a/cpmpy/solvers/rc2.py
+++ b/cpmpy/solvers/rc2.py
@@ -242,7 +242,7 @@ class CPM_rc2(CPM_pysat):
 
         terms, cons, k = _encode_lin_expr(self.ivarmap, xs, weights, self.encoding)
 
-        self += cons
+        self.add(cons)
         const += k
 
         # remove terms with coefficient 0 (`only_positive_coefficients_` may return them and RC2 does not accept them)

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -92,7 +92,7 @@ class SolverInterface(object):
         # rest uses own API
         if cpm_model is not None:
             # post all constraints at once, implemented in `add()`
-            self += cpm_model.constraints
+            self.add(cpm_model.constraints)
 
             # post objective
             if cpm_model.objective_ is not None:
@@ -282,7 +282,7 @@ class SolverInterface(object):
                 break
 
             # add nogood on the user variables
-            self += any([v != v.value() for v in self.user_vars if v.value() is not None])
+            self.add(any([v != v.value() for v in self.user_vars if v.value() is not None]))
 
             if time_limit is not None: # update remaining time
                 time_limit -= self.status().runtime


### PR DESCRIPTION
Fixing some leftovers from before we had `solver.add`, which required us to use the `self += constraints` when posting constraints within the solver interfaces.

Not sure if this will do anything runtime-wise but it cleans up the code a bit for sure.