### PR TITLE
more efficient Solver vars

### DIFF
--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -201,7 +201,7 @@ class CPM_exact(SolverInterface):
             warnings.warn(wrn_txt)
 
         # ensure all vars are known to solver
-        self.solver_vars_1d(list(self.user_vars))
+        self.solver_vars_1d(self.user_vars)
 
         self.xct_solver.clearAssumptions()
 
@@ -296,7 +296,7 @@ class CPM_exact(SolverInterface):
             warnings.warn(f"Exact only supports options at initialization: {kwargs.items()}")
 
         # ensure all vars are known to solver
-        self.solver_vars_1d(list(self.user_vars))
+        self.solver_vars_1d(self.user_vars)
 
         self.xct_solver.clearAssumptions()
 
@@ -682,7 +682,7 @@ class CPM_exact(SolverInterface):
         :param vals: list of (corresponding) values for the variables
         """
         # clear previous solution hints
-        self.xct_solver.clearSolutionHints(self.solver_vars_1d(list(self.user_vars)))
+        self.xct_solver.clearSolutionHints(self.solver_vars_1d(self.user_vars))
 
         cpm_vars = flatlist(cpm_vars)
         vals = flatlist(vals)

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -170,7 +170,7 @@ class CPM_exact(SolverInterface):
 
         # fill in variable values
         lst_vars = list(self.user_vars)
-        exact_vals = self.xct_solver.getLastSolutionFor(self.solver_vars(lst_vars))
+        exact_vals = self.xct_solver.getLastSolutionFor(self.solver_vars_1d(lst_vars))
         for cpm_var, val in zip(lst_vars,exact_vals):
             cpm_var._value = bool(val) if isinstance(cpm_var, _BoolVarImpl) else val # xct value is always an int
 
@@ -201,7 +201,7 @@ class CPM_exact(SolverInterface):
             warnings.warn(wrn_txt)
 
         # ensure all vars are known to solver
-        self.solver_vars(list(self.user_vars))
+        self.solver_vars_1d(list(self.user_vars))
 
         self.xct_solver.clearAssumptions()
 
@@ -210,7 +210,7 @@ class CPM_exact(SolverInterface):
             assumptions = list(assumptions)  # iterable to ordered list
             assert all(v.is_bool() for v in assumptions), "Non-Boolean assumptions given to Exact: " + str([v for v in assumptions if not v.is_bool()])
             assump_vals = [int(not isinstance(v, NegBoolView)) for v in assumptions]
-            assump_vars = [self.solver_var(v._bv if isinstance(v, NegBoolView) else v) for v in assumptions]
+            assump_vars = self.solver_vars_1d([v._bv if isinstance(v, NegBoolView) else v for v in assumptions])
             self.assumption_dict = {xct_var: (xct_val,cpm_assump) for (xct_var, xct_val, cpm_assump) in zip(assump_vars,assump_vals,assumptions)}
             self.xct_solver.setAssumptions(list(zip(assump_vars,assump_vals)))
 
@@ -296,7 +296,7 @@ class CPM_exact(SolverInterface):
             warnings.warn(f"Exact only supports options at initialization: {kwargs.items()}")
 
         # ensure all vars are known to solver
-        self.solver_vars(list(self.user_vars))
+        self.solver_vars_1d(list(self.user_vars))
 
         self.xct_solver.clearAssumptions()
 
@@ -485,9 +485,9 @@ class CPM_exact(SolverInterface):
         elif isinstance(lhs, _NumVarImpl):
             xcfvars = [(1,self.solver_var(lhs))]
         elif lhs.name == "sum":
-            xcfvars = [(1,x) for x in self.solver_vars(lhs.args)]
+            xcfvars = [(1,x) for x in self.solver_vars_1d(lhs.args)]
         elif lhs.name == "wsum":
-            xcfvars = list(zip([self.fix(c) for c in lhs.args[0]],self.solver_vars(lhs.args[1])))
+            xcfvars = list(zip([self.fix(c) for c in lhs.args[0]],self.solver_vars_1d(lhs.args[1])))
         else:
             raise NotImplementedError("Exact: Unexpected lhs {} for expression {}".format(lhs.name,lhs))
 
@@ -576,7 +576,7 @@ class CPM_exact(SolverInterface):
                         xct_rhs = self.solver_var(rhs)
                         assert all(isinstance(v, _IntVarImpl) for v in lhs.args), "constant * var should be " \
                                                                                   "rewritten by linearize"
-                        self.xct_solver.addMultiplication(self.solver_vars(lhs.args), True, xct_rhs, True, xct_rhs)
+                        self.xct_solver.addMultiplication(self.solver_vars_1d(lhs.args), True, xct_rhs, True, xct_rhs)
 
                     else:
                         assert isinstance(lhs, Operator) and (lhs.name == "sum" or lhs.name == "wsum")
@@ -679,9 +679,9 @@ class CPM_exact(SolverInterface):
         :param vals: list of (corresponding) values for the variables
         """
         # clear previous solution hints
-        self.xct_solver.clearSolutionHints(self.solver_vars(list(self.user_vars)))
+        self.xct_solver.clearSolutionHints(self.solver_vars_1d(list(self.user_vars)))
 
         cpm_vars = flatlist(cpm_vars)
         vals = flatlist(vals)
         assert (len(cpm_vars) == len(vals)), "Variables and values must have the same size for hinting"
-        self.xct_solver.setSolutionHints(list(zip(self.solver_vars(cpm_vars), vals)))
+        self.xct_solver.setSolutionHints(list(zip(self.solver_vars_1d(cpm_vars), vals)))

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -394,32 +394,35 @@ class CPM_exact(SolverInterface):
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
-            return cpm_var
 
-        # special case, negative-bool-view. Should be eliminated in linearize
-        if isinstance(cpm_var, NegBoolView):
-            raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
+        xct_var = self._varmap.get(cpm_var, None)
 
-        # return it if it already exists
-        if cpm_var in self._varmap:
-            return self._varmap[cpm_var]
+        if xct_var is not None:
+            return xct_var
 
-        # create if it does not exist
-        revar = str(cpm_var)
         if isinstance(cpm_var, _BoolVarImpl):
-            self.xct_solver.addVariable(revar)
-        elif isinstance(cpm_var, _IntVarImpl):
+            if isinstance(cpm_var, NegBoolView):
+                raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
+
+            xct_var = cpm_var.name
+            self.xct_solver.addVariable(xct_var) # does not return anything
+                    
+        elif isinstance(cpm_var, _IntVarImpl): # intvar, encode it
             lb, ub = cpm_var.get_bounds()
             if self.encoding is None:
                 encoding = "order" if ub-lb < 8 else "log" # heuristic bound
             else:
                 encoding = self.encoding # can also force it
-            self.xct_solver.addVariable(revar, lb, ub, encoding)
+            
+            xct_var = cpm_var.name
+            self.xct_solver.addVariable(xct_var, lb, ub, encoding)
+        elif is_num (cpm_var):
+            return cpm_var # TODO check if this case is needed
         else:
             raise NotImplementedError("Not a known var {}".format(cpm_var))
-        self._varmap[cpm_var] = revar
-        return revar
+
+        self._varmap[cpm_var] = xct_var
+        return xct_var
 
 
     def objective(self, expr, minimize):

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -158,21 +158,6 @@ class CPM_highs(SolverInterface):
 
         return self._varmap[cpm_var]
 
-    def solver_vars_1d(self, cpm_vars):
-        """
-           Faster `solver_vars()` for 1 dimensional iterables of ExprLikes
-        """
-        res = []
-        for cpm_var in cpm_vars:
-            solver_var = self._varmap.get(cpm_var, None)
-            if solver_var is not None:
-                # fast path
-                res.append(solver_var)
-            else:
-                # slow path, will check the varmap again
-                res.append(self.solver_var(cpm_var))
-        return res
-
     def _row_from_linexpr(self, linexpr) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.float64], int|float]:
         """
         Convert a flat linear numeric expression (var/sum/wsum)

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -44,7 +44,7 @@
     ==============
 """
 import sys
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Sequence
 import warnings  # for stdout checking
 import numpy as np
 
@@ -52,11 +52,11 @@ from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callbac
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal, ExprLike
 from ..expressions.globalconstraints import DirectConstraint
-from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, boolvar, intvar
+from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, boolvar, intvar, NDVarArray
 from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.utils import is_bool, get_nonneg_args, is_num, is_int, eval_comparison, flatlist, argval, argvals, \
+from ..expressions.utils import is_bool, get_nonneg_args, is_num, is_int, eval_comparison, flatlist, \
     get_bounds, is_true_cst, \
-    is_false_cst, implies, is_any_list
+    is_false_cst, is_any_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
@@ -193,7 +193,7 @@ class CPM_ortools(SolverInterface):
         """
         from ortools.sat.python import cp_model as ort
         # ensure all user vars are known to solver
-        self.solver_vars(list(self.user_vars))
+        self.solver_vars_1d(list(self.user_vars))
 
         # set time limit
         if time_limit is not None:
@@ -202,7 +202,7 @@ class CPM_ortools(SolverInterface):
             self.ort_solver.parameters.max_time_in_seconds = float(time_limit)
 
         if assumptions is not None:
-            ort_assum_vars = self.solver_vars(assumptions)
+            ort_assum_vars = self.solver_vars_1d(assumptions)
             # dict mapping ortools vars to CPMpy vars
             self.assumption_dict = {ort_var.Index(): cpm_var for (cpm_var, ort_var) in zip(assumptions, ort_assum_vars)}
             self.ort_model.ClearAssumptions()  # because add just appends
@@ -393,13 +393,13 @@ class CPM_ortools(SolverInterface):
         # sum or weighted sum
         if isinstance(cpm_expr, Operator):
             if cpm_expr.name == 'sum':
-                return ort.LinearExpr.sum(self.solver_vars(cpm_expr.args))
+                return ort.LinearExpr.sum(self.solver_vars_1d(cpm_expr.args))
             elif cpm_expr.name == "sub":
-                a,b = self.solver_vars(cpm_expr.args)
+                a,b = self.solver_vars_1d(cpm_expr.args)
                 return a - b
             elif cpm_expr.name == 'wsum':
                 w = cpm_expr.args[0]
-                x = self.solver_vars(cpm_expr.args[1])
+                x = self.solver_vars_1d(cpm_expr.args[1])
                 return ort.LinearExpr.weighted_sum(x,w)
 
         raise NotImplementedError("ORTools: Not a known supported numexpr {}".format(cpm_expr))
@@ -486,9 +486,9 @@ class CPM_ortools(SolverInterface):
         if isinstance(cpm_expr, Operator):
             # 'and'/n, 'or'/n, '->'/2
             if cpm_expr.name == 'and':
-                return self.ort_model.AddBoolAnd(self.solver_vars(cpm_expr.args))
+                return self.ort_model.AddBoolAnd(self.solver_vars_1d(cpm_expr.args))
             elif cpm_expr.name == 'or':
-                return self.ort_model.AddBoolOr(self.solver_vars(cpm_expr.args))
+                return self.ort_model.AddBoolOr(self.solver_vars_1d(cpm_expr.args))
             elif cpm_expr.name == '->':
                 assert(isinstance(cpm_expr.args[0], _BoolVarImpl))  # lhs must be boolvar
                 lhs = self.solver_var(cpm_expr.args[0])
@@ -522,15 +522,15 @@ class CPM_ortools(SolverInterface):
             elif cpm_expr.name == '==':
                 # NumExpr == IV, supported by ortools (thanks to `only_numexpr_equality()` transformation)
                 if lhs.name == 'min':
-                    return self.ort_model.AddMinEquality(ortrhs, self.solver_vars(lhs.args))
+                    return self.ort_model.AddMinEquality(ortrhs, self.solver_vars_1d(lhs.args))
                 elif lhs.name == 'max':
-                    return self.ort_model.AddMaxEquality(ortrhs, self.solver_vars(lhs.args))
+                    return self.ort_model.AddMaxEquality(ortrhs, self.solver_vars_1d(lhs.args))
                 elif lhs.name == 'abs':
                     return self.ort_model.AddAbsEquality(ortrhs, self.solver_var(lhs.args[0]))
                 elif lhs.name == 'mul':
-                    return self.ort_model.AddMultiplicationEquality(ortrhs, self.solver_vars(lhs.args))
+                    return self.ort_model.AddMultiplicationEquality(ortrhs, self.solver_vars_1d(lhs.args))
                 elif lhs.name == 'div':
-                    return self.ort_model.AddDivisionEquality(ortrhs, *self.solver_vars(lhs.args))
+                    return self.ort_model.AddDivisionEquality(ortrhs, *self.solver_vars_1d(lhs.args))
                 elif lhs.name == 'element':
                     arr, idx = lhs.args
                     if is_int(idx): # OR-Tools does not handle all constant integer cases
@@ -538,7 +538,7 @@ class CPM_ortools(SolverInterface):
                     # OR-Tools has slight different in argument order
                     return self.ort_model.AddElement(
                         self.solver_var(idx),
-                        self.solver_vars(arr),
+                        self.solver_vars_1d(arr),
                         ortrhs
                     )
                 elif lhs.name == 'mod':
@@ -547,7 +547,7 @@ class CPM_ortools(SolverInterface):
                     if get_bounds(y)[0] <= 0: # not supported, but result of modulo is agnositic to sign of second arg
                         y, link = get_or_make_var(-lhs.args[1], csemap=self._csemap)
                         self.add(link)
-                    return self.ort_model.AddModuloEquality(ortrhs, *self.solver_vars([x,y]))
+                    return self.ort_model.AddModuloEquality(ortrhs, *self.solver_vars_1d([x,y]))
                 elif lhs.name == 'pow':
                     # only `POW(b,2) == IV` supported, post as b*b == IV
                     if not is_num(lhs.args[1]):
@@ -571,21 +571,21 @@ class CPM_ortools(SolverInterface):
         elif isinstance(cpm_expr, GlobalConstraint):
 
             if cpm_expr.name == 'alldifferent':
-                return self.ort_model.AddAllDifferent(self.solver_vars(cpm_expr.args))
+                return self.ort_model.AddAllDifferent(self.solver_vars_1d(cpm_expr.args))
             elif cpm_expr.name == 'table':
                 assert (len(cpm_expr.args) == 2)  # args = [array, table]
                 array, table = cpm_expr.args
-                array = self.solver_vars(array)
+                array = self.solver_vars_1d(array)
                 # table needs to be a list of lists of integers
                 return self.ort_model.AddAllowedAssignments(array, table)
             elif cpm_expr.name == 'negative_table':
                 assert (len(cpm_expr.args) == 2)  # args = [array, table]
                 array, table = cpm_expr.args
-                array = self.solver_vars(array)
+                array = self.solver_vars_1d(array)
                 return self.ort_model.AddForbiddenAssignments(array, table)
             elif cpm_expr.name == "regular":
                 array, transitions, start, accepting = cpm_expr.args
-                array = self.solver_vars(array)
+                array = self.solver_vars_1d(array)
                 return self.ort_model.AddAutomaton(array, cpm_expr.node_map[start], [cpm_expr.node_map[n] for n in accepting], 
                                                    [(cpm_expr.node_map[src], label, cpm_expr.node_map[dst]) for src, label, dst in transitions])
             elif cpm_expr.name == "cumulative":
@@ -601,10 +601,14 @@ class CPM_ortools(SolverInterface):
                 demand, demand_cons = get_nonneg_args(demand)
                 self.add(demand_cons)
 
-                start, dur, end, demand, cap = self.solver_vars([start, dur, end, demand, cap])
-                intervals = [self.ort_model.NewIntervalVar(s,d,e,f"interval_{s}-{d}-{e}") for s,d,e in zip(start,dur,end)]
+                ort_start = self.solver_vars_1d(start)
+                ort_dur = self.solver_vars_1d(dur)
+                ort_end = self.solver_vars_1d(end)
+                intervals = [self.ort_model.NewIntervalVar(s,d,e,f"interval_{s}-{d}-{e}") for s,d,e in zip(ort_start,ort_dur,ort_end)]
 
-                return self.ort_model.AddCumulative(intervals, demand, cap)
+                ort_demand = self.solver_vars_1d(demand)
+                ort_cap = self.solver_var(cap)
+                return self.ort_model.AddCumulative(intervals, ort_demand, ort_cap)
             elif cpm_expr.name == "cumulative_optional":
                 start, dur, end, demand, cap, is_present = cpm_expr.args
                 # ensure duration is non-negative
@@ -618,10 +622,15 @@ class CPM_ortools(SolverInterface):
                 demand, demand_cons = get_nonneg_args(demand, is_present)
                 self.add(demand_cons)
 
-                start, dur, end, demand, cap, is_present = self.solver_vars([start, dur, end, demand, cap, is_present])
-                is_present = [bool(p) if is_bool(p) else p for p in is_present] # convert BoolVals to booleans
-                intervals = [self.ort_model.NewOptionalIntervalVar(s,d,e,p,f"interval_{s}-{d}-{e}-{p}") for s,d,e,p in zip(start,dur,end,is_present)]
-                return self.ort_model.AddCumulative(intervals, demand, cap)
+                ort_start = self.solver_vars_1d(start)
+                ort_dur = self.solver_vars_1d(dur)
+                ort_end = self.solver_vars_1d(end)
+                ort_is_present = [bool(p) if is_bool(p) else self.solver_var(p) for p in is_present] # convert BoolVals to booleans
+                intervals = [self.ort_model.NewOptionalIntervalVar(s,d,e,p,f"interval_{s}-{d}-{e}-{p}") for s,d,e,p in zip(ort_start,ort_dur,ort_end,ort_is_present)]
+
+                ort_demand = self.solver_vars_1d(demand)
+                ort_cap = self.solver_var(cap)
+                return self.ort_model.AddCumulative(intervals, ort_demand, ort_cap)
 
             elif cpm_expr.name == "no_overlap":
                 start, dur, end  = cpm_expr.args
@@ -631,10 +640,12 @@ class CPM_ortools(SolverInterface):
                 if end is None: # need to make the end-variables ourself
                     end = [intvar(*get_bounds(s+d)) for s,d in zip(start, dur)]
 
-                start, dur, end = self.solver_vars([start, dur, end])
-                intervals = [self.ort_model.NewIntervalVar(s, d, e, f"interval_{s}-{d}-{e}") for s, d, e in zip(start, dur, end)]
-
+                ort_start = self.solver_vars_1d(start)
+                ort_dur = self.solver_vars_1d(dur)
+                ort_end = self.solver_vars_1d(end)
+                intervals = [self.ort_model.NewIntervalVar(s, d, e, f"interval_{s}-{d}-{e}") for s, d, e in zip(ort_start, ort_dur, ort_end)]
                 return self.ort_model.AddNoOverlap(intervals)
+
             elif cpm_expr.name == "no_overlap_optional":
                 start, dur, end, is_present = cpm_expr.args
                 dur, dur_cons = get_nonneg_args(dur, is_present)
@@ -643,11 +654,13 @@ class CPM_ortools(SolverInterface):
                 if end is None: # need to make the end-variables ourself
                     end = [intvar(*get_bounds(s+d)) for s,d in zip(start, dur)]
 
-                start, dur, end, is_present = self.solver_vars([start, dur, end, is_present])
-                is_present = [bool(p) if is_bool(p) else p for p in is_present] # convert BoolVals
-                intervals = [self.ort_model.NewOptionalIntervalVar(s, d, e, p, f"interval_{s}-{d}-{e}-{p}") for s, d, e, p in zip(start, dur, end, is_present)]
+                ort_start = self.solver_vars_1d(start)
+                ort_dur = self.solver_vars_1d(dur)
+                ort_end = self.solver_vars_1d(end)
+                ort_is_present = [bool(p) if is_bool(p) else self.solver_var(p) for p in is_present] # convert BoolVals to booleans
+                intervals = [self.ort_model.NewOptionalIntervalVar(s, d, e, p, f"interval_{s}-{d}-{e}-{p}") for s, d, e, p in zip(ort_start, ort_dur, ort_end, ort_is_present)]
+                return self.ort_model.AddNoOverlap(intervals)
 
-                return self.ort_model.add_no_overlap(intervals)
             elif cpm_expr.name == "circuit":
                 # ortools has a constraint over the arcs, so we need to create these
                 # when using an objective over arcs, using these vars direclty is recommended
@@ -663,7 +676,8 @@ class CPM_ortools(SolverInterface):
                 return self.ort_model.AddCircuit(ort_arcs)
             elif cpm_expr.name == 'inverse':
                 assert len(cpm_expr.args) == 2, "inverse() expects two args: fwd, rev"
-                fwd, rev = self.solver_vars(cpm_expr.args)
+                fwd = self.solver_vars_1d(cpm_expr.args[0])
+                rev = self.solver_vars_1d(cpm_expr.args[1])
                 return self.ort_model.AddInverse(fwd, rev)
             elif cpm_expr.name == 'xor':
                 args = cpm_expr.args
@@ -676,7 +690,7 @@ class CPM_ortools(SolverInterface):
 
                 # remove false constants
                 args = [a for a in args if not is_false_cst(a)]
-                return self.ort_model.AddBoolXOr(self.solver_vars(args))
+                return self.ort_model.AddBoolXOr(self.solver_vars_1d(args))
             else:
                 raise NotImplementedError(f"Unknown global constraint {cpm_expr}, should be decomposed! "
                                           f"If you reach this, please report on github.")

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -44,13 +44,13 @@
     ==============
 """
 import sys
-from typing import Optional, List
+from typing import Optional, List, Any
 import warnings  # for stdout checking
 import numpy as np
 
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
 from ..exceptions import NotSupportedError
-from ..expressions.core import Expression, Comparison, Operator, BoolVal
+from ..expressions.core import Expression, Comparison, Operator, BoolVal, ExprLike
 from ..expressions.globalconstraints import DirectConstraint
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, boolvar, intvar
 from ..expressions.globalconstraints import GlobalConstraint
@@ -309,30 +309,29 @@ class CPM_ortools(SolverInterface):
         return cb.solution_count()
 
 
-    def solver_var(self, cpm_var):
+    def solver_var(self, cpm_var: ExprLike) -> Any:
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
-            return cpm_var
+        solver_var = self._varmap.get(cpm_var, None)
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return self.solver_var(cpm_var._bv).Not()
-
-        # create if it does not exist
-        if cpm_var not in self._varmap:
+        if solver_var is None:
             if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.ort_model.NewBoolVar(str(cpm_var))
+                if isinstance(cpm_var, NegBoolView):
+                    # special case: work direclty on var inside the view
+                    return self.solver_var(cpm_var._bv).Not()
+                solver_var = self.ort_model.NewBoolVar(str(cpm_var))
             elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+                solver_var = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+            elif is_num(cpm_var):
+                # allowed to ease posting of constraints with mixed arguments
+                return cpm_var
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var] = solver_var
 
-        return self._varmap[cpm_var]
+        return solver_var
 
 
     def objective(self, expr, minimize):

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -599,14 +599,16 @@ class CPM_ortools(SolverInterface):
                 # ensure duration is non-negative
                 dur, dur_cons = get_nonneg_args(dur)
                 self.add(dur_cons)
+                # make interval variables
+                ort_intervals, task_cons = self._get_ort_intervals(start, dur, end)
+                self.add(task_cons)
+
                 # ensure demand is non-negative
                 demand, demand_cons = get_nonneg_args(demand)
                 self.add(demand_cons)
-                # make interval variables
-                tasks, task_cons = self._get_ort_intervals(start, dur, end)
-                self.add(task_cons)
+                ort_demand = self.solver_vars_1d(demand)
 
-                return self.ort_model.AddCumulative(tasks, self.solver_vars(demand), self.solver_vars(cap))
+                return self.ort_model.AddCumulative(ort_intervals, ort_demand, self.solver_var(cap))
             
             elif cpm_expr.name == "cumulative_optional":
                 if len(cpm_expr.args) == 5:
@@ -618,14 +620,16 @@ class CPM_ortools(SolverInterface):
                 # ensure duration is non-negative
                 dur, dur_cons = get_nonneg_args(dur, is_present)
                 self.add(dur_cons)
+                # make interval variables
+                ort_intervals, task_cons = self._get_ort_intervals(start, dur, end, is_present)
+                self.add(task_cons)
+
                 # ensure demand is non-negative
                 demand, demand_cons = get_nonneg_args(demand, is_present)
                 self.add(demand_cons)
-                # make interval variables
-                tasks, task_cons = self._get_ort_intervals(start, dur, end, is_present)
-                self.add(task_cons)
-                
-                return self.ort_model.AddCumulative(tasks, self.solver_vars(demand), self.solver_vars(cap))
+                ort_demand = self.solver_vars_1d(demand)
+
+                return self.ort_model.AddCumulative(ort_intervals, ort_demand, self.solver_var(cap))
 
             elif cpm_expr.name == "no_overlap":
                 if len(cpm_expr.args) == 2:
@@ -638,9 +642,9 @@ class CPM_ortools(SolverInterface):
                 dur, dur_cons = get_nonneg_args(dur)
                 self.add(dur_cons)
                 # make interval variables
-                tasks, task_cons = self._get_ort_intervals(start, dur, end)
+                ort_intervals, task_cons = self._get_ort_intervals(start, dur, end)
                 self.add(task_cons)
-                return self.ort_model.AddNoOverlap(tasks)
+                return self.ort_model.AddNoOverlap(ort_intervals)
 
             elif cpm_expr.name == "no_overlap_optional":
                 if len(cpm_expr.args) == 3:
@@ -652,19 +656,11 @@ class CPM_ortools(SolverInterface):
                 # ensure duration is non-negative
                 dur, dur_cons = get_nonneg_args(dur, is_present)
                 self.add(dur_cons)
-                # make interval variables   
-                tasks, task_cons = self._get_ort_intervals(start, dur, end, is_present)
+                # make interval variables
+                ort_intervals, task_cons = self._get_ort_intervals(start, dur, end, is_present)
                 self.add(task_cons)
-                return self.ort_model.AddNoOverlap(tasks)
+                return self.ort_model.AddNoOverlap(ort_intervals)
 
-                if end is None: # need to make the end-variables ourself
-                    end = [intvar(*get_bounds(s+d)) for s,d in zip(start, dur)]
-
-                start, dur, end, is_present = self.solver_vars([start, dur, end, is_present])
-                is_present = [bool(p) if is_bool(p) else p for p in is_present] # convert BoolVals
-                intervals = [self.ort_model.NewOptionalIntervalVar(s, d, e, p, f"interval_{s}-{d}-{e}-{p}") for s, d, e, p in zip(start, dur, end, is_present)]
-
-                return self.ort_model.add_no_overlap(intervals)
             elif cpm_expr.name == "circuit":
                 # ortools has a constraint over the arcs, so we need to create these
                 # when using an objective over arcs, using these vars direclty is recommended
@@ -718,9 +714,10 @@ class CPM_ortools(SolverInterface):
         """Helper function to create tasks variables for use in Cumulative and NoOverlap constraints."""
         tasks = []
         cons = []
+        ort_end = self.solver_vars_1d(end) if end is not None else None
         for i, (cpm_s, cpm_d) in enumerate(zip(start, duration)):
 
-            ort_s, ort_d = self.solver_vars([cpm_s, cpm_d])
+            ort_s, ort_d = self.solver_vars_1d((cpm_s, cpm_d))
             
             # handle optional intervals
             if is_present is not None:
@@ -738,7 +735,7 @@ class CPM_ortools(SolverInterface):
                     else:
                         tasks.append(self.ort_model.NewOptionalFixedSizeIntervalVar(ort_s, ort_d, ort_p, f"interval_{cpm_s}-{cpm_d}-{is_present[i]}"))
                 else: # variable sized interval, need to make the end variable ourself
-                    cpm_e, end_cons = get_or_make_var(cpm_s + cpm_d, csemap=self.csemap)
+                    cpm_e, end_cons = get_or_make_var(cpm_s + cpm_d, csemap=self._csemap)
                     cons.extend(end_cons)
                     if ort_p is None:
                         tasks.append(self.ort_model.NewIntervalVar(ort_s, ort_d, cpm_e, f"interval_{cpm_s}-{cpm_d}-{cpm_e}"))
@@ -746,9 +743,9 @@ class CPM_ortools(SolverInterface):
                         tasks.append(self.ort_model.NewOptionalIntervalVar(ort_s, ort_d, cpm_e, ort_p, f"interval_{cpm_s}-{cpm_d}-{cpm_e}-{is_present[i]}"))
             
             elif ort_p is None: # mandatory interval
-                tasks.append(self.ort_model.NewIntervalVar(ort_s, ort_d, self.solver_var(end[i]), f"interval_{cpm_s}-{cpm_d}-{end[i]}"))
+                tasks.append(self.ort_model.NewIntervalVar(ort_s, ort_d, ort_end[i], f"interval_{cpm_s}-{cpm_d}-{end[i]}"))
             else: # optional interval
-                tasks.append(self.ort_model.NewOptionalIntervalVar(ort_s, ort_d, self.solver_var(end[i]), ort_p, f"interval_{cpm_s}-{cpm_d}-{end[i]}-{is_present[i]}"))
+                tasks.append(self.ort_model.NewOptionalIntervalVar(ort_s, ort_d, ort_end[i], ort_p, f"interval_{cpm_s}-{cpm_d}-{end[i]}-{is_present[i]}"))
         
         return tasks, cons
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -315,24 +315,24 @@ class CPM_ortools(SolverInterface):
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
         """
-        solver_var = self._varmap.get(cpm_var, None)
+        ort_var = self._varmap.get(cpm_var, None)
 
-        if solver_var is None:
+        if ort_var is None:
             if isinstance(cpm_var, _BoolVarImpl):
                 if isinstance(cpm_var, NegBoolView):
                     # special case: work direclty on var inside the view
                     return self.solver_var(cpm_var._bv).Not()
-                solver_var = self.ort_model.NewBoolVar(cpm_var.name)
+                ort_var = self.ort_model.NewBoolVar(cpm_var.name)
             elif isinstance(cpm_var, _IntVarImpl):
-                solver_var = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, cpm_var.name)
+                ort_var = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, cpm_var.name)
             elif is_num(cpm_var):
                 # allowed to ease posting of constraints with mixed arguments
                 return cpm_var
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = solver_var
+            self._varmap[cpm_var] = ort_var
 
-        return solver_var
+        return ort_var
 
 
     def objective(self, expr, minimize):

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -322,9 +322,9 @@ class CPM_ortools(SolverInterface):
                 if isinstance(cpm_var, NegBoolView):
                     # special case: work direclty on var inside the view
                     return self.solver_var(cpm_var._bv).Not()
-                solver_var = self.ort_model.NewBoolVar(str(cpm_var))
+                solver_var = self.ort_model.NewBoolVar(cpm_var.name)
             elif isinstance(cpm_var, _IntVarImpl):
-                solver_var = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+                solver_var = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, cpm_var.name)
             elif is_num(cpm_var):
                 # allowed to ease posting of constraints with mixed arguments
                 return cpm_var

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -675,10 +675,10 @@ class CPM_ortools(SolverInterface):
                 ort_arcs = [(i,j,self.solver_var(b)) for (i,j),b in np.ndenumerate(arcvars) if i != j]
                 return self.ort_model.AddCircuit(ort_arcs)
             elif cpm_expr.name == 'inverse':
-                assert len(cpm_expr.args) == 2, "inverse() expects two args: fwd, rev"
-                fwd = self.solver_vars_1d(cpm_expr.args[0])
-                rev = self.solver_vars_1d(cpm_expr.args[1])
-                return self.ort_model.AddInverse(fwd, rev)
+                fwd, rev = cpm_expr.args
+                ort_fwd = self.solver_vars_1d(fwd)
+                ort_rev = self.solver_vars_1d(rev)
+                return self.ort_model.AddInverse(ort_fwd, ort_rev)
             elif cpm_expr.name == 'xor':
                 args = cpm_expr.args
                 if any(is_true_cst(a) for a in cpm_expr.args):

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -710,9 +710,8 @@ class CPM_ortools(SolverInterface):
         """Helper function to create tasks variables for use in Cumulative and NoOverlap constraints."""
         tasks = []
         cons = []
-        for i, (cpm_s, cpm_d) in enumerate(zip(start, duration)):
-
-            ort_s, ort_d = self.solver_vars([cpm_s, cpm_d])
+        ort_start, ort_duration = self.solver_vars_1d(start), self.solver_vars_1d(duration)
+        for i, (cpm_s, cpm_d, ort_s, ort_d) in enumerate(zip(start, duration, ort_start, ort_duration)):
             
             # handle optional intervals
             if is_present is not None:

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -657,14 +657,6 @@ class CPM_ortools(SolverInterface):
                 self.add(task_cons)
                 return self.ort_model.AddNoOverlap(tasks)
 
-                if end is None: # need to make the end-variables ourself
-                    end = [intvar(*get_bounds(s+d)) for s,d in zip(start, dur)]
-
-                start, dur, end, is_present = self.solver_vars([start, dur, end, is_present])
-                is_present = [bool(p) if is_bool(p) else p for p in is_present] # convert BoolVals
-                intervals = [self.ort_model.NewOptionalIntervalVar(s, d, e, p, f"interval_{s}-{d}-{e}-{p}") for s, d, e, p in zip(start, dur, end, is_present)]
-
-                return self.ort_model.add_no_overlap(intervals)
             elif cpm_expr.name == "circuit":
                 # ortools has a constraint over the arcs, so we need to create these
                 # when using an objective over arcs, using these vars direclty is recommended

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -193,7 +193,7 @@ class CPM_ortools(SolverInterface):
         """
         from ortools.sat.python import cp_model as ort
         # ensure all user vars are known to solver
-        self.solver_vars_1d(list(self.user_vars))
+        self.solver_vars_1d(self.user_vars)
 
         # set time limit
         if time_limit is not None:

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -124,7 +124,7 @@ class CPM_pindakaas(SolverInterface):
 
     def _int2bool_user_vars(self):
         # ensure all vars are known to solver
-        self.solver_vars(list(self.user_vars))
+        self.solver_vars_1d(list(self.user_vars))
 
         # the user vars are only the Booleans (e.g. to ensure solveAll behaves consistently)
         user_vars = set()
@@ -157,7 +157,7 @@ class CPM_pindakaas(SolverInterface):
             time_limit_delta = timedelta(seconds=time_limit)
         if assumptions is not None:
             assumptions = list(assumptions)  # iterable to ordered list
-            solver_assumptions = self.solver_vars(assumptions)
+            solver_assumptions = self.solver_vars_1d(assumptions)
         else:
             solver_assumptions = None
 
@@ -215,21 +215,32 @@ class CPM_pindakaas(SolverInterface):
         return has_sol
 
     def solver_var(self, cpm_var):
-        if isinstance(cpm_var, NegBoolView):  # negative literal
-            # get inner variable and return its negated solver var
-            return ~self.solver_var(cpm_var._bv)
-        elif isinstance(cpm_var, _BoolVarImpl):  # positive literal
-            # insert if new
-            if cpm_var.name not in self._varmap:
-                self._varmap[cpm_var.name] = self.pdk_solver.new_var()
-            return self._varmap[cpm_var.name]
-        elif isinstance(cpm_var, _IntVarImpl):  # intvar
+        """
+            Creates solver variable for cpmpy variable
+            or returns from cache if previously created
+        """
+
+        pdk_var = self._varmap.get(cpm_var.name, None)
+
+        if pdk_var is not None:
+            return pdk_var
+        
+        if isinstance(cpm_var, _BoolVarImpl):
+
+            if isinstance(cpm_var, NegBoolView):
+                return ~self.solver_var(cpm_var._bv)
+            pdk_var = self.pdk_solver.new_var()
+            self._varmap[cpm_var.name] = pdk_var
+            return pdk_var
+
+        elif isinstance(cpm_var, _IntVarImpl): # intvar, encode to Boolean
             if cpm_var.name not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
                 self.add(cons)
+                self.ivarmap[cpm_var.name] = enc
             else:
                 enc = self.ivarmap[cpm_var.name]
-            return self.solver_vars(enc.vars())
+            return self.solver_vars_1d(enc.vars())
         else:
             raise TypeError(f"Unexpected type: {cpm_var}")
 
@@ -276,7 +287,7 @@ class CPM_pindakaas(SolverInterface):
         if not isinstance(clause, (tuple, list)):
             raise TypeError
 
-        self.pdk_solver.add_clause(self.solver_vars([~c for c in conditions] + list(clause)))
+        self.pdk_solver.add_clause(self.solver_vars_1d([~c for c in conditions] + list(clause)))
 
     def _post_constraint(self, cpm_expr, conditions=[]):
         if not isinstance(conditions, list):
@@ -317,9 +328,9 @@ class CPM_pindakaas(SolverInterface):
                 raise ValueError(f"Trying to encode non (Boolean) linear constraint: {cpm_expr}")
 
             # Create `pindakaas` Boolean linear expression object
-            lhs = sum(c * l for c, l in zip(coefficients, self.solver_vars(literals)))
+            lhs = sum(c * l for c, l in zip(coefficients, self.solver_vars_1d(literals)))
 
-            self.pdk_solver.add_encoding(eval_comparison(cpm_expr.name, lhs, rhs), conditions=self.solver_vars(conditions))
+            self.pdk_solver.add_encoding(eval_comparison(cpm_expr.name, lhs, rhs), conditions=self.solver_vars_1d(conditions))
         else:
             raise NotSupportedError(f"{self.name}: Unsupported constraint {cpm_expr}")
 

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -124,7 +124,7 @@ class CPM_pindakaas(SolverInterface):
 
     def _int2bool_user_vars(self):
         # ensure all vars are known to solver
-        self.solver_vars_1d(self.user_vars)
+        self.solver_vars_1d(list(self.user_vars))
 
         # the user vars are only the Booleans (e.g. to ensure solveAll behaves consistently)
         user_vars = set()
@@ -287,7 +287,10 @@ class CPM_pindakaas(SolverInterface):
         if not isinstance(clause, (tuple, list)):
             raise TypeError
 
-        self.pdk_solver.add_clause(self.solver_vars_1d([~c for c in conditions] + list(clause)))
+        pdk_vars = self.solver_vars_1d(clause)
+        if len(conditions) > 0:
+            pdk_vars = self.solver_vars_1d(~c for c in conditions) + pdk_vars
+        self.pdk_solver.add_clause(pdk_vars)
 
     def _post_constraint(self, cpm_expr, conditions=[]):
         if not isinstance(conditions, list):

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -111,7 +111,7 @@ class CPM_pindakaas(SolverInterface):
         import pindakaas as pdk
 
         assert subsolver is None, "Pindakaas does not support any subsolvers for the moment"
-        self.ivarmap = dict[_IntVarImpl,IntVarEnc]()  # for the integer to boolean encoders
+        self.ivarmap = dict()  # for the integer to boolean encoders
         self.encoding = "auto"
         self.pdk_solver = pdk.solver.CaDiCaL()
         self.unsatisfiable = False  # `pindakaas` might determine unsat before solving
@@ -124,7 +124,7 @@ class CPM_pindakaas(SolverInterface):
 
     def _int2bool_user_vars(self):
         # ensure all vars are known to solver
-        self.solver_vars_1d(list(self.user_vars))
+        self.solver_vars_1d(self.user_vars)
 
         # the user vars are only the Booleans (e.g. to ensure solveAll behaves consistently)
         user_vars = set()
@@ -133,7 +133,7 @@ class CPM_pindakaas(SolverInterface):
                 user_vars.add(x)
             else:
                 # extends set with encoding variables of `x`
-                user_vars.update(self.ivarmap[x].vars())
+                user_vars.update(self.ivarmap[x.name].vars())
         return user_vars
 
     def solve(self, time_limit: Optional[float] = None, assumptions: Optional[Iterable[_BoolVarImpl]] = None):
@@ -237,9 +237,9 @@ class CPM_pindakaas(SolverInterface):
             if cpm_var not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
                 self.add(cons)
-                self.ivarmap[cpm_var] = enc
+                self.ivarmap[cpm_var.name] = enc # ivarmap still name -- TODO: change _varmap to use str too
             else:
-                enc = self.ivarmap[cpm_var]
+                enc = self.ivarmap[cpm_var.name]
             return self.solver_vars_1d(enc.vars())
         else:
             raise TypeError(f"Unexpected type: {cpm_var}")

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -47,7 +47,7 @@ from ..expressions.utils import eval_comparison
 from ..expressions.variables import NegBoolView, _BoolVarImpl, _IntVarImpl
 from ..transformations.flatten_model import flatten_constraint
 from ..transformations.get_variables import get_variables
-from ..transformations.int2bool import _decide_encoding, _encode_int_var, int2bool
+from ..transformations.int2bool import _decide_encoding, _encode_int_var, int2bool, IntVarEnc
 from ..transformations.linearize import linearize_constraint, linearize_reified_variables, decompose_linear
 from ..transformations.normalize import simplify_boolean, toplevel_list
 from ..transformations.reification import only_bv_reifies, only_implies
@@ -111,7 +111,7 @@ class CPM_pindakaas(SolverInterface):
         import pindakaas as pdk
 
         assert subsolver is None, "Pindakaas does not support any subsolvers for the moment"
-        self.ivarmap = dict()  # for the integer to boolean encoders
+        self.ivarmap = dict[_IntVarImpl,IntVarEnc]()  # for the integer to boolean encoders
         self.encoding = "auto"
         self.pdk_solver = pdk.solver.CaDiCaL()
         self.unsatisfiable = False  # `pindakaas` might determine unsat before solving
@@ -133,7 +133,7 @@ class CPM_pindakaas(SolverInterface):
                 user_vars.add(x)
             else:
                 # extends set with encoding variables of `x`
-                user_vars.update(self.ivarmap[x.name].vars())
+                user_vars.update(self.ivarmap[x].vars())
         return user_vars
 
     def solve(self, time_limit: Optional[float] = None, assumptions: Optional[Iterable[_BoolVarImpl]] = None):
@@ -186,9 +186,9 @@ class CPM_pindakaas(SolverInterface):
                 for cpm_var in self.user_vars:
                     # essentially `.solver_var`, but failing if new vars are added
                     if isinstance(cpm_var, NegBoolView):
-                        lit = ~self._varmap[cpm_var._bv.name]
+                        lit = ~self._varmap[cpm_var._bv]
                     elif isinstance(cpm_var, _BoolVarImpl):
-                        lit = self._varmap[cpm_var.name]
+                        lit = self._varmap[cpm_var]
                     else:
                         raise ValueError(
                             f"Integer variables should have been encoded using `int2bool` transformation, but {cpm_var} is integer, please report on GitHub"
@@ -220,7 +220,7 @@ class CPM_pindakaas(SolverInterface):
             or returns from cache if previously created
         """
 
-        pdk_var = self._varmap.get(cpm_var.name, None)
+        pdk_var = self._varmap.get(cpm_var, None)
 
         if pdk_var is not None:
             return pdk_var
@@ -230,16 +230,16 @@ class CPM_pindakaas(SolverInterface):
             if isinstance(cpm_var, NegBoolView):
                 return ~self.solver_var(cpm_var._bv)
             pdk_var = self.pdk_solver.new_var()
-            self._varmap[cpm_var.name] = pdk_var
+            self._varmap[cpm_var] = pdk_var
             return pdk_var
 
         elif isinstance(cpm_var, _IntVarImpl): # intvar, encode to Boolean
-            if cpm_var.name not in self.ivarmap:
+            if cpm_var not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
                 self.add(cons)
-                self.ivarmap[cpm_var.name] = enc
+                self.ivarmap[cpm_var] = enc
             else:
-                enc = self.ivarmap[cpm_var.name]
+                enc = self.ivarmap[cpm_var]
             return self.solver_vars_1d(enc.vars())
         else:
             raise TypeError(f"Unexpected type: {cpm_var}")

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -19,14 +19,14 @@
         ExitStatus
 
 """
-from typing import Optional, List, Callable, TypeAlias
+from typing import Optional, List, Callable, TypeAlias, Iterable, Any
 import warnings
 import time
 from enum import Enum
 
 from ..exceptions import NotSupportedError
-from ..expressions.core import Expression, ListLike
-from ..expressions.variables import _NumVarImpl
+from ..expressions.core import Expression, ListLike, ExprLike
+from ..expressions.variables import _NumVarImpl, NDVarArray
 from ..transformations.cse import CSEMap
 from ..transformations.get_variables import get_variables
 from ..expressions.utils import is_any_list, argvals
@@ -185,6 +185,24 @@ class SolverInterface(object):
         if is_any_list(cpm_vars):
             return [self.solver_vars(v) for v in cpm_vars]
         return self.solver_var(cpm_vars)
+
+    def solver_vars_1d(self, cpm_vars: Iterable[ExprLike]) -> list[Any]:
+        """
+           Faster `solver_vars()` for 1 dimensional iterables of ExprLikes
+        """
+        res: list[Any] = []
+        for cpm_var in cpm_vars:
+            solver_var = self._varmap.get(cpm_var, None)
+            if solver_var is not None:
+                # fast path
+                res.append(solver_var)
+            elif isinstance(cpm_var, int):
+                # reasonably fast path
+                res.append(cpm_var)
+            else:
+                # slow path, will check the varmap again
+                res.append(self.solver_var(cpm_var))
+        return res
 
     def transform(self, cpm_expr):
         """

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -87,7 +87,7 @@ class SolverInterface(object):
 
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
-        self._varmap = dict[ExprLike, Any]()  # maps cpmpy variables to native solver variables
+        self._varmap = dict()  # maps cpmpy variables to native solver variables
         self._csemap = CSEMap()  # maps cpmpy expressions to previously created expressions (typically auxiliary variables)
 
         # rest uses own API

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -87,7 +87,7 @@ class SolverInterface(object):
 
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
-        self._varmap = dict()  # maps cpmpy variables to native solver variables
+        self._varmap : dict[ExprLike, Any] = dict()  # maps cpmpy variables to native solver variables
         self._csemap = CSEMap()  # maps cpmpy expressions to previously created expressions (typically auxiliary variables)
 
         # rest uses own API

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -87,7 +87,7 @@ class SolverInterface(object):
 
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
-        self._varmap : dict[ExprLike, Any] = dict()  # maps cpmpy variables to native solver variables
+        self._varmap = dict[ExprLike, Any]()  # maps cpmpy variables to native solver variables
         self._csemap = CSEMap()  # maps cpmpy expressions to previously created expressions (typically auxiliary variables)
 
         # rest uses own API

--- a/dev/time_ortools.py
+++ b/dev/time_ortools.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402
+"""
+Time OR-Tools transformation and posting steps on XCSP3 instances.
+
+Iterates over XCSP3 instances (using cpmpy.tools.xcsp3), runs the same
+transformation pipeline as CPM_ortools.transform() step by step, and records
+the time for each phase. It also times `post_constraints`, which measures only
+constraint posting to the OR-Tools model using already transformed constraints.
+
+Output: a single-row CSV with columns date_finished, git_tag, then one column
+per step (aggregated total seconds), step order = order of first appearance in records.
+Also writes time_ortools.records.csv in the same directory: one row per instance, columns instance
+then one per step (same order as in output), values are times for that instance; updated after every instance.
+
+Usage:
+  python dev/time_ortools.py [--year YEAR] [--track TRACK] [-o OUTPUT] [--limit LIMIT]
+                             [--offset OFFSET] [--stop-after STEPNAME]
+                             [--instances-per-problem N] [-j WORKERS]
+                             [--download] [--data PATH] [-v|--verbose]
+"""
+
+import argparse
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import pathlib
+import sys
+import traceback
+import time
+
+import pandas as pd
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from dev.time_transformations import _calc_stats, _write_records, _write_output, step_order_from_records
+
+from cpmpy.tools.xcsp3 import XCSP3Dataset, _parse_xcsp3, _load_xcsp3, decompress_lzma
+from cpmpy.solvers.ortools import CPM_ortools
+from cpmpy.transformations.normalize import toplevel_list
+from cpmpy.transformations.safening import no_partial_functions
+from cpmpy.transformations.negation import push_down_negation
+from cpmpy.transformations.decompose_global import decompose_in_tree
+from cpmpy.transformations.flatten_model import flatten_constraint
+from cpmpy.transformations.reification import only_bv_reifies, only_implies, reify_rewrite
+from cpmpy.transformations.comparison import only_numexpr_equality
+
+
+def _process_instance(args):
+    """Process a single instance; returns (records, stats) or (None, error_msg) on failure.
+    Must be a top-level function for ProcessPoolExecutor pickling.
+    stats: dict with 'runtime', 'n_constraints', 'n_variables'."""
+    path, metadata, track, stop_after = args
+    instance_id = f"{track}/{metadata['name']}"
+    start_time = time.perf_counter()
+
+    if str(path).endswith(".lzma"):
+        path = decompress_lzma(path)
+
+    try:
+        records = []
+        step = "parse_xcsp3"
+        t0 = time.perf_counter()
+        parser = _parse_xcsp3(path)  # type: ignore
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, {"runtime": time.perf_counter() - start_time, "n_constraints": None, "n_variables": None}
+        step = "create_model"
+        t0 = time.perf_counter()
+        model = _load_xcsp3(parser)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, model.constraints)
+    except Exception as e:
+        return (None, str(e))  # (None, error_msg) for load failure
+
+    solver = CPM_ortools(cpm_model=None)
+    cpm_expr = model.constraints
+
+    try:
+        step = "toplevel_list"
+        t0 = time.perf_counter()
+        cpm_expr = toplevel_list(cpm_expr)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "no_partial_functions"
+        t0 = time.perf_counter()
+        cpm_expr = no_partial_functions(cpm_expr, safen_toplevel=frozenset({"div", "mod"}))
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "decompose_in_tree"
+        t0 = time.perf_counter()
+        cpm_expr = decompose_in_tree(
+            cpm_expr,
+            supported=solver.supported_global_constraints,
+            supported_reified=solver.supported_reified_global_constraints,
+            csemap=solver._csemap,
+        )
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "push_down_negation"
+        t0 = time.perf_counter()
+        cpm_expr = push_down_negation(cpm_expr)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "flatten_constraint"
+        t0 = time.perf_counter()
+        cpm_expr = flatten_constraint(cpm_expr, csemap=solver._csemap)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "reify_rewrite"
+        t0 = time.perf_counter()
+        cpm_expr = reify_rewrite(cpm_expr, supported=frozenset({"sum", "wsum"}), csemap=solver._csemap)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "only_numexpr_equality"
+        t0 = time.perf_counter()
+        cpm_expr = only_numexpr_equality(
+            cpm_expr,
+            supported=frozenset({"sum", "wsum", "sub"}),
+            csemap=solver._csemap,
+        )
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "only_bv_reifies"
+        t0 = time.perf_counter()
+        cpm_expr = only_bv_reifies(cpm_expr, csemap=solver._csemap)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        step = "only_implies"
+        t0 = time.perf_counter()
+        cpm_expr = only_implies(cpm_expr, csemap=solver._csemap)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        # Posting-only timing: transformed constraints are already computed.
+        step = "post_constraints"
+        t0 = time.perf_counter()
+        for con in cpm_expr:
+            solver._post_constraint(con)
+        records.append((instance_id, step, time.perf_counter() - t0))
+        if stop_after and step == stop_after:
+            return records, _calc_stats(start_time, cpm_expr)
+
+        # Calculate final stats
+        return records, _calc_stats(start_time, cpm_expr)
+    except Exception:
+        # Capture full traceback for transform failures
+        tb_str = traceback.format_exc()
+        return (None, tb_str)  # (None, traceback_string) for transform failure
+
+
+def time_ortools(dataset, output, limit, offset=0, stop_after=None, instances_per_problem=1, workers=1, verbose=False):
+    """Run transformation timing over the dataset; aggregate and append results to output CSV."""
+    track = getattr(dataset, "track", "default")
+    output_path = pathlib.Path(output)
+    records_path = output_path.parent / "time_ortools.records.csv"
+
+    records = []  # list of (instance, step, time)
+    records_cols = ["instance", "step", "time"]
+    n_failed = 0
+
+    instances = list(dataset)
+    prefix_count = defaultdict(int)
+    filtered = []
+    for path, meta in instances:
+        prefix = meta["name"].split("-")[0]
+        if prefix_count[prefix] < instances_per_problem:
+            prefix_count[prefix] += 1
+            filtered.append((path, meta))
+    filtered = filtered[offset : offset + limit] if limit is not None else filtered[offset:]
+
+    # Read existing output now so we can append our cumulative row (preserves on interrupt)
+    existing_output = None
+    if output_path.exists():
+        try:
+            existing_output = pd.read_csv(output_path)
+        except Exception:
+            existing_output = None
+
+    task_args = [(path, metadata, track, stop_after) for path, metadata in filtered]
+
+    def _format_stats(stats):
+        """Format stats for printing."""
+        runtime_str = f"{stats['runtime']:.2f}s" if stats['runtime'] is not None else "N/A"
+        constraints_str = f"{stats['n_constraints']:,}" if stats['n_constraints'] is not None else "N/A"
+        variables_str = f"{stats['n_variables']:,}" if stats['n_variables'] is not None else "N/A"
+        return f"runtime={runtime_str}, constraints={constraints_str}, variables={variables_str}"
+
+    def _handle_completed_instance(metadata, result):
+        """Shared post-processing for sequential and parallel execution."""
+        nonlocal n_failed
+        if isinstance(result, tuple) and result[0] is None:
+            n_failed += 1
+            if result[1]:
+                if "\n" in result[1]:
+                    print(f"Transform failed {track}/{metadata['name']}:", file=sys.stderr)
+                    print(result[1], file=sys.stderr)
+                else:
+                    print(f"Load failed {track}/{metadata['name']}: {result[1]}", file=sys.stderr)
+            else:
+                print(f"Transform failed {track}/{metadata['name']}", file=sys.stderr)
+            return
+
+        records_list, stats = result
+        records.extend(records_list)
+        _write_records(records, records_path, records_cols)
+        _write_output(records, output_path, records_cols, existing_output)
+        if verbose:
+            print(f"Completed transforming {track}/{metadata['name']} ({_format_stats(stats)})")
+        else:
+            print(f"Completed transforming {track}/{metadata['name']}")
+
+    if workers <= 1:
+        # Sequential: no pool, process one by one, write after each
+        for path, metadata in filtered:
+            result = _process_instance((path, metadata, track, stop_after))
+            _handle_completed_instance(metadata, result)
+    else:
+        # Parallel: each worker runs in its own process (no shared state)
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            future_to_meta = {pool.submit(_process_instance, args): args for args in task_args}
+            for future in as_completed(future_to_meta):
+                _, metadata, _, _ = future_to_meta[future]
+                try:
+                    result = future.result()
+                except Exception as e:
+                    n_failed += 1
+                    print(f"Worker failed {track}/{metadata['name']}: {e}", file=sys.stderr)
+                    continue
+                _handle_completed_instance(metadata, result)
+
+    # Final write (redundant if loop ran, but ensures we have output if no instances completed)
+    if records:
+        _write_output(records, output_path, records_cols, existing_output)
+    step_order = step_order_from_records(records)
+    if step_order:
+        final_step = step_order[-1]
+        n_ok = len({inst for inst, step, _ in records if step == final_step})
+    else:
+        n_ok = 0
+    print(f"Wrote 1 row ({n_ok} instances) to {output_path}")
+    if n_failed:
+        print(f"({n_failed} instances failed load or transform)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Time OR-Tools transformations and posting on XCSP3 instances (no solving).")
+    parser.add_argument("--year", type=int, default=2024, help="Year of the dataset (default 2024)")
+    parser.add_argument("--track", type=str, default="COP", help="XCSP3 track (e.g. COP, MiniCOP)")
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=pathlib.Path("time_ortools.csv"))
+    parser.add_argument("--limit", type=int, default=None, help="Limit the number of instances to process (default None)")
+    parser.add_argument("--offset", type=int, default=0, help="Skip this many instances before starting")
+    parser.add_argument("--stop-after", type=str, default=None, metavar="STEPNAME",
+                        help="Stop after this step (e.g. flatten_constraint or post_constraints)")
+    parser.add_argument("--instances-per-problem", type=int, default=1, metavar="N",
+                        help="Max instances per problem type (prefix before first '-'); default 1")
+    parser.add_argument("-j", "--workers", type=int, default=1, metavar="N",
+                        help="Number of parallel workers (default 1). Each worker runs in a separate process.")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print per-instance runtime/constraints/variables stats.")
+    parser.add_argument("--download", action="store_true", help="Download the dataset if it doesn't exist")
+    parser.add_argument("--data", type=pathlib.Path, default=None, help="Path to the dataset. If combined with --download, the dataset will be downloaded to this path. If not provided, the dataset will be downloaded to / looked for in the current working directory.")
+    args = parser.parse_args()
+
+    root = args.data.resolve() if args.data else pathlib.Path(".").resolve()
+    year = args.year
+    track = args.track
+
+    if not CPM_ortools.supported():
+        print("ortools is not available; install cpmpy[ortools].", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        dataset = XCSP3Dataset(root=str(root), year=year, track=track, download=args.download)
+    except ValueError as e:
+        print(f"Dataset not found for track {track}: {e}", file=sys.stderr)
+        print("Use option --download to download the dataset", file=sys.stderr)
+        sys.exit(1)
+
+    time_ortools(
+        dataset,
+        args.output,
+        args.limit,
+        args.offset,
+        args.stop_after,
+        args.instances_per_problem,
+        args.workers,
+        args.verbose,
+    )


### PR DESCRIPTION
an experiment on ortools based on a side-comment in #412 

2026-04-22T12:54:41Z,v0.10.0-69-g42d87f80,25.9,2.34,4.23,0.0,0.37,2.76,0.24,9.28,0.16,0.16,0.1,1.22,     5.03
2026-04-22T12:53:00Z,v0.10.0-70-g2fa240ed,25.03,2.28,4.18,0.0,0.37,2.72,0.24,9.42,0.16,0.16,0.1,1.2,     4.2
2026-04-22T12:58:39Z,v0.10.0-71-g15d530d6,25.18,2.47,4.35,0.0,0.39,2.77,0.24,9.56,0.16,0.17,0.1,1.24,  3.72

so in this run-once experiments the 2 commit made the 'post constraints' time for time_ortools go from 5s to 4.2s to 3.7s

could be worth applying to all solvers?