### PR TITLE
Test Native MUS function

### DIFF
--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -648,8 +648,7 @@ class CPM_exact(SolverInterface):
         return [self.assumption_dict[i][1] for i in self.xct_solver.getLastCore()]
     
     @classmethod
-    def mus_native(cls, soft, hard=[]):
-        assert False        
+    def mus_native(cls, soft, hard=[]):      
         # Create assumption variables and model with hard + (assumption -> soft)
         from cpmpy.tools.explain.utils import make_assump_model # avoid circular import
         m, soft, assumptions = make_assump_model(soft, hard)

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -648,7 +648,8 @@ class CPM_exact(SolverInterface):
         return [self.assumption_dict[i][1] for i in self.xct_solver.getLastCore()]
     
     @classmethod
-    def mus_native(cls, soft, hard=[]):        
+    def mus_native(cls, soft, hard=[]):
+        assert False        
         # Create assumption variables and model with hard + (assumption -> soft)
         from cpmpy.tools.explain.utils import make_assump_model # avoid circular import
         m, soft, assumptions = make_assump_model(soft, hard)

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -87,7 +87,7 @@ class TestMus:
 # add solvers that implement the native_mus method
 @pytest.mark.requires_solver("exact")       
 class TestNativeMus(TestMus):
-    # use solver from conftest.py
+    # use modern hook to add solver argument to setup method
     @pytest.fixture(autouse=True)
     def setup_method(self, solver):
         self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -4,7 +4,7 @@ import cpmpy as cp
 from cpmpy.tools import mss_opt, marco, OCUSException
 from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, optimal_mus, optimal_mus_naive, mss, mcs, ocus, ocus_naive, mus_native
 
-
+@pytest.mark.requires_solver("ortools")
 class TestMus:
     def setup_method(self):
         self.mus_func = mus
@@ -25,7 +25,7 @@ class TestMus:
         assert set(self.mus_func(cons)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
 
-    def test_bug_191(self):
+    def test_bug_191(self, solver):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
@@ -34,12 +34,12 @@ class TestMus:
         hard = [~bv]
         soft = [bv]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard) # crashes
+        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver) # crashes
         assert set(mus_cons) == set(soft)
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_bug_191_many_soft(self):
+    def test_bug_191_many_soft(self, solver):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
         when the number of soft constraints > 1.
@@ -52,12 +52,12 @@ class TestMus:
             y == 4
         ]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard) # crashes
+        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver) # crashes
         assert set(mus_cons) == set(soft)
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_wglobal(self):
+    def test_wglobal(self, solver):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
 
@@ -76,7 +76,7 @@ class TestMus:
 
         # non-determinstic
         #self.assertEqual(set(mus(cons)), set(cons[1:3]))
-        ms = self.mus_func(cons)
+        ms = self.mus_func(cons, solver=solver)
         assert len(ms) < len(cons)
         assert not cp.Model(ms).solve()
         ms = self.naive_func(cons)
@@ -85,12 +85,10 @@ class TestMus:
         # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
 
 # add solvers that implement the native_mus method
-@pytest.mark.requires_solver("exact")       
+@pytest.mark.requires_solver("exact", "gurobi")       
 class TestNativeMus(TestMus):
-    # use modern hook to add solver argument to setup method
-    @pytest.fixture(autouse=True)
-    def setup_method(self, solver):
-        self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
+    def setup_method(self):
+        self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 
 class TestQuickXplain(TestMus):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -57,7 +57,7 @@ class TestMus:
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_wglobal(self, solver):
+    def test_wglobal(self):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -24,7 +24,6 @@ class TestMus:
 
         assert set(self.mus_func(cons)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
-        assert False
 
 
     def test_bug_191(self):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -6,7 +6,6 @@ from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, 
 
 @pytest.mark.requires_solver("ortools")
 class TestMus:
-    @pytest.fixture
     def setup_method(self):
         self.mus_func = mus
         self.naive_func = mus_naive

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -10,7 +10,7 @@ class TestMus:
         self.mus_func = mus
         self.naive_func = mus_naive
 
-    def test_circular(self):
+    def test_circular(self, solver):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
         cons = [
@@ -25,8 +25,7 @@ class TestMus:
         assert set(self.mus_func(cons)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
 
-
-    def test_bug_191(self):
+    def test_bug_191(self, solver):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
@@ -40,7 +39,7 @@ class TestMus:
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_bug_191_many_soft(self):
+    def test_bug_191_many_soft(self, solver):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
         when the number of soft constraints > 1.
@@ -58,7 +57,7 @@ class TestMus:
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_wglobal(self):
+    def test_wglobal(self, solver):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
 
@@ -86,7 +85,7 @@ class TestMus:
         # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
 @pytest.mark.requires_solver("exact")       
 class TestNativeMusExact(TestMus):
-    def setup_method(self):
+    def setup_method(self, solver):
         self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver="exact")
         self.naive_func = mus_naive
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -87,6 +87,8 @@ class TestMus:
 # add solvers that implement the native_mus method
 @pytest.mark.requires_solver("exact")       
 class TestNativeMus(TestMus):
+    # use solver from conftest.py
+    @pytest.fixture(autouse=True)
     def setup_method(self, solver):
         self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -10,7 +10,7 @@ class TestMus:
         self.mus_func = mus
         self.naive_func = mus_naive
 
-    def test_circular(self):
+    def test_circular(self, solver):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
         cons = [
@@ -22,7 +22,7 @@ class TestMus:
             (x[3] > x[1]).implies((x[3] > x[2]) & ((x[3] == 3) | (x[1] == x[2])))
         ]
 
-        assert set(self.mus_func(cons)) == set(cons[:3])
+        assert set(self.mus_func(cons, solver=solver)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
 
     def test_bug_191(self, solver):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -24,6 +24,8 @@ class TestMus:
 
         assert set(self.mus_func(cons)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
+        assert False
+
 
     def test_bug_191(self):
         """

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -10,7 +10,7 @@ class TestMus:
         self.mus_func = mus
         self.naive_func = mus_naive
 
-    def test_circular(self, solver):
+    def test_circular(self):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
         cons = [
@@ -25,7 +25,7 @@ class TestMus:
         assert set(self.mus_func(cons)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
 
-    def test_bug_191(self, solver):
+    def test_bug_191(self):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
@@ -39,7 +39,7 @@ class TestMus:
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_bug_191_many_soft(self, solver):
+    def test_bug_191_many_soft(self):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
         when the number of soft constraints > 1.
@@ -84,11 +84,12 @@ class TestMus:
         assert not cp.Model(ms).solve()
         # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
 @pytest.mark.requires_solver("exact")       
-class TestNativeMusExact(TestMus):
+class TestNativeMus(TestMus):
     def setup_method(self, solver):
-        self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver="exact")
-        self.naive_func = mus_naive
-
+        # solvers that implement native mus
+        if solver in ["exact"]:
+            self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver=solver)
+            self.naive_func = mus_naive
 
 class TestQuickXplain(TestMus):
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -89,7 +89,7 @@ class TestMus:
 class TestNativeMus(TestMus):
     # use solver from conftest.py
     @pytest.fixture(autouse=True)
-    def setup_method(self, solver):
+    def setup_solver(self, solver):
         self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -88,7 +88,7 @@ class TestMus:
 @pytest.mark.requires_solver("exact")       
 class TestNativeMus(TestMus):
     def setup_method(self, solver):
-        self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver=solver)
+        self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 
 class TestQuickXplain(TestMus):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -34,7 +34,7 @@ class TestMus:
         hard = [~bv]
         soft = [bv]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard, solver="ortools") # crashes
+        mus_cons = self.mus_func(soft=soft, hard=hard) # crashes
         assert set(mus_cons) == set(soft)
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
@@ -89,7 +89,7 @@ class TestMus:
 class TestNativeMus(TestMus):
     # use solver from conftest.py
     @pytest.fixture(autouse=True)
-    def setup_solver(self, solver):
+    def setup_method(self, solver):
         self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -6,6 +6,7 @@ from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, 
 
 @pytest.mark.requires_solver("ortools")
 class TestMus:
+    @pytest.fixture
     def setup_method(self):
         self.mus_func = mus
         self.naive_func = mus_naive
@@ -95,13 +96,11 @@ class TestMus:
         assert len(set(mus_naive_cons)) == 1
         
 # add solvers that implement the native_mus method
-@pytest.mark.requires_solver("exact", "gurobi")       
+@pytest.mark.requires_solver("exact", "gurobi")
 class TestNativeMus(TestMus):
     def setup_method(self):
         self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
-
-
 
 
 class TestQuickXplain(TestMus):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -83,13 +83,13 @@ class TestMus:
         assert len(ms) < len(cons)
         assert not cp.Model(ms).solve()
         # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
+
+# add solvers that implement the native_mus method
 @pytest.mark.requires_solver("exact")       
 class TestNativeMus(TestMus):
     def setup_method(self, solver):
-        # solvers that implement native mus
-        if solver in ["exact"]:
-            self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver=solver)
-            self.naive_func = mus_naive
+        self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver=solver)
+        self.naive_func = mus_naive
 
 class TestQuickXplain(TestMus):
 


### PR DESCRIPTION
Not sure if this is the correct way to do things, but apparently the `native_mus` tests are never run according to Henk's code cov and I confirm this by just putting an` assert False` in the function. Since the test is for exact only I wrote `@pytest.mark.requires_solver("exact")` above the testclass, which probably is related to the issue.

@ThomSerg do you know more about this?