### PR TITLE
Run coverage and upload report in CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -23,3 +23,43 @@ jobs:
     with:
       solver: ${{ matrix.solver }}
       install_commands: ${{ matrix.install_commands || '' }}
+
+  coverage:
+    name: Merge coverage
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install coverage
+        run: pip install coverage
+
+      - name: Download all coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-data-*
+
+      - name: Merge coverage reports
+        run: |
+          set -euo pipefail
+          # Each artifact is in its own directory; rename to unique filenames
+          i=0
+          for dir in coverage-data-*/; do
+            mv "${dir}.coverage" ".coverage.${i}"
+            i=$((i + 1))
+          done
+          coverage combine
+          coverage html -d coverage-html
+          coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload merged coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-html/

--- a/.github/workflows/test-solver.yml
+++ b/.github/workflows/test-solver.yml
@@ -45,11 +45,12 @@ jobs:
         run: |
           set -euo pipefail
           python -m pytest -n auto tests/ --solver "${{ inputs.solver }}" -ref \
-            --cov=cpmpy --cov-report=html:coverage-html --cov-report=xml:coverage.xml
+            --cov=cpmpy --cov-report=
 
-      - name: Upload coverage report
+      - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ inputs.solver }}
-          path: coverage-html/
+          name: coverage-data-${{ inputs.solver }}
+          path: .coverage
+          include-hidden-files: true

--- a/.github/workflows/test-solver.yml
+++ b/.github/workflows/test-solver.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install ".[test, ${{ inputs.solver }}]"
-          pip install pytest-xdist
+          pip install pytest-xdist pytest-cov
 
       - name: Install solver dependencies
         if: ${{ inputs.install_commands != '' }}
@@ -44,4 +44,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pytest -n auto tests/ --solver "${{ inputs.solver }}" -ref
+          python -m pytest -n auto tests/ --solver "${{ inputs.solver }}" -ref \
+            --cov=cpmpy --cov-report=html:coverage-html --cov-report=xml:coverage.xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ inputs.solver }}
+          path: coverage-html/


### PR DESCRIPTION
This "proof-of-concept" PR adds coverage reports to the CI, meaning we get (in each CI job) a downloadable HTML artifact which shows which lines are run during tests which are missing. A missing line which is not run could either be:

- A missing test for it
- More interesting: something we expect to run but isn't e.g. a transformation decomposes a constraint which is actually supported by the solver

Since the solver jobs are split, for this to be more useful we'd probably want to produce just one report rather than per-solver report. Furthermore, there are other test coverage tools we could consider rather than pytest-cov, I didn't really do a comparison (e.g. there's https://docs.codecov.com/docs/code-coverage-with-python, or https://github.com/marketplace/actions/code-coverage-summary). The advantage also is that then you could see the report from a website, rather than having to download the zip/html file from finding the link in the CI logs e.g. https://github.com/CPMpy/cpmpy/actions/runs/24774510169/artifacts/6576393617 for OR-tools. Finally, one could consider failing the CI if the PR degrades coverage (or something), to ensure new lines are actually tested. This can be useful but of course also annoying.