### PR TITLE
Save expr == var in csemap to catch silly user mistakes

### DIFF
--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -18,8 +18,8 @@ class CSEMap:
     def __getitem__(self, expr: Expression) -> _IntVarImpl:
         return self.flat_map[expr]
 
-    def __setitem__(self, attr, val):
-        raise ValueError("__setitem__ is not supported for flat_map, use get_or_make_var instead")
+    def __setitem__(self, attr: Expression, val: _IntVarImpl) -> None:
+        self.flat_map[attr] = val
 
     @overload
     def get(self, expr: Expression) -> Optional[_IntVarImpl]: ...

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -229,7 +229,6 @@ def flatten_constraint(expr, csemap=None):
             exprname = expr.name  # so it can be modified
             lexpr, rexpr = expr.args
             rewritten = False
-
             # rewrite 'Var # Expr' to normalized 'Expr # Var' (where # is any comparator)
             if __is_flat_var(lexpr) and not __is_flat_var(rexpr):
                 assert (expr.name in ('==', '!=', '>', '>=', '<', '<='))
@@ -245,6 +244,12 @@ def flatten_constraint(expr, csemap=None):
                     exprname = '>'
                 elif exprname == '<=':
                     exprname = '>='
+
+            # save expr == var to the csemap, so we don't make a new variable for expr later
+            if csemap is not None and exprname == '==': # cheap checks first
+                if isinstance(lexpr, Expression) and isinstance(rexpr, Expression) and \
+                    lexpr.is_bool() == rexpr.is_bool() and __is_flat_var(rexpr): # types must match
+                    csemap[lexpr] = rexpr # save lexpr == rexpr to the csemap
 
             # already flat?
             if not expr.has_subexpr():

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -196,6 +196,6 @@ class TestCSE:
         assert len(flat_cons) == 3
         assert str(flat_cons[0]) == "(BV0) == (aux)"
         assert str(flat_cons[1]) == "((a) or (b)) == (BV0)"
-        assert str(flat_cons[2]) == "(x) * (IV0) <= 10"
+        assert str(flat_cons[2]) == "(x) * (BV0) <= 10"
 
     ### other transformations only use csemap as argument to flatten_constraint internally, not sure how to easily test them

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -153,4 +153,49 @@ class TestCSE:
                          '(x) + (y)': 'IV3'} # flat expr
         assert {str(key): str(val) for key, val in csemap.flat_map.items()} == csemap_should
 
+    def test_expr_eq_var_flatten(self):
+
+        x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
+        a,b = cp.boolvar(shape=2, name=tuple("ab"))
+
+        constraints = []
+        aux_var = cp.intvar(0,10, name="aux") # mimic as if the user made the variable themselves
+        constraints += [aux_var == x + y]
+        # but then promplty forgot about it
+        constraints += [z * (x + y) <= 10] # lhs is not flat
+        csemap = CSEMap()
+        flat_cons = flatten_constraint(constraints, csemap=csemap)
+        assert len(flat_cons) == 2
+        assert str(flat_cons[0]) == "((x) + (y)) == (aux)"
+        assert str(flat_cons[1]) == "(z) * (aux) <= 10"
+        assert len(csemap) == 1
+        assert str(csemap.flat_map[x + y]) == "aux"
+
+        # check for Boolean
+        constraints = []
+        aux_var = cp.boolvar(name="aux") # mimic as if the user made the variable themselves
+        constraints += [aux_var == a | b]
+        # but then promplty forgot about it
+        constraints += [x * (a | b) <= 10] # lhs is not flat
+        csemap = CSEMap()
+        flat_cons = flatten_constraint(constraints, csemap=csemap)
+        assert len(flat_cons) == 2
+        assert str(flat_cons[0]) == "((a) or (b)) == (aux)"
+        assert str(flat_cons[1]) == "(x) * (aux) <= 10"
+        assert len(csemap) == 1
+        assert str(csemap.flat_map[a | b]) == "aux"
+
+        # check mixed types
+        constraints = []
+        aux_var = cp.intvar(0,10, name="aux") # mimic as if the user made the variable themselves
+        constraints += [aux_var == a | b] # rhs should be promoted to integer
+        # but then promplty forgot about it
+        constraints += [x * (a | b) <= 10] # lhs is not flat
+        csemap = CSEMap()
+        flat_cons = flatten_constraint(constraints, csemap=csemap)
+        assert len(flat_cons) == 3
+        assert str(flat_cons[0]) == "(BV0) == (aux)"
+        assert str(flat_cons[1]) == "((a) or (b)) == (BV0)"
+        assert str(flat_cons[2]) == "(x) * (IV0) <= 10"
+
     ### other transformations only use csemap as argument to flatten_constraint internally, not sure how to easily test them


### PR DESCRIPTION
As discussed offline, it would be useful to catch silly mistakes by the user, where an aux var is introduced for some expression, but then the expression is used later on as a nested expression somewhere.

To fix this, this PR saves the `csemap[expr] = var` whenever we encounter a top-level `==` constraint.
