### PR TITLE
export make_assump_model in tools.explain module

### DIFF
--- a/cpmpy/tools/explain/__init__.py
+++ b/cpmpy/tools/explain/__init__.py
@@ -39,6 +39,7 @@ from .utils import OCUSException, make_assump_model
 
 __all__ = [
     "OCUSException",
+    "make_assump_model",
     "marco",
     "mcs",
     "mcs_grow",
@@ -58,5 +59,4 @@ __all__ = [
     "quickxplain",
     "quickxplain_naive",
     "smus",
-    "make_assump_model"
 ]

--- a/cpmpy/tools/explain/__init__.py
+++ b/cpmpy/tools/explain/__init__.py
@@ -35,7 +35,7 @@ from .mus import (
     quickxplain_naive,
     smus,
 )
-from .utils import OCUSException
+from .utils import OCUSException, make_assump_model
 
 __all__ = [
     "OCUSException",
@@ -58,4 +58,5 @@ __all__ = [
     "quickxplain",
     "quickxplain_naive",
     "smus",
+    "make_assump_model"
 ]


### PR DESCRIPTION
Re-export the `make_assump_model` helper function at the `tools.explain` module, instead of `tools.explain.utils`.
Quite some legacy code relied on this (e.g., xcp tutorial)