### PR TITLE
Pass `verbose` to sub-process in order to save stats

### DIFF
--- a/cpmpy/tools/xcsp3/benchmark.py
+++ b/cpmpy/tools/xcsp3/benchmark.py
@@ -177,14 +177,15 @@ def execute_instance(args: Tuple[str, dict, str, int, int, int, str, bool, bool,
     process = ctx.Process(target=xcsp3_wrapper, args=(
                                                     child_conn, 
                                                       {
-                                                          "benchname": filename, 
-                                                          "solver": solver, 
-                                                          "time_limit": time_limit, 
-                                                          "mem_limit": mem_limit, 
-                                                          "intermediate": intermediate, 
+                                                          "benchname": filename,
+                                                          "solver": solver,
+                                                          "time_limit": time_limit,
+                                                          "mem_limit": mem_limit,
+                                                          "intermediate": intermediate,
                                                           "force_mem_limit": True,
                                                           "time_buffer": 1,
                                                           "cores": cores,
+                                                          "verbose": verbose,
                                                         }, 
                                                     verbose))
     process.start()


### PR DESCRIPTION
Important because if verbose is not passed to the sub-process, it will not output its various statistics (e.g. posting time, solve time, ...)