### PR TITLE
Remove Gurobi TODO

### DIFF
--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -619,7 +619,7 @@ class CPM_gurobi(SolverInterface):
             else:
                 raise TypeError(f"Unexpected Gurobi constraint {grb_con} of type {type(grb_con)}")
 
-        assert all(in_iis(grb_hard_con) for grb_hard_con in grb_hard_cons), "Gurobi did not properly enforce the hard constraints for this instance, which has led to a potentially non-minimal MUS. Until the bug is resolved, you should use another MUS algorithm. Please report on GitHub."
+        assert all(in_iis(grb_hard_con) for grb_hard_con in grb_hard_cons), "Gurobi did not properly enforce the hard constraints for this instance, which has led to a potentially non-minimal MUS. Until Gurobi resolves their bug (requests/116323), you should use another MUS algorithm."
 
         # Return `soft_con` if its representing Gurobi constraint is in the IIS
         return [soft_con for soft_con, grb_soft_con in zip(soft_cons, grb_soft_cons) if in_iis(grb_soft_con)]

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -619,8 +619,7 @@ class CPM_gurobi(SolverInterface):
             else:
                 raise TypeError(f"Unexpected Gurobi constraint {grb_con} of type {type(grb_con)}")
 
-        # TODO once the bug is resolved, we should only perform this check for older versions of Gurobi (see ticket https://support.gurobi.com/hc/en-us/requests/116323)
-        assert all(in_iis(grb_hard_con) for grb_hard_con in grb_hard_cons), "Due to an upstream bug in Gurobi, the hard constraints have not properly been enforced for this instance, which has led to a potentially non-minimal MUS. Until the bug is resolved, you should use another MUS algorithm."
+        assert all(in_iis(grb_hard_con) for grb_hard_con in grb_hard_cons), "Gurobi did not properly enforce the hard constraints for this instance, which has led to a potentially non-minimal MUS. Until the bug is resolved, you should use another MUS algorithm. Please report on GitHub."
 
         # Return `soft_con` if its representing Gurobi constraint is in the IIS
         return [soft_con for soft_con, grb_soft_con in zip(soft_cons, grb_soft_cons) if in_iis(grb_soft_con)]


### PR DESCRIPTION
There was a gurobi IIS bug, which is now resolved in 13.0.2, however, I'd say we should probably leave in this assert for safety (rather than adding a version guard). It's a non-trivial check (going over each transformed hard constraint), however, it should still be much faster than the IIS call itself. So this PR just removes the TODO (otherwise we can use this PR to do the version guard to only do the check if `gurobipy<=13.0.2`)