### PR TITLE
listlike: switch from invariant list[T] to covariant Sequence[t]

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -103,7 +103,7 @@ from ..exceptions import TypeError
 
 # Common typing helpers
 T = TypeVar("T")
-ListLike: TypeAlias = Union[list[T], tuple[T, ...], np.ndarray]  # matches is_any_list() check
+ListLike: TypeAlias = Union[Sequence[T], np.ndarray]  # similar to is_any_list() check  (Sequence a bit more general than list/tuple)
 ExprLike: TypeAlias = Union["Expression", int, np.integer, np.bool_]  # expression or int (incl np variants, e.g. user facing)
 
 


### PR DESCRIPTION
so list[Expression] was not a ListLike[ExprLike]...

because list is mutable, and mutable collections are type 'invariant'; what we want is 'covariant' behaviour which would treat Expression as a subclass of ExprLike
https://mypy.readthedocs.io/en/stable/common_issues.html#invariance-vs-covariance

The Sequence type covers tuple and list (and others, like iterators I think) and it is covariant, so that resolves that (and accepts other things we also accept, because we just use generic sequence (iterate, select element) functions on it