### PR TITLE
typing of min/max

### DIFF
--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -78,9 +78,9 @@ import numpy as np
 import cpmpy as cp
 
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
-from .core import Expression, Operator, ExprLike, ListLike
-from .variables import boolvar, intvar, cpm_array
-from .utils import flatlist, argval, is_num, is_int, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, implies
+from .core import Expression, Operator, Comparison, ExprLike, ListLike
+from .variables import intvar, NDVarArray
+from .utils import argval, is_num, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, implies, npint2int, argvals_intexpr, get_bounds_intexpr
 
 
 class GlobalFunction(Expression):
@@ -162,18 +162,28 @@ class Minimum(GlobalFunction):
         Arguments:
             arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the minimum
         """
-        super().__init__("min", tuple(flatlist(arg_list)))
+        if isinstance(arg_list, NDVarArray):
+            has_subexpr = arg_list.has_subexpr()
+            return super().__init__("min", tuple(arg_list.flat), has_subexpr=has_subexpr)
+
+        newarg_list = npint2int(arg_list)
+        # arg: tuple[int|Expression, ...]
+        super().__init__("min", tuple(newarg_list))
+    
+    @property
+    def args(self) -> tuple[int|Expression, ...]:
+        """ READ-ONLY, well-typed argument of this global function """
+        return self._args
 
     def value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The minimum value of the arguments, or None if any argument is not assigned
         """
-        vargs = [argval(a) for a in self.args]
-        if any(val is None for val in vargs):
+        vals = argvals_intexpr(self.args)
+        if vals is None:
             return None
-
-        return min(vargs)
+        return min(vals)
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
         """
@@ -196,8 +206,8 @@ class Minimum(GlobalFunction):
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the minimum value
         """
-        bnds = [get_bounds(x) for x in self.args]
-        return min(lb for lb, ub in bnds), min(ub for lb, ub in bnds)
+        lbs, ubs = get_bounds_intexpr(self.args)
+        return min(lbs), min(ubs)
 
 
 class Maximum(GlobalFunction):
@@ -210,18 +220,29 @@ class Maximum(GlobalFunction):
         Arguments:
             arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the maximum
         """
-        super().__init__("max", tuple(flatlist(arg_list)))
+        if isinstance(arg_list, NDVarArray):
+            has_subexpr = arg_list.has_subexpr()
+            return super().__init__("max", tuple(arg_list.flat), has_subexpr=has_subexpr)
+
+        newarg_list = npint2int(arg_list)
+        # arg: tuple[int|Expression, ...]
+        super().__init__("max", tuple(newarg_list))
+
+    @property
+    def args(self) -> tuple[int|Expression, ...]:
+        """ READ-ONLY, well-typed argument of this global function """
+        return self._args
 
     def value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The maximum value of the arguments, or None if any argument is not assigned
         """
-        vargs = [argval(a) for a in self.args]
-        if any(val is None for val in vargs):
+        vals = argvals_intexpr(self.args)
+        if vals is None:
             return None
 
-        return max(vargs)
+        return max(vals)
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
         """
@@ -244,8 +265,8 @@ class Maximum(GlobalFunction):
         Returns:
             tuple[int, int]: A tuple of (lower bound, upper bound) for the maximum value
         """
-        bnds = [get_bounds(x) for x in self.args]
-        return max(lb for lb, ub in bnds), max(ub for lb, ub in bnds)
+        lbs, ubs = get_bounds_intexpr(self.args)
+        return max(lbs), max(ubs)
 
 
 class Abs(GlobalFunction):

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -73,14 +73,14 @@
 
 """
 import warnings  # for deprecation warning
-from typing import Optional
+from typing import Optional, Iterable
 import numpy as np
 import cpmpy as cp
 
 from ..exceptions import CPMpyException, IncompleteFunctionError, TypeError
-from .core import Expression, Operator, Comparison, ExprLike, ListLike
-from .variables import intvar, NDVarArray
-from .utils import argval, is_num, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, implies, npint2int, argvals_intexpr, get_bounds_intexpr
+from .core import Expression, Operator, ExprLike, ListLike
+from .variables import intvar, NDVarArray, _NumVarImpl, BoolVal
+from .utils import argval, is_num, eval_comparison, is_any_list, is_boolexpr, get_bounds, argvals, implies, argvals_intexpr, get_bounds_intexpr, npint2int
 
 
 class GlobalFunction(Expression):
@@ -162,13 +162,16 @@ class Minimum(GlobalFunction):
         Arguments:
             arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the minimum
         """
-        if isinstance(arg_list, NDVarArray):
-            has_subexpr = arg_list.has_subexpr()
-            return super().__init__("min", tuple(arg_list.flat), has_subexpr=has_subexpr)
+        has_subexpr: Optional[bool] = None
 
-        newarg_list = npint2int(arg_list)
-        # arg: tuple[int|Expression, ...]
-        super().__init__("min", tuple(newarg_list))
+        arg_iter: Iterable[ExprLike] = arg_list
+        if isinstance(arg_list, np.ndarray):
+            if isinstance(arg_list, NDVarArray):
+                has_subexpr = arg_list.has_subexpr()
+            arg_iter = arg_list.flat
+
+        args: tuple[int|Expression, ...] = npint2int(arg_iter)
+        super().__init__("min", args, has_subexpr=has_subexpr)
     
     @property
     def args(self) -> tuple[int|Expression, ...]:
@@ -220,13 +223,16 @@ class Maximum(GlobalFunction):
         Arguments:
             arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the maximum
         """
-        if isinstance(arg_list, NDVarArray):
-            has_subexpr = arg_list.has_subexpr()
-            return super().__init__("max", tuple(arg_list.flat), has_subexpr=has_subexpr)
+        has_subexpr: Optional[bool] = None
 
-        newarg_list = npint2int(arg_list)
-        # arg: tuple[int|Expression, ...]
-        super().__init__("max", tuple(newarg_list))
+        arg_iter: Iterable[ExprLike] = arg_list
+        if isinstance(arg_list, np.ndarray):
+            if isinstance(arg_list, NDVarArray):
+                has_subexpr = arg_list.has_subexpr()
+            arg_iter = arg_list.flat
+
+        args: tuple[int|Expression, ...] = npint2int(arg_iter)
+        super().__init__("max", args, has_subexpr=has_subexpr)
 
     @property
     def args(self) -> tuple[int|Expression, ...]:

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -170,6 +170,7 @@ class Minimum(GlobalFunction):
                 has_subexpr = arg_list.has_subexpr()
             arg_iter = arg_list.flat
 
+        # convert numpy integers to Python integers
         args: tuple[int|Expression, ...] = npint2int(arg_iter)
         super().__init__("min", args, has_subexpr=has_subexpr)
     
@@ -231,6 +232,7 @@ class Maximum(GlobalFunction):
                 has_subexpr = arg_list.has_subexpr()
             arg_iter = arg_list.flat
 
+        # convert numpy integers to Python integers
         args: tuple[int|Expression, ...] = npint2int(arg_iter)
         super().__init__("max", args, has_subexpr=has_subexpr)
 

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -175,7 +175,7 @@ class Minimum(GlobalFunction):
     
     @property
     def args(self) -> tuple[int|Expression, ...]:
-        """ READ-ONLY, well-typed argument of this global function """
+        """ READ-ONLY, well-typed argument of this global function, no numpy ints"""
         return self._args
 
     def value(self) -> Optional[int]:
@@ -236,7 +236,7 @@ class Maximum(GlobalFunction):
 
     @property
     def args(self) -> tuple[int|Expression, ...]:
-        """ READ-ONLY, well-typed argument of this global function """
+        """ READ-ONLY, well-typed argument of this global function, no numpy ints"""
         return self._args
 
     def value(self) -> Optional[int]:

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -35,12 +35,12 @@ import numpy as np
 import math
 from collections.abc import Iterable  # for flatten
 from itertools import combinations
-from typing import TYPE_CHECKING, TypeGuard, overload
+from typing import TYPE_CHECKING, TypeGuard, Optional, overload, cast
 from cpmpy.exceptions import IncompleteFunctionError
 
 if TYPE_CHECKING:
     # only import for type checking
-    from cpmpy.expressions.core import BoolExprLike, Expression
+    from cpmpy.expressions.core import ListLike, ExprLike, BoolExprLike, Expression
     from cpmpy.expressions.variables import NDVarArray
 
 
@@ -153,6 +153,18 @@ def argvals(arr):
         return [argvals(arg) for arg in arr]
     return argval(arr)
 
+def argvals_intexpr(lst: Iterable[int|Expression]) -> Optional[list[int]]:
+    """ The well-typed way to get the values of a list of int|Expression, or None if any expression is not assigned """
+    vals: list[int] = []
+    for e in lst:
+        if isinstance(e, int):
+            vals.append(e)
+        else:  # Expression
+            v = e.value()
+            if v is None:
+                return None
+            vals.append(v)
+    return vals
 
 def eval_comparison(str_op, lhs, rhs):
     """
@@ -208,6 +220,20 @@ def get_bounds(expr):
         if is_bool(expr):
             return int(expr), int(expr)
         return math.floor(expr), math.ceil(expr)
+
+def get_bounds_intexpr(lst: Iterable[int|Expression]) -> tuple[list[int], list[int]]:
+    """ The well-typed way to get the bounds of a list of ExprLike's """
+    lbs: list[int] = []
+    ubs: list[int] = []
+    for e in lst:
+        if isinstance(e, int):
+            lbs.append(e)
+            ubs.append(e)
+        else:  # Expression
+            (lb, ub) = e.get_bounds()
+            lbs.append(lb)
+            ubs.append(ub)
+    return lbs, ubs
 
 # first two are declarations for typing purposes only
 @overload
@@ -282,3 +308,21 @@ def is_star(arg):
         Check if arg is star as used in the ShortTable global constraint
     """
     return isinstance(arg, type(STAR)) and arg == STAR
+
+def npint2int(lst: ListLike[ExprLike]) -> ListLike[int|Expression]:
+    """ Convert numpy integers in list to Python integers """
+
+    newlst: Optional[list[int|Expression]] = None  # only create when first needed
+    for i,elem in enumerate(lst):
+        if isinstance(elem, np.integer):
+            if newlst is None:
+                newlst = cast(list[int|Expression], lst[:i])
+            newlst.append(int(elem))
+        else:
+            if newlst is not None:
+                newlst.append(elem)
+    if newlst is not None:
+        return newlst
+    return lst  # type: ignore  # typer doesn't see its valid, cant cast because cyclic dependency
+     
+

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -35,12 +35,12 @@ import numpy as np
 import math
 from collections.abc import Iterable  # for flatten
 from itertools import combinations
-from typing import TYPE_CHECKING, TypeGuard, Optional, overload, cast
+from typing import TYPE_CHECKING, TypeGuard, Optional, overload
 from cpmpy.exceptions import IncompleteFunctionError
 
 if TYPE_CHECKING:
     # only import for type checking
-    from cpmpy.expressions.core import ListLike, ExprLike, BoolExprLike, Expression
+    from cpmpy.expressions.core import ExprLike, BoolExprLike, Expression
     from cpmpy.expressions.variables import NDVarArray
 
 
@@ -309,20 +309,9 @@ def is_star(arg):
     """
     return isinstance(arg, type(STAR)) and arg == STAR
 
-def npint2int(lst: ListLike[ExprLike]) -> ListLike[int|Expression]:
-    """ Convert numpy integers in list to Python integers """
 
-    newlst: Optional[list[int|Expression]] = None  # only create when first needed
-    for i,elem in enumerate(lst):
-        if isinstance(elem, np.integer):
-            if newlst is None:
-                newlst = cast(list[int|Expression], lst[:i])
-            newlst.append(int(elem))
-        else:
-            if newlst is not None:
-                newlst.append(elem)
-    if newlst is not None:
-        return newlst
-    return lst  # type: ignore  # typer doesn't see its valid, cant cast because cyclic dependency
+def npint2int(iter: Iterable[ExprLike]) -> tuple[int|Expression, ...]:
+    """Convert numpy values in iterable to Python integers, return as tuple."""
+    return tuple(int(el) if isinstance(el, (np.integer, np.bool_)) else el for el in iter)
      
 

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -35,7 +35,7 @@ import numpy as np
 import math
 from collections.abc import Iterable  # for flatten
 from itertools import combinations
-from typing import TYPE_CHECKING, TypeGuard, Optional, overload
+from typing import TYPE_CHECKING, TypeGuard, Optional, overload, Final
 from cpmpy.exceptions import IncompleteFunctionError
 
 if TYPE_CHECKING:
@@ -43,6 +43,11 @@ if TYPE_CHECKING:
     from cpmpy.expressions.core import ExprLike, BoolExprLike, Expression
     from cpmpy.expressions.variables import NDVarArray
 
+NP_TYPES: Final = frozenset({
+    np.int8, np.int16, np.int32, np.int64,
+    np.uint8, np.uint16, np.uint32, np.uint64,
+    np.bool_
+})
 
 def is_bool(arg):
     """ is it a boolean (incl numpy variants)
@@ -154,7 +159,7 @@ def argvals(arr):
     return argval(arr)
 
 def argvals_intexpr(lst: Iterable[int|Expression]) -> Optional[list[int]]:
-    """ The well-typed way to get the values of a list of int|Expression, or None if any expression is not assigned """
+    """ A well-typed helper function to get the values of a list of int|Expression, or None if any expression is not assigned """
     vals: list[int] = []
     for e in lst:
         if isinstance(e, int):
@@ -222,7 +227,7 @@ def get_bounds(expr):
         return math.floor(expr), math.ceil(expr)
 
 def get_bounds_intexpr(lst: Iterable[int|Expression]) -> tuple[list[int], list[int]]:
-    """ The well-typed way to get the bounds of a list of ExprLike's """
+    """ A well-typed helper function to get the bounds of a list of int|Expression's """
     lbs: list[int] = []
     ubs: list[int] = []
     for e in lst:
@@ -312,6 +317,6 @@ def is_star(arg):
 
 def npint2int(iter: Iterable[ExprLike]) -> tuple[int|Expression, ...]:
     """Convert numpy values in iterable to Python integers, return as tuple."""
-    return tuple(int(el) if isinstance(el, (np.integer, np.bool_)) else el for el in iter)
+    return tuple(int(el) if type(el) in NP_TYPES else el for el in iter)  # type: ignore  # it can't see we're removing the np.integers
      
 


### PR DESCRIPTION
This is a small, more specialised subset of #910 mypy_globfunc (consider that one on hold)
Here we for the first time filter out the np.integers in a global, so we don't have to account for them later...

With that, we don't need the
circular imported Expression in the typed utils
(because with int|Expression, if not int, then implicitly Expression)