### PR TITLE
Canonicalize neq comparisons in csemap

### DIFF
--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -2,7 +2,7 @@ import copy
 from typing import Optional, Any, cast, overload, Literal
 from ..expressions.core import Expression, Comparison
 from ..expressions.utils import is_int
-from ..expressions.variables import boolvar, intvar, _IntVarImpl, _BoolVarImpl
+from ..expressions.variables import NegBoolView, boolvar, intvar, _IntVarImpl, _BoolVarImpl
 
 
 class CSEMap:
@@ -89,7 +89,8 @@ class CSEMap:
 
             self.flat_map[expr] = bv
             if negate: # return the negated variable to get the original expression back
-                return ~bv, Comparison("==", expr, bv)
+                neg_bv = cast(NegBoolView, ~bv) # __invert__ of _BoolVarImpl returns Expression, but we know it is a NegBoolView
+                return neg_bv, Comparison("==", expr, bv)
             return bv, Comparison("==", expr, bv)
         else:
             iv = intvar(*expr.get_bounds())

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -1,4 +1,5 @@
-from typing import Optional, Any, overload, Literal
+import copy
+from typing import Optional, Any, cast, overload, Literal
 from ..expressions.core import Expression, Comparison
 from ..expressions.utils import is_int
 from ..expressions.variables import boolvar, intvar, _IntVarImpl, _BoolVarImpl
@@ -27,6 +28,13 @@ class CSEMap:
     @overload
     def get(self, expr: Expression, default: Any) -> Any: ...
     def get(self, expr: Expression, default: Any = None) -> Any:
+        if expr.is_bool():
+            expr, negate = self._canonicalize_boolexpr(expr)
+            res = self.flat_map.get(expr, default)
+            if res is not None and negate: # return negated Boolean variable, stored negation in flat_map
+                return ~res
+            return res
+            
         return self.flat_map.get(expr, default)
 
     def save_decomposition(self, expr: Expression, newexpr: Expression):
@@ -71,14 +79,33 @@ class CSEMap:
         if isinstance(expr, _IntVarImpl):
             return expr, None
 
-        if expr in self.flat_map:
-            return self.flat_map[expr], None
+        res = self.get(expr)
+        if res is not None:
+            return res, None # already made a variable for expr
 
-        elif expr.is_bool():
+        if expr.is_bool():
             bv = boolvar()
+            expr, negate = self._canonicalize_boolexpr(expr)
+
             self.flat_map[expr] = bv
+            if negate: # return the negated variable to get the original expression back
+                return ~bv, Comparison("==", expr, bv)
             return bv, Comparison("==", expr, bv)
         else:
             iv = intvar(*expr.get_bounds())
             self.flat_map[expr] = iv
             return iv, Comparison("==", expr, iv)
+
+
+    def _canonicalize_boolexpr(self, expr: Expression) -> tuple[Expression, bool]:
+        """canonicalize a Boolean expression, results in more hits in the flat_map"""
+
+        if isinstance(expr, Comparison):
+            lhs, rhs = expr.args
+            if expr.name == "!=" and is_int(rhs):
+                # b <-> (expr != val) :: (~b) <-> (expr == val)
+                expr = copy.copy(expr)
+                expr.name = "=="
+                return expr, True
+            
+        return expr, False

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -89,7 +89,7 @@ class CSEMap:
 
             self.flat_map[expr] = bv
             if negate: # return the negated variable to get the original expression back
-                neg_bv = cast(NegBoolView, ~bv) # __invert__ of _BoolVarImpl returns Expression, but we know it is a NegBoolView
+                neg_bv = NegBoolView(bv) # invert
                 return neg_bv, Comparison("==", expr, bv)
             return bv, Comparison("==", expr, bv)
         else:
@@ -105,8 +105,8 @@ class CSEMap:
             lhs, rhs = expr.args
             if expr.name == "!=" and is_int(rhs):
                 # b <-> (expr != val) :: (~b) <-> (expr == val)
-                expr = copy.copy(expr)
-                expr.name = "=="
-                return expr, True
+                new_expr = Comparison("==", lhs, rhs)
+                new_expr._has_subexpr = expr._has_subexpr
+                return new_expr, True
             
         return expr, False

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -642,14 +642,15 @@ class TestLinearizeReifiedVariablesThreshold:
 
         assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1, (BV[a == 3]) or (BV[a == 2])]"
 
-    # The following tests are marked with `xfail` because they are expected to fail, because they are not yet implemented; to see the current output compared with the desired output in the test, run with `pytest --runxfail`
-    @pytest.mark.xfail(reason="aspirational")
     def test_linearize_reified_disequalities(self):
         """Use direct encoding on disequalities and replace `a != 1` expressions"""
         a = self.a
         out = linearize_reified_variables(self.linearize((a != 1) | (a != 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
-        assert str(out) == "[(~BV[a == 1]) or (~BV[a == 2]), sum([BV[a == 1], BV[a == 2], BV[a == 3]]) == 1"
+        assert str(out) == "[(~BV[a == 1]) or (~BV[a == 2]), sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1]"
 
+    
+    # The following tests are marked with `xfail` because they are expected to fail, because they are not yet implemented; to see the current output compared with the desired output in the test, run with `pytest --runxfail`
+    
     @pytest.mark.xfail(reason="aspirational")
     def test_linearize_reified_inequalities(self):
         """Use order encoding on inequalities and replace `a>=1` expressions"""


### PR DESCRIPTION
Some small canonicalization to improve the csemap.

If we encounter `var != val` as a subexpression, we now make a Boolean variable `bv` with the consrtaint `bv <-> var == val` and return `~bv`.
This increases the number of hits in the csemap, and greatly improves the linearize_reified_varvals transformation.