### PR TITLE
Linear decomposition for Regular using MDD

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -50,6 +50,7 @@ from .globalconstraints import (
     NoOverlap,
     NoOverlapOptional,
     NegativeTable,
+    MDD,
     Regular,
 )
 from .globalfunctions import (
@@ -116,6 +117,7 @@ __all__ = [
     "LexChainLessEq",
     "LexLess",
     "LexLessEq",
+    "MDD",
     "NegativeTable",
     "NoOverlap",
     "NoOverlapOptional",

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -112,6 +112,7 @@
         ShortTable
         NegativeTable
         Regular
+        MDD
         IfThenElse
         InDomain
         Xor
@@ -133,6 +134,7 @@
 
 """
 import warnings
+from collections import defaultdict
 from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
 import numpy as np
 
@@ -141,7 +143,7 @@ import cpmpy as cp
 from ..exceptions import TypeError
 from .core import Expression, BoolVal, ExprLike, ListLike
 from .variables import cpm_array, intvar, boolvar, _BoolVarImpl, _IntVarImpl, NDVarArray
-from .utils import all_pairs, is_int, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies
+from .utils import all_pairs, is_int, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies, argval
 
 if TYPE_CHECKING:
     from cpmpy.solvers.solver_interface import SolverInterface
@@ -824,6 +826,151 @@ class Regular(GlobalConstraint):
             else:
                 return False
         return curr_node in accepting
+
+
+class MDD(GlobalConstraint):
+    """
+    MDD-constraint: an MDD (Multi-valued Decision Diagram) is an acyclic layered graph starting from a single node and
+    ending in one. Each path of the MDD corresponds to a solution.
+    The values of the variables in 'array' correspond to a path in the MDD formed by the transitions in 'transitions'.
+    The root node is the first node used as a start in the first transition (i.e. transitions[0][0])
+    spec:
+        - array: an array of CPMpy expressions (integer variable, global functions,...)
+        - transitions: an array of tuples (nodeID, int, nodeID) where nodeID is some unique identifier for the nodes
+        (int or str are fine)
+    Example:
+        The following transitions depict a 3 layer MDD, starting at 'r' and ending in 't'
+        ("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
+        ("n4", 0, "t"), ("n5", 1, "t")
+        Its graphical representation is:
+                  r
+              0/ |1  \2     X
+            n1   n2   n3
+            2| /2    /O     Y
+             n4     n5
+              0\   /1       Z
+                 t
+        It has 3 paths, corresponding to 3 solution for (X,Y,Z): (0,2,0), (1,2,0) and (2,0,1)
+    """
+
+    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]]):
+        """
+        Arguments:
+            array (ListLike[Expression]): List of expressions representing the input sequence
+            transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
+        """
+        array = flatlist(array)
+        if not all(isinstance(x, Expression) for x in array):
+            raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
+
+        def is_transition(arg):
+            """ test if the argument is a transition, i.e. a 3-elements-tuple specifying a starting state,
+            a transition value and an ending node"""
+            return len(arg) == 3 and \
+                isinstance(arg[0], (int, str)) and is_int(arg[1]) and isinstance(arg[2], (int, str))
+
+
+        if not all(is_transition(transition) for transition in transitions):
+            raise TypeError("The second argument of an MDD constraint should be collection of transitions")
+        super().__init__("mdd", (array, transitions))
+        self.root_node = transitions[0][0]
+        self.mapping = defaultdict(dict)
+        for s, v, e in transitions:
+            self.mapping[s][v] = e
+
+        self.levels = {self.root_node: 0}
+        current_nodes = [self.root_node]
+        for i in range(len(array)):
+            new_nodes = []
+            for n in current_nodes:
+                for v in self.mapping[n]:
+                    new_nodes.append(self.mapping[n][v])
+                    self.levels[self.mapping[n][v]] = i + 1
+            current_nodes = new_nodes
+
+    def _reduce(self):
+        """
+            Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
+        """
+        pass
+
+
+    def decompose(self) -> tuple[list[Expression], list[Expression]]:
+        """
+            Flow decomposition of the MDD global constraint.
+            Enforces that the condition is satisfied.
+
+            Returns:
+                tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        """
+        arr, _ = self.args
+
+        flow = {k: {"in" : [], "out" : []} for k in self.levels.keys()}
+        transition_counter = {(level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub+1)}
+
+        for (src, edges) in self.mapping.items():
+            for (value, dst) in edges.items():
+                transition = (self.levels[src], value)
+                transition_counter[transition] += 1
+                flow[src]["out"].append((transition, transition_counter[transition]))
+                flow[dst]["in"].append((transition, transition_counter[transition]))
+
+        cons = []
+        substitution = {}
+        for key in transition_counter.keys():
+            (level, value) = key
+            if transition_counter[key] == 0:
+                continue
+            elif transition_counter[key] == 1:
+                substitution[(key, 1)] = (arr[level] == value)
+            else:
+                bvs = cp.boolvar(shape=transition_counter[key]) # edge variables must be defined
+                for n in range(1, transition_counter[key] + 1):
+                    substitution[(key, n)] = bvs[n - 1]
+
+        for i, key in enumerate(sorted(flow.keys(), key=lambda k: self.levels[k])):
+
+            if ((len(flow[key]["in"]) == 1) and (len(flow[key]["out"]) == 1) and
+                    transition_counter[flow[key]["in"][0][0]] > 1 and transition_counter[flow[key]["out"][0][0]] > 1):
+                substitution[flow[key]["out"][0]] = substitution[flow[key]["in"][0]] # substitute equivalent edge variables
+
+            elif (len(flow[key]["in"]) > 0) and (len(flow[key]["out"]) > 0):
+                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) ==
+                         cp.sum([substitution[edge] for edge in flow[key]["out"]])]
+
+            elif len(flow[key]["in"]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow[key]["out"]]) == 1]
+
+            elif len(flow[key]["out"]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) == 1]
+
+        for key in transition_counter.keys():
+            if transition_counter[key] > 1:
+                (level, value) = key
+                cons += [cp.sum([substitution[(key, n)] for n in range(1, transition_counter[key] + 1)]) == (arr[level] == value)]
+
+        return cons, []
+
+    def value(self) -> Optional[bool]:
+        """
+        Returns:
+            Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
+        """
+        arr, transitions = self.args
+        arrvals = [argval(a) for a in arr]
+        curr_node = self.root_node
+        for v in arrvals:
+            if v is None:
+                return None
+            if curr_node in self.mapping:
+                if v in self.mapping[curr_node]:
+                    curr_node = self.mapping[curr_node][v]
+                else:
+                    return False
+            else:
+                return False
+        return True # can only have reached end node
+
 
 # syntax of the form 'if b then x == 9 else x == 0' is not supported (no override possible)
 # same semantic as CPLEX IfThenElse constraint

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -894,65 +894,80 @@ class MDD(GlobalConstraint):
         """
         pass
 
-
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-            Flow decomposition of the MDD global constraint.
-            Enforces that the condition is satisfied.
+        Flow decomposition of the MDD global constraint.
+        Enforces that the condition is satisfied.
 
-            Returns:
-                tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        Returns:
+            tuple[list[Expression], list[Expression]]:
+                A tuple containing the constraints representing the constraint value and the defining constraints.
         """
         arr, _ = self.args
 
-        flow_in: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
-        flow_out: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
-        transition_counter = {
-            (level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub + 1)
-        }
+        flow_in: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
+        flow_out: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
+        edge_vars = defaultdict(list)
 
-        for (src, edges) in self.mapping.items():
-            for (value, dst) in edges.items():
-                transition = (self.levels[src], value)
-                transition_counter[transition] += 1
-                flow_out[src].append((transition, transition_counter[transition]))
-                flow_in[dst].append((transition, transition_counter[transition]))
+        for src, edges in self.mapping.items():
+            for value, dst in edges.items():
+                tr = (self.levels[src], value)
+                edge_var = cp.boolvar()
+
+                flow_out[src].append((tr, edge_var))
+                flow_in[dst].append((tr, edge_var))
+                edge_vars[tr].append(edge_var)
 
         cons = []
-        substitution = {}
-        for key in transition_counter.keys():
-            (level, value) = key
-            if transition_counter[key] == 0:
-                continue
-            elif transition_counter[key] == 1:
-                substitution[(key, 1)] = (arr[level] == value)
+        b = cp.boolvar()
+        invalid_edge_vars = []
+
+        # Go over the nodes in the MDD, and enforce flow constraints
+        for node in self.levels.keys():
+            incoming = flow_in[node]
+            outgoing = flow_out[node]
+            missing = []
+
+            if outgoing:
+                valid_transitions = [tr for tr, _ in outgoing]
+                lvl = valid_transitions[0][0]
+
+                # Find all transition values for which there is no valid path, in order to direct them to a dummy node
+                for val in range(arr[lvl].lb, arr[lvl].ub + 1):
+                    tr = (lvl, val)
+
+                    if tr not in valid_transitions:
+                        var = cp.boolvar()
+                        edge_vars[tr].append(var)
+                        invalid_edge_vars.append(var)
+                        missing.append(var)
+
+            if incoming and outgoing:
+                cons += [
+                    cp.sum([e for _, e in incoming]) ==
+                    cp.sum([e for _, e in outgoing]) + cp.sum(missing)
+                ]
+
+            elif outgoing:
+                cons += [
+                    cp.sum([e for _, e in outgoing]) + cp.sum(missing) == 1
+                ]
+
             else:
-                bvs = cp.boolvar(shape=transition_counter[key]) # edge variables must be defined
-                for n in range(1, transition_counter[key] + 1):
-                    substitution[(key, n)] = bvs[n - 1]
+                cons += [
+                    cp.sum([e for _, e in incoming]) == b
+                ]
 
-        for node in sorted(flow_in.keys() | flow_out.keys(), key=lambda k: self.levels[k]):
+        # Link direct encoding variables with edge variables
+        for (level, value), vars_ in edge_vars.items():
+            cons += [
+                cp.sum(set(vars_)) == (arr[level] == value)
+            ]
 
-            if ((len(flow_in[node]) == 1) and (len(flow_out[node]) == 1) and
-                    transition_counter[flow_in[node][0][0]] > 1 and transition_counter[flow_out[node][0][0]] > 1):
-                substitution[flow_out[node][0]] = substitution[flow_in[node][0]] # substitute equivalent edge variables
+        # Ensure that if an invalid edge is taken, the constraint is not satisfied
+        cons += [cp.sum(invalid_edge_vars) == ~b]
 
-            elif (len(flow_in[node]) > 0) and (len(flow_out[node]) > 0):
-                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) ==
-                         cp.sum([substitution[edge] for edge in flow_out[node]])]
-
-            elif len(flow_in[node]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow_out[node]]) == 1]
-
-            elif len(flow_out[node]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) == 1]
-
-        for key in transition_counter.keys():
-            if transition_counter[key] > 1:
-                (level, value) = key
-                cons += [cp.sum([substitution[(key, n)] for n in range(1, transition_counter[key] + 1)]) == (arr[level] == value)]
-
-        return cons, []
+        return [b], cons
 
     def value(self) -> Optional[bool]:
         """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -921,7 +921,7 @@ class MDD(GlobalConstraint):
             tuple[list[Expression], list[Expression]]:
                 A tuple containing the constraints representing the constraint value and the defining constraints.
         """
-        arr, _ = self.args
+        arr, _, _ = self.args
 
         # MDD is extended with invalid edges, which are directed to the sink node
         extended_mapping, invalid_edges_set = self._get_complete_mdd()

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -581,6 +581,42 @@ class Table(GlobalConstraint):
         arr, tab = self.args
         return [cp.any([cp.all([ai == ri for ai, ri in zip(arr, row)]) for row in tab])], []
 
+    def decompose_linear(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Linear-friendly decomposition of the Table global constraint using an MDD, which is subsequently decomposed into linear flow constraints.
+
+         Returns:
+            tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+         """
+
+        arr, tab = self.args
+
+        transitions : list[tuple[int | str, int, int | str]] = []
+        prefix_to_node = {}
+        next_id = 0
+
+        for row in tab:
+            current = "src"
+            prefix : tuple[int, ...] = ()
+            for i, val in enumerate(row):
+                if i == len(row) - 1:
+                    nxt = "snk"
+                else:
+                    prefix = prefix + (val,)
+                    if prefix not in prefix_to_node:
+                        prefix_to_node[prefix] = f"n{next_id}"
+                        next_id += 1
+                    nxt = prefix_to_node[prefix]
+
+                transition = (current, int(val), nxt)
+                if transition not in transitions:
+                    transitions.append(transition)
+                current = nxt
+
+        return [MDD(arr, transitions)], []
+
+
+
     def value(self) -> Optional[bool]:
         """
         Returns:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -874,7 +874,7 @@ class MDD(GlobalConstraint):
             raise TypeError("The second argument of an MDD constraint should be collection of transitions")
         super().__init__("mdd", (array, transitions))
         self.root_node = transitions[0][0]
-        self.mapping = defaultdict(dict)
+        self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
             self.mapping[s][v] = e
 
@@ -905,15 +905,18 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        flow = {k: {"in" : [], "out" : []} for k in self.levels.keys()}
-        transition_counter = {(level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub+1)}
+        flow_in: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
+        flow_out: dict[int | str, list[tuple[tuple[int, int], int]]] = defaultdict(list)
+        transition_counter = {
+            (level, d): 0 for level in range(len(arr)) for d in range(arr[level].lb, arr[level].ub + 1)
+        }
 
         for (src, edges) in self.mapping.items():
             for (value, dst) in edges.items():
                 transition = (self.levels[src], value)
                 transition_counter[transition] += 1
-                flow[src]["out"].append((transition, transition_counter[transition]))
-                flow[dst]["in"].append((transition, transition_counter[transition]))
+                flow_out[src].append((transition, transition_counter[transition]))
+                flow_in[dst].append((transition, transition_counter[transition]))
 
         cons = []
         substitution = {}
@@ -928,21 +931,21 @@ class MDD(GlobalConstraint):
                 for n in range(1, transition_counter[key] + 1):
                     substitution[(key, n)] = bvs[n - 1]
 
-        for i, key in enumerate(sorted(flow.keys(), key=lambda k: self.levels[k])):
+        for node in sorted(flow_in.keys() | flow_out.keys(), key=lambda k: self.levels[k]):
 
-            if ((len(flow[key]["in"]) == 1) and (len(flow[key]["out"]) == 1) and
-                    transition_counter[flow[key]["in"][0][0]] > 1 and transition_counter[flow[key]["out"][0][0]] > 1):
-                substitution[flow[key]["out"][0]] = substitution[flow[key]["in"][0]] # substitute equivalent edge variables
+            if ((len(flow_in[node]) == 1) and (len(flow_out[node]) == 1) and
+                    transition_counter[flow_in[node][0][0]] > 1 and transition_counter[flow_out[node][0][0]] > 1):
+                substitution[flow_out[node][0]] = substitution[flow_in[node][0]] # substitute equivalent edge variables
 
-            elif (len(flow[key]["in"]) > 0) and (len(flow[key]["out"]) > 0):
-                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) ==
-                         cp.sum([substitution[edge] for edge in flow[key]["out"]])]
+            elif (len(flow_in[node]) > 0) and (len(flow_out[node]) > 0):
+                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) ==
+                         cp.sum([substitution[edge] for edge in flow_out[node]])]
 
-            elif len(flow[key]["in"]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow[key]["out"]]) == 1]
+            elif len(flow_in[node]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow_out[node]]) == 1]
 
-            elif len(flow[key]["out"]) == 0:
-                cons += [cp.sum([substitution[edge] for edge in flow[key]["in"]]) == 1]
+            elif len(flow_out[node]) == 0:
+                cons += [cp.sum([substitution[edge] for edge in flow_in[node]]) == 1]
 
         for key in transition_counter.keys():
             if transition_counter[key] > 1:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -133,6 +133,7 @@
         DirectConstraint
 
 """
+import copy
 import warnings
 from collections import defaultdict
 from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
@@ -863,15 +864,12 @@ class MDD(GlobalConstraint):
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
 
-        def is_transition(arg):
-            """ test if the argument is a transition, i.e. a 3-elements-tuple specifying a starting state,
-            a transition value and an ending node"""
-            return len(arg) == 3 and \
-                isinstance(arg[0], (int, str)) and is_int(arg[1]) and isinstance(arg[2], (int, str))
+        _node_type = type(transitions[0][0])
+        for s, v, e in transitions:
+            if not isinstance(s, _node_type) or not isinstance(e, _node_type) or not isinstance(v, int):
+                raise TypeError(
+                    f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
-
-        if not all(is_transition(transition) for transition in transitions):
-            raise TypeError("The second argument of an MDD constraint should be collection of transitions")
         super().__init__("mdd", (array, transitions))
         self.root_node = transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
@@ -888,6 +886,25 @@ class MDD(GlobalConstraint):
                     self.levels[self.mapping[n][v]] = i + 1
             current_nodes = new_nodes
 
+    def _extend_mdd(self):
+        """
+            Auxiliary function that extends the MDD with edges for all possible values, directing the new edges to the sink node.
+        """
+        invalid_edges = []
+
+        extended_mapping = copy.deepcopy(self.mapping)
+        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
+        for s in self.mapping.keys():
+            level = self.levels[s]
+            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            for v in domain:
+                if v not in self.mapping[s]:
+                    extended_mapping[s][v] = sink_node
+                    invalid_edges.append((s, v))
+        return extended_mapping, invalid_edges
+
+
+
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
@@ -897,7 +914,7 @@ class MDD(GlobalConstraint):
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
         Flow decomposition of the MDD global constraint.
-        Enforces that the condition is satisfied.
+        Enforces that the condition is satisfied, by ensuring that the flow in equals the flow out for every node.
 
         Returns:
             tuple[list[Expression], list[Expression]]:
@@ -905,69 +922,47 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        flow_in: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
-        flow_out: dict[int | str, list[tuple[tuple[int, int], Expression]]] = defaultdict(list)
+        extended_mapping, invalid_edges = self._extend_mdd()
+
+        # Represents the ingoing and outgoing flow for a certain node: for every node, the edge variables are listed
+        flow_in: dict[int | str, list[Expression]] = defaultdict(list)
+        flow_out: dict[int | str, list[Expression]] = defaultdict(list)
+
         edge_vars = defaultdict(list)
+        invalid_edge_vars = []
 
-        for src, edges in self.mapping.items():
+        for src, edges in extended_mapping.items():
             for value, dst in edges.items():
-                tr = (self.levels[src], value)
+                level = self.levels[src]
                 edge_var = cp.boolvar()
+                flow_out[src].append(edge_var)
+                flow_in[dst].append(edge_var)
+                edge_vars[(level, value)].append(edge_var)
 
-                flow_out[src].append((tr, edge_var))
-                flow_in[dst].append((tr, edge_var))
-                edge_vars[tr].append(edge_var)
+                if (src, value) in invalid_edges:
+                    invalid_edge_vars.append(edge_var)
 
         cons = []
-        b = cp.boolvar()
-        invalid_edge_vars = []
 
         # Go over the nodes in the MDD, and enforce flow constraints
         for node in self.levels.keys():
             incoming = flow_in[node]
             outgoing = flow_out[node]
-            missing = []
 
-            if outgoing:
-                valid_transitions = [tr for tr, _ in outgoing]
-                lvl = valid_transitions[0][0]
-
-                # Find all transition values for which there is no valid path, in order to direct them to a dummy node
-                for val in range(arr[lvl].lb, arr[lvl].ub + 1):
-                    tr = (lvl, val)
-
-                    if tr not in valid_transitions:
-                        var = cp.boolvar()
-                        edge_vars[tr].append(var)
-                        invalid_edge_vars.append(var)
-                        missing.append(var)
 
             if incoming and outgoing:
-                cons += [
-                    cp.sum([e for _, e in incoming]) ==
-                    cp.sum([e for _, e in outgoing]) + cp.sum(missing)
-                ]
-
+                cons.append(cp.sum(incoming) == cp.sum(outgoing))
             elif outgoing:
-                cons += [
-                    cp.sum([e for _, e in outgoing]) + cp.sum(missing) == 1
-                ]
-
+                cons.append(cp.sum(outgoing) == 1)
             else:
-                cons += [
-                    cp.sum([e for _, e in incoming]) == b
-                ]
+                cons.append(cp.sum(incoming) == 1)
 
         # Link direct encoding variables with edge variables
         for (level, value), vars_ in edge_vars.items():
-            cons += [
-                cp.sum(set(vars_)) == (arr[level] == value)
-            ]
+            cons.append(cp.sum(vars_) == (arr[level] == value))
 
-        # Ensure that if an invalid edge is taken, the constraint is not satisfied
-        cons += [cp.sum(invalid_edge_vars) == ~b]
+        return [cp.sum(invalid_edge_vars) == 0], cons
 
-        return [b], cons
 
     def value(self) -> Optional[bool]:
         """
@@ -980,6 +975,8 @@ class MDD(GlobalConstraint):
         for v in arrvals:
             if v is None:
                 return None
+
+        for v in arrvals:
             if curr_node in self.mapping:
                 if v in self.mapping[curr_node]:
                     curr_node = self.mapping[curr_node][v]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -886,25 +886,6 @@ class MDD(GlobalConstraint):
                     self.levels[self.mapping[n][v]] = i + 1
             current_nodes = new_nodes
 
-    def _extend_mdd(self):
-        """
-            Auxiliary function that extends the MDD with edges for all possible values, directing the new edges to the sink node.
-        """
-        invalid_edges = []
-
-        extended_mapping = copy.deepcopy(self.mapping)
-        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
-        for s in self.mapping.keys():
-            level = self.levels[s]
-            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
-            for v in domain:
-                if v not in self.mapping[s]:
-                    extended_mapping[s][v] = sink_node
-                    invalid_edges.append((s, v))
-        return extended_mapping, invalid_edges
-
-
-
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
@@ -915,6 +896,8 @@ class MDD(GlobalConstraint):
         """
         Flow decomposition of the MDD global constraint.
         Enforces that the condition is satisfied, by ensuring that the flow in equals the flow out for every node.
+        To do this, we introduce auxiliary boolean variables for every edge in the MDD, use them in flow constraints,
+        and link them to all variable assignments in the array.
 
         Returns:
             tuple[list[Expression], list[Expression]]:
@@ -922,15 +905,27 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        extended_mapping, invalid_edges = self._extend_mdd()
+        # MDD is extended with invalid edges, which are directed to the sink node
+        invalid_edges = []
+        extended_mapping = copy.deepcopy(self.mapping)
+        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
+        for s in self.mapping.keys():
+            level = self.levels[s]
+            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            for v in domain:
+                if v not in self.mapping[s]:
+                    extended_mapping[s][v] = sink_node
+                    invalid_edges.append((s, v))
 
         # Represents the ingoing and outgoing flow for a certain node: for every node, the edge variables are listed
         flow_in: dict[int | str, list[Expression]] = defaultdict(list)
         flow_out: dict[int | str, list[Expression]] = defaultdict(list)
 
+        # Used to link edge variables to direct encoding variables in a later step
         edge_vars = defaultdict(list)
         invalid_edge_vars = []
 
+        # Flow in and flow out calculated for every node
         for src, edges in extended_mapping.items():
             for value, dst in edges.items():
                 level = self.levels[src]
@@ -944,11 +939,10 @@ class MDD(GlobalConstraint):
 
         cons = []
 
-        # Go over the nodes in the MDD, and enforce flow constraints
+        # Nodes in the MDD are iterated over, and flow constraints are enforced
         for node in self.levels.keys():
             incoming = flow_in[node]
             outgoing = flow_out[node]
-
 
             if incoming and outgoing:
                 cons.append(cp.sum(incoming) == cp.sum(outgoing))

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -833,8 +833,7 @@ class MDD(GlobalConstraint):
     """
     An MDD of depth n is an acyclic layered graph with a single root node, and one accepting sink node.
     The constraint takes as input an array of n integer variables and a graph representation using a transition table.
-    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node
-    , and ending in the accepting sink node.
+    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node, and ending in the accepting sink node.
 
     The transitions are defined by a list of tuples (id1, value, id2).
     An id is an integer or string representing a state in the automaton, and value is an integer representing the value of the variable in the sequence.
@@ -864,7 +863,7 @@ class MDD(GlobalConstraint):
                 raise TypeError(
                     f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
-        super().__init__("mdd", (array, transitions, start))
+        super().__init__("mdd", (array, transitions))
         self.root_node = start if start is not None else transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
@@ -881,6 +880,10 @@ class MDD(GlobalConstraint):
             current_nodes = new_nodes
         # Check that there is exactly one sink node on level n (with n the number of integer variables)
         assert sum(level == len(array) for node, level in self.levels.items()) == 1
+
+        self.sink_node = next(node for node, level in self.levels.items() if level == len(array))
+        self.nodes = self.levels.keys()
+        self.node_map = {n: (-1 if n == self.sink_node else i) for i, n in enumerate(self.nodes)}
 
     def _reduce(self):
         """
@@ -921,7 +924,7 @@ class MDD(GlobalConstraint):
             tuple[list[Expression], list[Expression]]:
                 A tuple containing the constraints representing the constraint value and the defining constraints.
         """
-        arr, _, _ = self.args
+        arr, _ = self.args
 
         # MDD is extended with invalid edges, which are directed to the sink node
         extended_mapping, invalid_edges_set = self._get_complete_mdd()
@@ -976,7 +979,7 @@ class MDD(GlobalConstraint):
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
-        arr, transitions, _ = self.args
+        arr, transitions = self.args
         argvals = [argval(a) for a in arr]
         curr_node = self.root_node
         if any(v is None for v in argvals):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -831,34 +831,28 @@ class Regular(GlobalConstraint):
 
 class MDD(GlobalConstraint):
     """
-    MDD-constraint: an MDD (Multi-valued Decision Diagram) is an acyclic layered graph starting from a single node and
-    ending in one. Each path of the MDD corresponds to a solution.
-    The values of the variables in 'array' correspond to a path in the MDD formed by the transitions in 'transitions'.
-    The root node is the first node used as a start in the first transition (i.e. transitions[0][0])
-    spec:
-        - array: an array of CPMpy expressions (integer variable, global functions,...)
-        - transitions: an array of tuples (nodeID, int, nodeID) where nodeID is some unique identifier for the nodes
-        (int or str are fine)
-    Example:
-        The following transitions depict a 3 layer MDD, starting at 'r' and ending in 't'
-        ("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
-        ("n4", 0, "t"), ("n5", 1, "t")
-        Its graphical representation is:
-                  r
-              0/ |1  \2     X
-            n1   n2   n3
-            2| /2    /O     Y
-             n4     n5
-              0\   /1       Z
-                 t
-        It has 3 paths, corresponding to 3 solution for (X,Y,Z): (0,2,0), (1,2,0) and (2,0,1)
+    An MDD of depth n is an acyclic layered graph with a single root node, and one accepting sink node.
+    The constraint takes as input an array of n integer variables and a graph representation using a transition table.
+    The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node
+    , and ending in the accepting sink node.
+
+    The transitions are defined by a list of tuples (id1, value, id2).
+    An id is an integer or string representing a state in the automaton, and value is an integer representing the value of the variable in the sequence.
+    If not given explicitly, the root node is the first node in the transition table (i.e., transitions[0][0]), and is on level 0.
+    The sink node is the only node on level n.
+
+    Example: the following MDD accepts the solutions [1,1,1], [2,2,1] and [2,3,2] for the three variables x,y,z. The root node is "A" and the sink node is "F".
+    cp.MDD(array=[x,y,z],
+           transitions = [("A", 1, "B"), ("B", 1, "D"), ("D", 1 "F"),
+                          ("A",2,"C"), ("C", 2, "D"), ("C", 3, "E"), ("E", 2, "F")])
     """
 
-    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]]):
+    def __init__(self, array: ListLike[Expression], transitions: ListLike[tuple[int|str, int, int|str]], start: Optional[int|str] = None):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the input sequence
             transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
+            start (Optional[int | str]): Root node id, if None, the root node is assumed to be the first node in the transition table (i.e., transitions[0][0])
         """
         array = flatlist(array)
         if not all(isinstance(x, Expression) for x in array):
@@ -871,7 +865,7 @@ class MDD(GlobalConstraint):
                     f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
         super().__init__("mdd", (array, transitions))
-        self.root_node = transitions[0][0]
+        self.root_node = start if start is not None else transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
             self.mapping[s][v] = e
@@ -885,12 +879,36 @@ class MDD(GlobalConstraint):
                     new_nodes.append(self.mapping[n][v])
                     self.levels[self.mapping[n][v]] = i + 1
             current_nodes = new_nodes
+        # Check that there is exactly one sink node on level n (with n the number of integer variables)
+        assert sum(level == len(array) for node, level in self.levels.items()) == 1
 
     def _reduce(self):
         """
             Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
         """
         pass
+
+    def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
+        """
+        Auxiliary function that extends the MDD with invalid edges, which are directed to the sink node.
+
+        Returns:
+            tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
+            A tuple containing the extended mapping of the MDD and a set of invalid edges (source node, transition value) that are added to the MDD.
+        """
+        invalid_edges = set()
+        extended_mapping = copy.deepcopy(self.mapping)
+        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
+        for s in self.mapping.keys():
+            level = self.levels[s]
+            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
+            for v in domain:
+                if v not in self.mapping[s]:
+                    extended_mapping[s][v] = sink_node
+                    invalid_edges.add((s, v))
+
+        return extended_mapping, invalid_edges
+
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -906,18 +924,11 @@ class MDD(GlobalConstraint):
         arr, _ = self.args
 
         # MDD is extended with invalid edges, which are directed to the sink node
-        invalid_edges = []
-        extended_mapping = copy.deepcopy(self.mapping)
-        sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
-        for s in self.mapping.keys():
-            level = self.levels[s]
-            domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
-            for v in domain:
-                if v not in self.mapping[s]:
-                    extended_mapping[s][v] = sink_node
-                    invalid_edges.append((s, v))
+        extended_mapping, invalid_edges_set = self._get_complete_mdd()
+        invalid_edges = frozenset(invalid_edges_set)
 
-        # Represents the ingoing and outgoing flow for a certain node: for every node, the edge variables are listed
+        # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
+        # The default is an empty list, representing no ingoing / outgoing flow.
         flow_in: dict[int | str, list[Expression]] = defaultdict(list)
         flow_out: dict[int | str, list[Expression]] = defaultdict(list)
 
@@ -925,7 +936,7 @@ class MDD(GlobalConstraint):
         edge_vars = defaultdict(list)
         invalid_edge_vars = []
 
-        # Flow in and flow out calculated for every node
+        # Determine flow in and flow out for each node
         for src, edges in extended_mapping.items():
             for value, dst in edges.items():
                 level = self.levels[src]
@@ -939,19 +950,21 @@ class MDD(GlobalConstraint):
 
         cons = []
 
-        # Nodes in the MDD are iterated over, and flow constraints are enforced
-        for node in self.levels.keys():
+        # Enforce flow constraints: flow in = flow out, at most one activated in/out edge
+        for node, level in self.levels.items():
             incoming = flow_in[node]
             outgoing = flow_out[node]
 
-            if incoming and outgoing:
-                cons.append(cp.sum(incoming) == cp.sum(outgoing))
-            elif outgoing:
-                cons.append(cp.sum(outgoing) == 1)
+            if level == 0:
+                cons.append(cp.sum(outgoing) == 1) # root
+            elif level == len(arr):
+                cons.append(cp.sum(incoming) == 1) # sink
             else:
-                cons.append(cp.sum(incoming) == 1)
+                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
+                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
+                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
 
-        # Link direct encoding variables with edge variables
+        # Enforce direct encoding variable arr[i] == v if an edge with label v is activated at level i
         for (level, value), vars_ in edge_vars.items():
             cons.append(cp.sum(vars_) == (arr[level] == value))
 
@@ -964,13 +977,12 @@ class MDD(GlobalConstraint):
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
         arr, transitions = self.args
-        arrvals = [argval(a) for a in arr]
+        argvals = [argval(a) for a in arr]
         curr_node = self.root_node
-        for v in arrvals:
-            if v is None:
-                return None
+        if any(v is None for v in argvals):
+            return None
 
-        for v in arrvals:
+        for v in argvals:
             if curr_node in self.mapping:
                 if v in self.mapping[curr_node]:
                     curr_node = self.mapping[curr_node][v]

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -864,7 +864,7 @@ class MDD(GlobalConstraint):
                 raise TypeError(
                     f"The second argument of an MDD constraint should be a collection of transitions ({_node_type}, int, {_node_type})")
 
-        super().__init__("mdd", (array, transitions))
+        super().__init__("mdd", (array, transitions, start))
         self.root_node = start if start is not None else transitions[0][0]
         self.mapping: dict[int | str, dict[int, int | str]] = defaultdict(dict)  # mapping from source node and transition value to destination node
         for s, v, e in transitions:
@@ -976,7 +976,7 @@ class MDD(GlobalConstraint):
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
         """
-        arr, transitions = self.args
+        arr, transitions, _ = self.args
         argvals = [argval(a) for a in arr]
         curr_node = self.root_node
         if any(v is None for v in argvals):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -591,9 +591,8 @@ class Table(GlobalConstraint):
 
         arr, tab = self.args
 
-        transitions : list[tuple[int | str, int, int | str]] = []
-        prefix_to_node = {}
-        next_id = 0
+        transitions : set[tuple[int | str, int, int | str]] = set()
+        prefix_to_node : dict[tuple[int, ...], str] = {}
 
         for row in tab:
             current = "src"
@@ -604,16 +603,15 @@ class Table(GlobalConstraint):
                 else:
                     prefix = prefix + (val,)
                     if prefix not in prefix_to_node:
-                        prefix_to_node[prefix] = f"n{next_id}"
-                        next_id += 1
+                        prefix_to_node[prefix] = f"n{len(prefix_to_node) + 1}"
                     nxt = prefix_to_node[prefix]
 
                 transition = (current, int(val), nxt)
                 if transition not in transitions:
-                    transitions.append(transition)
+                    transitions.add(transition)
                 current = nxt
 
-        return [MDD(arr, transitions)], []
+        return [MDD(arr, list(transitions))], []
 
 
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -845,6 +845,53 @@ class Regular(GlobalConstraint):
         # constraint is satisfied iff last state is accepting
         return [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])], defining
 
+    def decompose_linear(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Linear decomposition of the Regular global constraint using an MDD, which is subsequently decomposed into linear flow constraints.
+        The MDD is obtained by means of constructing a layered directed multigraph for the given automaton, based on Algorithm 1 of:
+        "A Regular Language Membership Constraint for Finite Sequences of Variables", Gilles Pesant, 2004
+        Returns:
+            tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        """
+        arr, transitions, start, accepting = self.args
+
+        # Keeps track of the supported nodes Q[(i,j)] for variable i taking value j
+        Q = defaultdict(set)
+        # Keeps track of the nodes N[i] that can be reached at layer i of the layered graph
+        N = defaultdict(set)
+        N[0].add(start)
+
+        # Forward phase
+        for i in range(len(arr)):
+            for j in range(arr[i].lb, arr[i].ub + 1):
+                for node in N[i]:
+                    if (node, j) in self.trans_dict.keys():
+                        Q[(i,j)].add(node)
+                        N[i+1].add(self.trans_dict[(node, j)])
+
+        # Backward phase, remove non-accepting nodes
+        N[len(arr)] = N[len(arr)].intersection(accepting)
+
+        mdd_transitions : list[tuple[int | str, int, int | str]] = []
+
+        # Unique ID for every node in the layered graph
+        id_map = {(i, node): idx for idx, (i, node) in enumerate((i, node) for i in range(len(arr)) for node in self.nodes)}
+
+        # All accepting nodes in the final layer are merged into one
+        for node in accepting:
+            id_map[(len(arr), node)] = len(arr) * len(self.nodes)
+
+        # Backward phase, add valid MDD transitions
+        for i in reversed(range(len(arr))):
+            for j in range(arr[i].lb, arr[i].ub + 1):
+                for node in Q[(i,j)]:
+                    if (node, j) in self.trans_dict.keys() and self.trans_dict[(node, j)] in N[i+1]:
+                        next_node = self.trans_dict[(node, j)]
+                        mdd_transitions.append((id_map[(i, node)], j, id_map[(i+1, next_node)]))
+
+        return [MDD(arr, mdd_transitions, start=id_map[(0, start)])], []
+
+
     def value(self) -> Optional[bool]:
         """
         Returns:
@@ -921,11 +968,41 @@ class MDD(GlobalConstraint):
 
     def _reduce(self):
         """
-            Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes (to be implemented)
+        Auxiliary function that reduces the original MDD by merging nodes with equivalent suffixes
         """
-        pass
+        reduced_mapping = copy.deepcopy(self.mapping)
+        substitutions = {}
 
-    def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
+        for i in range(len(self.args[0]) - 1, -1, -1):
+            level_nodes = [n for n in self.levels if self.levels[n] == i]
+            groups = {}
+
+            for node in level_nodes:
+                tf = reduced_mapping[node]
+                signature = tuple(sorted(tf.items()))
+                if signature not in groups:
+                    groups[signature] = []
+
+                groups[signature].append(node)
+
+            for equiv_nodes in groups.values():
+                rep = equiv_nodes[0]
+                for node in equiv_nodes[1:]:
+                    substitutions[node] = rep
+                    reduced_mapping.pop(node, None)
+
+        for node in reduced_mapping:
+            for value in reduced_mapping[node]:
+                dst = reduced_mapping[node][value]
+
+                while dst in substitutions:
+                    dst = substitutions[dst]
+
+                reduced_mapping[node][value] = dst
+
+        return reduced_mapping
+
+    def _get_complete_mdd(self, mapping : dict[int | str, dict[int, int | str]]) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
         """
         Auxiliary function that extends the MDD with invalid edges, which are directed to the sink node.
 
@@ -934,13 +1011,13 @@ class MDD(GlobalConstraint):
             A tuple containing the extended mapping of the MDD and a set of invalid edges (source node, transition value) that are added to the MDD.
         """
         invalid_edges = set()
-        extended_mapping = copy.deepcopy(self.mapping)
+        extended_mapping = copy.deepcopy(mapping)
         sink_node = max(self.levels.keys(), key=lambda x: self.levels[x])
-        for s in self.mapping.keys():
+        for s in mapping.keys():
             level = self.levels[s]
             domain = range(self.args[0][level].lb, self.args[0][level].ub + 1)
             for v in domain:
-                if v not in self.mapping[s]:
+                if v not in mapping[s]:
                     extended_mapping[s][v] = sink_node
                     invalid_edges.add((s, v))
 
@@ -1018,8 +1095,11 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
+        # Merge equivalent nodes in the original MDD, results in smaller flow encoding
+        reduced_mapping = self._reduce()
+
         # MDD is extended with invalid edges, which are directed to the sink node
-        extended_mapping, invalid_edges_set = self._get_complete_mdd()
+        extended_mapping, invalid_edges_set = self._get_complete_mdd(reduced_mapping)
         invalid_edges = frozenset(invalid_edges_set)
 
         cons, invalid_edge_vars = self._mdd_to_flow(extended_mapping, invalid_edges)
@@ -1035,7 +1115,9 @@ class MDD(GlobalConstraint):
             tuple[list[Expression], list[Expression]]:
                 A tuple containing the constraints representing the constraint value and the defining constraints.
         """
-        cons, _ = self._mdd_to_flow(self.mapping)
+        # Merge equivalent nodes in the original MDD, results in smaller flow encoding
+        reduced_mapping = self._reduce()
+        cons, _ = self._mdd_to_flow(reduced_mapping)
         return cons, []
 
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -611,7 +611,7 @@ class Table(GlobalConstraint):
                     transitions.add(transition)
                 current = nxt
 
-        return [MDD(arr, list(transitions))], []
+        return [MDD(arr, list(transitions), start="src")], []
 
 
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -912,23 +912,21 @@ class MDD(GlobalConstraint):
 
         return extended_mapping, invalid_edges
 
-
-    def decompose(self) -> tuple[list[Expression], list[Expression]]:
+    def _mdd_to_flow(self,
+                     mapping: dict[int | str, dict[int, int | str]],
+                     invalid_edges: frozenset[tuple[int | str, int]] = frozenset()
+                     ) -> tuple[list[Expression], list[Expression]]:
         """
-        Flow decomposition of the MDD global constraint.
-        Enforces that the condition is satisfied, by ensuring that the flow in equals the flow out for every node.
+        Auxiliary function taking as input a mapping of the MDD and a set of invalid edges,
+        and returning the flow constraints encoding the MDD, and the list of edge variables corresponding to invalid edges.
         To do this, we introduce auxiliary boolean variables for every edge in the MDD, use them in flow constraints,
         and link them to all variable assignments in the array.
-
         Returns:
             tuple[list[Expression], list[Expression]]:
-                A tuple containing the constraints representing the constraint value and the defining constraints.
+                A tuple containing the constraints representing the flow encoding of the MDD and the list of edge variables corresponding to invalid edges.
         """
-        arr, _ = self.args
 
-        # MDD is extended with invalid edges, which are directed to the sink node
-        extended_mapping, invalid_edges_set = self._get_complete_mdd()
-        invalid_edges = frozenset(invalid_edges_set)
+        arr = self.args[0]
 
         # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
         # The default is an empty list, representing no ingoing / outgoing flow.
@@ -937,10 +935,10 @@ class MDD(GlobalConstraint):
 
         # Used to link edge variables to direct encoding variables in a later step
         edge_vars = defaultdict(list)
-        invalid_edge_vars = []
+        invalid_edge_vars : list[Expression] = []
 
         # Determine flow in and flow out for each node
-        for src, edges in extended_mapping.items():
+        for src, edges in mapping.items():
             for value, dst in edges.items():
                 level = self.levels[src]
                 edge_var = cp.boolvar()
@@ -959,25 +957,26 @@ class MDD(GlobalConstraint):
             outgoing = flow_out[node]
 
             if level == 0:
-                cons.append(cp.sum(outgoing) == 1) # root
+                cons.append(cp.sum(outgoing) == 1)  # root
             elif level == len(arr):
-                cons.append(cp.sum(incoming) == 1) # sink
+                cons.append(cp.sum(incoming) == 1)  # sink
             else:
-                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
-                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
-                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
+                cons.append(cp.sum(incoming) == cp.sum(outgoing))  # enforce flow for internal nodes
+                cons.append(cp.sum(incoming) <= 1)  # redundant constraint: at most one incoming edge
+                cons.append(cp.sum(outgoing) <= 1)  # redundant constraint: at most one outgoing edge
 
         # Enforce direct encoding variable arr[i] == v if an edge with label v is activated at level i
         for (level, value), vars_ in edge_vars.items():
             cons.append(cp.sum(vars_) == (arr[level] == value))
+        return cons, invalid_edge_vars
 
-        return [cp.sum(invalid_edge_vars) == 0], cons
 
-
-    def decompose_positive(self) -> tuple[list[Expression], list[Expression]]:
+    def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-        Positive flow decomposition of the MDD global constraint.
-        Alternatively to
+        Flow decomposition of the MDD global constraint.
+        Enforces that the condition is satisfied, by ensuring that the flow in equals the flow out for every node.
+        First the mapping is extended with invalid edges, which are directed to the sink node, and then the flow constraints are defined.
+        The MDD global evaluates to true iff no invalid edge is taken.
 
         Returns:
             tuple[list[Expression], list[Expression]]:
@@ -985,43 +984,24 @@ class MDD(GlobalConstraint):
         """
         arr, _ = self.args
 
-        # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
-        # The default is an empty list, representing no ingoing / outgoing flow.
-        flow_in: dict[int | str, list[Expression]] = defaultdict(list)
-        flow_out: dict[int | str, list[Expression]] = defaultdict(list)
+        # MDD is extended with invalid edges, which are directed to the sink node
+        extended_mapping, invalid_edges_set = self._get_complete_mdd()
+        invalid_edges = frozenset(invalid_edges_set)
 
-        # Used to link edge variables to direct encoding variables in a later step
-        edge_vars = defaultdict(list)
+        cons, invalid_edge_vars = self._mdd_to_flow(extended_mapping, invalid_edges)
+        return [cp.sum(invalid_edge_vars) == 0], cons
 
-        # Determine flow in and flow out for each node
-        for src, edges in self.mapping.items():
-            for value, dst in edges.items():
-                level = self.levels[src]
-                edge_var = cp.boolvar()
-                flow_out[src].append(edge_var)
-                flow_in[dst].append(edge_var)
-                edge_vars[(level, value)].append(edge_var)
 
-        cons = []
+    def decompose_positive(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Positive flow decomposition of the MDD global constraint.
+        In contrast with decompose(), no extension with invalid edges is needed for the positive decomposition.
 
-        # Enforce flow constraints: flow in = flow out, at most one activated in/out edge
-        for node, level in self.levels.items():
-            incoming = flow_in[node]
-            outgoing = flow_out[node]
-
-            if level == 0:
-                cons.append(cp.sum(outgoing) == 1) # root
-            elif level == len(arr):
-                cons.append(cp.sum(incoming) == 1) # sink
-            else:
-                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
-                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
-                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
-
-        # Enforce direct encoding variable arr[i] == v if an edge with label v is activated at level i
-        for (level, value), vars_ in edge_vars.items():
-            cons.append(cp.sum(vars_) == (arr[level] == value))
-
+        Returns:
+            tuple[list[Expression], list[Expression]]:
+                A tuple containing the constraints representing the constraint value and the defining constraints.
+        """
+        cons, _ = self._mdd_to_flow(self.mapping)
         return cons, []
 
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -974,6 +974,57 @@ class MDD(GlobalConstraint):
         return [cp.sum(invalid_edge_vars) == 0], cons
 
 
+    def decompose_positive(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Positive flow decomposition of the MDD global constraint.
+        Alternatively to
+
+        Returns:
+            tuple[list[Expression], list[Expression]]:
+                A tuple containing the constraints representing the constraint value and the defining constraints.
+        """
+        arr, _ = self.args
+
+        # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
+        # The default is an empty list, representing no ingoing / outgoing flow.
+        flow_in: dict[int | str, list[Expression]] = defaultdict(list)
+        flow_out: dict[int | str, list[Expression]] = defaultdict(list)
+
+        # Used to link edge variables to direct encoding variables in a later step
+        edge_vars = defaultdict(list)
+
+        # Determine flow in and flow out for each node
+        for src, edges in self.mapping.items():
+            for value, dst in edges.items():
+                level = self.levels[src]
+                edge_var = cp.boolvar()
+                flow_out[src].append(edge_var)
+                flow_in[dst].append(edge_var)
+                edge_vars[(level, value)].append(edge_var)
+
+        cons = []
+
+        # Enforce flow constraints: flow in = flow out, at most one activated in/out edge
+        for node, level in self.levels.items():
+            incoming = flow_in[node]
+            outgoing = flow_out[node]
+
+            if level == 0:
+                cons.append(cp.sum(outgoing) == 1) # root
+            elif level == len(arr):
+                cons.append(cp.sum(incoming) == 1) # sink
+            else:
+                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
+                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
+                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
+
+        # Enforce direct encoding variable arr[i] == v if an edge with label v is activated at level i
+        for (level, value), vars_ in edge_vars.items():
+            cons.append(cp.sum(vars_) == (arr[level] == value))
+
+        return cons, []
+
+
     def value(self) -> Optional[bool]:
         """
         Returns:

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -654,10 +654,13 @@ class CPM_choco(SolverInterface):
 
                 array, transitions = cpm_expr.args
                 transitions_int = [[cpm_expr.node_map[src], val, cpm_expr.node_map[dst]] for src, val, dst in transitions]
-                handle = create_mdd_transitions(make_intvar_array(self._to_vars(array)), make_int_2d_array(transitions_int))
-                mdd = MultivaluedDecisionDiagram.__new__(MultivaluedDecisionDiagram)
-                _HandleWrapper.__init__(mdd, handle)
-                return self.chc_model.mddc(self._to_vars(array), mdd)
+                # currently no user-friendly way to create MDD objects with transitions in Pychoco.
+                # Manually create the required objects using the backend API.
+                # Issue opened on github: https://github.com/chocoteam/pychoco/issues/43
+                chc_handle = create_mdd_transitions(make_intvar_array(self._to_vars(array)), make_int_2d_array(transitions_int))
+                chc_mdd = MultivaluedDecisionDiagram.__new__(MultivaluedDecisionDiagram)
+                _HandleWrapper.__init__(chc_mdd, chc_handle)
+                return self.chc_model.mddc(self._to_vars(array), chc_mdd)
 
             elif cpm_expr.name == 'InDomain':
                 assert len(cpm_expr.args) == 2  # args = [array, list of vals]

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -87,7 +87,7 @@ class CPM_choco(SolverInterface):
                                     "table", 'negative_table', "short_table", "regular", "InDomain",
                                     "cumulative", "no_overlap", "circuit", "gcc", "inverse", "precedence",
                                     "increasing", "decreasing", "strictly_increasing", "strictly_decreasing",
-                                    "lex_lesseq", "lex_less",
+                                    "lex_lesseq", "lex_less", "mdd",
                                     "min", "max", "div", "mod", "pow", "abs", "mul", "count", "element", "nvalue", "among"})
     supported_reified_global_constraints = supported_global_constraints  # choco supports everything reified
 
@@ -646,7 +646,33 @@ class CPM_choco(SolverInterface):
                 automaton.set_initial_state(cpm_expr.node_map[start])
                 automaton.set_final(*[cpm_expr.node_map[a] for a in accepting])
                 return self.chc_model.regular(self._to_vars(array), automaton)
-            
+            elif cpm_expr.name == "mdd":
+                from pychoco.objects.graphs.multivalued_decision_diagram import MultivaluedDecisionDiagram
+                array, transitions, start = cpm_expr.args
+                root = start if start is not None else transitions[0][0]
+
+                from collections import defaultdict
+
+                def transitions_to_tuples(transitions, root, length):
+                    adj = defaultdict(list)
+                    for src, val, dst in transitions:
+                        adj[src].append((val, dst))
+
+                    def depth_first(node, path):
+                        if len(path) == length:
+                            return [tuple(path)]
+                        return [
+                            t
+                            for val, dst in adj.get(node, [])
+                            for t in depth_first(dst, path + [val])
+                        ]
+
+                    return depth_first(root, [])
+                # convert to MultivaluedDecisionDiagram Choco object, requiring list of accepted tuples
+                tuples = transitions_to_tuples(transitions, root, len(array))
+                mdd = MultivaluedDecisionDiagram(self._to_vars(array), tuples)
+                return self.chc_model.mddc(self._to_vars(array), mdd)
+
             elif cpm_expr.name == 'InDomain':
                 assert len(cpm_expr.args) == 2  # args = [array, list of vals]
                 expr, table = self.solver_vars(cpm_expr.args)

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -648,29 +648,15 @@ class CPM_choco(SolverInterface):
                 return self.chc_model.regular(self._to_vars(array), automaton)
             elif cpm_expr.name == "mdd":
                 from pychoco.objects.graphs.multivalued_decision_diagram import MultivaluedDecisionDiagram
-                array, transitions, start = cpm_expr.args
-                root = start if start is not None else transitions[0][0]
+                from pychoco.backend import create_mdd_transitions
+                from pychoco._handle_wrapper import _HandleWrapper
+                from pychoco._utils import make_int_2d_array, make_intvar_array
 
-                from collections import defaultdict
-
-                def transitions_to_tuples(transitions, root, length):
-                    adj = defaultdict(list)
-                    for src, val, dst in transitions:
-                        adj[src].append((val, dst))
-
-                    def depth_first(node, path):
-                        if len(path) == length:
-                            return [tuple(path)]
-                        return [
-                            t
-                            for val, dst in adj.get(node, [])
-                            for t in depth_first(dst, path + [val])
-                        ]
-
-                    return depth_first(root, [])
-                # convert to MultivaluedDecisionDiagram Choco object, requiring list of accepted tuples
-                tuples = transitions_to_tuples(transitions, root, len(array))
-                mdd = MultivaluedDecisionDiagram(self._to_vars(array), tuples)
+                array, transitions = cpm_expr.args
+                transitions_int = [[cpm_expr.node_map[src], val, cpm_expr.node_map[dst]] for src, val, dst in transitions]
+                handle = create_mdd_transitions(make_intvar_array(self._to_vars(array)), make_int_2d_array(transitions_int))
+                mdd = MultivaluedDecisionDiagram.__new__(MultivaluedDecisionDiagram)
+                _HandleWrapper.__init__(mdd, handle)
                 return self.chc_model.mddc(self._to_vars(array), mdd)
 
             elif cpm_expr.name == 'InDomain':

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -184,22 +184,25 @@ def _decompose_in_tree_args(args: ListLike[Any],
                     continue
                 else:
                     # nested global function, decompose
-                    if decompose_custom is not None and arg.name in decompose_custom:
-                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
-                    else:
-                        newarg, toplevel_exprs = arg.decompose()
-
                     orig_for_csemap = arg
-                    arg = newarg
-                    if len(toplevel_exprs) > 0:
-                        toplevel.extend(toplevel_exprs)
+                    # this is a bit awkward, but the decompose can return a new GlobFunc to decompose...
+                    while isinstance(arg, GlobalFunction) and arg.name not in supported:
+                        if decompose_custom is not None and arg.name in decompose_custom:
+                            newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                        else:
+                            newarg, toplevel_exprs = arg.decompose()
+                        arg = newarg
+                        if len(toplevel_exprs) > 0:
+                            toplevel.extend(toplevel_exprs)
 
-                    # TODO: violates type!!!
-                    # apparently in #630 we decided that decompose may return an int (e.g. for element)...
-                    # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
+                        # TODO: violates type!!!
+                        # apparently in #630 we decided that decompose may return an int (e.g. for element)...
+                        # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
+                        if isinstance(arg, int):
+                            # no need to recurse further, stop here
+                            newargs.append(arg)
+                            break
                     if isinstance(arg, int):
-                        # no need to recurse further, stop here
-                        newargs.append(arg)
                         continue
             
             # if it has subexprs, decompose its arguments too

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -22,10 +22,10 @@ import copy
 from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
 import numpy as np
 
-from ..expressions.core import Expression, ListLike
-from ..expressions.variables import NDVarArray
-from ..expressions.utils import is_any_list
-from ..expressions.python_builtins import all as cpm_all
+from ..expressions.core import Expression, ListLike, BoolVal, Operator
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalfunctions import GlobalFunction
+from ..expressions.variables import NDVarArray, cpm_array
 
 
 def decompose_in_tree(lst_of_expr: list[Expression],
@@ -58,22 +58,38 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    changed, newlst_of_expr, todo_toplevel = _decompose_in_tree(lst_of_expr, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom)
-    if not changed:
-        return lst_of_expr
+    newlist: List[Expression] = []
+    todolist: List[Expression] = []  # these still need to be decomposed
+    for expr in lst_of_expr:
+        if isinstance(expr, GlobalConstraint) and expr.name not in supported:
+            # toplevel/positive global constraint, decompose
+            if decompose_custom is not None and expr.name in decompose_custom:
+                exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
+            else:
+                exprs, toplevel_exprs = expr.decompose()
+            # both might contain globals too
+            todolist.extend(exprs)
+            if len(toplevel_exprs) > 0:
+                todolist.extend(toplevel_exprs)
+        elif isinstance(expr, bool):
+            # TODO: violates type!!!
+            newlist.append(BoolVal(expr))
+        elif expr.has_subexpr():
+            # decompose its arguments
+            changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+            if changed:
+                expr = copy.copy(expr)
+                expr.update_args(newargs)
+                if len(rec_toplevel) > 0:
+                    todolist.extend(rec_toplevel)
+            newlist.append(expr)
+        else:
+            newlist.append(expr)
 
-    # new toplevel constraints may need to be decomposed too
-    while len(todo_toplevel):
-        changed, decomp, next_toplevel = _decompose_in_tree(todo_toplevel, supported=supported, supported_reified=supported_reified, is_toplevel=True, csemap=csemap, decompose_custom=decompose_custom)
-        if not changed:
-            newlst_of_expr.extend(todo_toplevel)
-            break
-
-        # changed, loop again
-        newlst_of_expr.extend(decomp)
-        todo_toplevel = next_toplevel # decompositions may have introduced nested lists or ands
-
-    return newlst_of_expr
+    # recurse on any newly generated toplevel expressions
+    if len(todolist) == 0:
+        return newlist
+    return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
 
 
 def decompose_objective(expr: Expression,
@@ -107,21 +123,20 @@ def decompose_objective(expr: Expression,
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    changed, newexpr, todo_toplevel = _decompose_in_tree((expr,), supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
-    if not changed:
+    changed, newexprs, todo_toplevel = _decompose_in_tree_args((expr,), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+    if changed:
+        assert len(newexprs) == 1, "decompose_objective: expected a single expression as decomposed objective but got {newexprs}"
+        return newexprs[0], todo_toplevel
+    else:
         return expr, []
 
-    assert len(newexpr) == 1, "decompose_objective: expected a single expression as decomposed objective but got {newexpr}"
-    return newexpr[0], todo_toplevel
-
-
-def _decompose_in_tree(lst_of_expr: ListLike[Any],
-                       supported: AbstractSet[str],
-                       supported_reified: AbstractSet[str],
-                       is_toplevel: bool,
-                       csemap: Optional[Dict[Expression, Expression]]=None,
-                       decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Expression], List[Expression]]:
+def _decompose_in_tree_args(args: ListLike[Any],
+                            supported: AbstractSet[str],
+                            supported_reified: AbstractSet[str],
+                            csemap: Optional[Dict[Expression, Expression]]=None,
+                            decompose_custom:Optional[Dict[str, Callable]]=None) -> Tuple[bool, List[Any], List[Expression]]:
     """
+    TODO: OUTDATED DOC!!
     Decompose any global constraint or global function not supported by the solver, recursive internal version.
 
     INTERNAL function, not guaranteed to remain backward compatible.
@@ -130,8 +145,6 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
         or other sequence of expressions that may use global constraints or global functions.
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
-    :param is_toplevel: whether ``lst_of_expr`` is the toplevel list of constraints.
-        If False, ``lst_of_expr`` is an argument to another expression and its global constraints must support reification.
     :param csemap: a dictionary of 'expr: expr' mappings, for Common Subexpression Elimination
 
     :returns: ``(changed, newexpr, toplevel)`` where:
@@ -140,78 +153,96 @@ def _decompose_in_tree(lst_of_expr: ListLike[Any],
         - ``toplevel`` is the list of auxiliary constraints to post at top level.
     """
     changed = False
-    newlist: List[Any] = []  # TODO: because of is_any_list, can be many things...
     toplevel: List[Expression] = []
+    newargs: List[Any] = []
+    for arg in args:
+        if isinstance(arg, Expression):
+            orig_for_csemap: Optional[Expression] = None  # if set, will store the new arg in the csemap
 
-    for expr in lst_of_expr:
-        if is_any_list(expr):
-            assert not is_toplevel, "Lists in lists is only allowed for arguments (e.g. of global constrainst)." \
-                                    "Make sure to run func:`cpmpy.transformations.normalize.toplevel_list` first."
-
-            if isinstance(expr, NDVarArray) and not expr.has_subexpr():
-                pass  # no subexpressions, nothing to do
-            elif isinstance(expr, np.ndarray) and expr.dtype != object:
-                pass  # only constants, nothing to do
-            else:
-                rec_changed, rec_expr, rec_toplevel = _decompose_in_tree(expr, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    expr = rec_expr
-                    toplevel.extend(rec_toplevel)
-                    changed = True
-            newlist.append(expr)
-            continue
-
-        if isinstance(expr, Expression):
-            # if an expression, decompose its arguments first
-            if expr.has_subexpr():
-                rec_changed, newargs, rec_toplevel = _decompose_in_tree(expr.args, supported=supported, supported_reified=supported_reified, is_toplevel=False, csemap=csemap, decompose_custom=decompose_custom)
-                if rec_changed:
-                    expr = copy.copy(expr)
-                    expr.update_args(newargs)
-                    toplevel.extend(rec_toplevel)
-                    changed = True
-
-            if hasattr(expr, "decompose"):  # it is a global function or global constraint
-                is_supported = expr.name in supported
-                if not is_toplevel and expr.is_bool():
-                    # argument to another expression, only possible if supported reified
-                    is_supported = expr.name in supported_reified
-
-                if is_supported is False:
-                    if (csemap is not None) and expr in csemap:
-                        # we might have already decomposed it previously
-                        newexpr = csemap[expr]
-                    else:
-                        if decompose_custom is not None and expr.name in decompose_custom:
-                            newexpr, define = decompose_custom[expr.name](expr)
-                        else:
-                            newexpr, define = expr.decompose()
-                        toplevel.extend(define)
-
-                        # decomposed constraints may introduce new globals
-                        if isinstance(newexpr, list):  # globals return a list instead of a single expression (TODO: change?)
-                            rec_changed, rec_newexpr, rec_toplevel = _decompose_in_tree(newexpr, supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
-                            if rec_changed:
-                                newexpr_lst = rec_newexpr
-                                toplevel.extend(rec_toplevel)
-                            else:
-                                newexpr_lst = newexpr  # for mypy
-                            newexpr = cpm_all(newexpr_lst)  # make the list a single expression
-                        else:
-                            rec_changed, rec_lst_newexpr, rec_toplevel = _decompose_in_tree((newexpr,), supported=supported, supported_reified=supported_reified, is_toplevel=is_toplevel, csemap=csemap, decompose_custom=decompose_custom)
-                            if rec_changed:
-                                newexpr = rec_lst_newexpr[0]
-                                toplevel.extend(rec_toplevel)
-
-                        if (csemap is not None):
-                            csemap[expr] = newexpr
-
-                    newlist.append(newexpr)
-                    changed = True
+            # a nested expression (its inside an args)
+            if isinstance(arg, GlobalConstraint) and arg.name not in supported_reified:
+                changed = True
+                if (csemap is not None) and arg in csemap:  # have we decomposed it before?
+                    newargs.append(csemap[arg])
                     continue
+                else:
+                    # nested global constraint, decompose
+                    if decompose_custom is not None and arg.name in decompose_custom:
+                        exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[arg.name](arg))
+                    else:
+                        exprs, toplevel_exprs = arg.decompose()
 
-        # constants, variables, other expressions are left as is
-        newlist.append(expr)
+                    # replace arg by conjunction of decompose
+                    orig_for_csemap = arg
+                    arg = Operator("and", exprs)  # don't use cpm_all as for len=1 it shortcuts
+                    if len(toplevel_exprs) > 0:
+                        toplevel.extend(toplevel_exprs)
+            elif isinstance(arg, GlobalFunction) and arg.name not in supported:
+                changed = True
+                if (csemap is not None) and arg in csemap:  # have we decomposed it before?
+                    newargs.append(csemap[arg])
+                    continue
+                else:
+                    # nested global function, decompose
+                    if decompose_custom is not None and arg.name in decompose_custom:
+                        newarg, toplevel_exprs = cast(Tuple[Expression, List[Expression]], decompose_custom[arg.name](arg))
+                    else:
+                        newarg, toplevel_exprs = arg.decompose()
 
-    assert is_toplevel or len(newlist) == len(lst_of_expr), f"Nested decomposition should not change the number of expressions\n{lst_of_expr}\n{newlist}"
-    return (changed, newlist, toplevel)
+                    orig_for_csemap = arg
+                    arg = newarg
+                    if len(toplevel_exprs) > 0:
+                        toplevel.extend(toplevel_exprs)
+
+                    # TODO: violates type!!!
+                    # apparently in #630 we decided that decompose may return an int (e.g. for element)...
+                    # we should change that (Element constructor requires variable index; the []/__get__ override can still take anything)
+                    if isinstance(arg, int):
+                        # no need to recurse further, stop here
+                        newargs.append(arg)
+                        continue
+            
+            # if it has subexprs, decompose its arguments too
+            if arg.has_subexpr():
+                rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if rec_changed:
+                    changed = True
+                    arg = copy.copy(arg)
+                    arg.update_args(rec_newargs)
+                    if len(rec_toplevel) > 0:
+                        toplevel.extend(rec_toplevel)
+
+            # very special case: "and" with single argument (from simple glob.decomp)
+            if arg.name == "and" and len(arg.args) == 1:
+                arg = cast(Expression, arg.args[0])
+
+            if orig_for_csemap is not None and csemap is not None:
+                csemap[orig_for_csemap] = arg
+            newargs.append(arg)
+        
+        elif isinstance(arg, np.ndarray) and arg.dtype == object:
+            if isinstance(arg, NDVarArray):
+                if arg.has_subexpr():
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(cpm_array(rec_newargs).reshape(arg.shape))
+                    else:
+                        newargs.append(arg)
+                else:
+                    newargs.append(arg)
+            else:  # regular np.array
+                if arg.dtype == object:
+                    rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.flatten(), supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                    if rec_changed:
+                        changed = True
+                        newargs.append(np.array(rec_newargs).reshape(arg.shape))
+                    else:
+                        newargs.append(arg)
+                else:
+                    newargs.append(arg)
+        else:
+            # constants, variables, other expressions are left as is
+            newargs.append(arg)
+
+    return (changed, newargs, toplevel)

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -71,7 +71,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             todolist.extend(exprs)
             if len(toplevel_exprs) > 0:
                 todolist.extend(toplevel_exprs)
-        elif isinstance(expr, bool):
+        elif isinstance(expr, (bool, np.bool_)):
             # TODO: violates type!!!
             newlist.append(BoolVal(expr))
         elif expr.has_subexpr():

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -64,11 +64,11 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
+            positive_decomp = decompose_positive.get(expr.name)
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
-            elif expr.name in decompose_positive:
-                global_constraint = expr
-                exprs, toplevel_exprs = global_constraint.decompose_positive()
+            elif positive_decomp is not None:
+                exprs, toplevel_exprs = positive_decomp(expr)
             else:
                 exprs, toplevel_exprs = expr.decompose()
             # both might contain globals too
@@ -79,28 +79,24 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             # TODO: violates type!!!
             newlist.append(BoolVal(expr))
         elif expr.has_subexpr():
-            # decompose its arguments
+
             if expr.name == "->" and isinstance(expr.args[1], GlobalConstraint):
-                if expr.args[1].name in decompose_positive:
-
-                    if decompose_custom is not None and expr.name in decompose_custom:
-                        exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]],
-                                                     decompose_custom[expr.name](expr))
-                    else:
-                        global_constraint = expr.args[1]
-                        exprs, toplevel_exprs = global_constraint.decompose_positive()
-
-                    print("exprs: ", exprs)
+                # special case: positively reified global constraint, use positive decomposition
+                positive_decomp = decompose_positive.get(expr.args[1].name)
+                if positive_decomp is not None:
+                    global_constraint = expr.args[1]
+                    exprs, toplevel_exprs = positive_decomp(global_constraint)
                     newlist.extend(expr.args[0].implies(e) for e in exprs)
                     newlist.extend(toplevel_exprs)
-
-            changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-            if changed:
-                expr = copy.copy(expr)
-                expr.update_args(newargs)
-                if len(rec_toplevel) > 0:
-                    todolist.extend(rec_toplevel)
-            newlist.append(expr)
+            else:
+                # decompose its arguments
+                changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                if changed:
+                    expr = copy.copy(expr)
+                    expr.update_args(newargs)
+                    if len(rec_toplevel) > 0:
+                        todolist.extend(rec_toplevel)
+                newlist.append(expr)
         else:
             newlist.append(expr)
 
@@ -269,7 +265,7 @@ def _decompose_in_tree_args(args: ListLike[Any],
     return (changed, newargs, toplevel)
 
 
-def get_positive_decompositions():
-    return dict(
-        mdd=MDD.decompose_positive
-    )
+def get_positive_decompositions() -> dict[str, Callable[[Any], tuple[list[Expression], list[Expression]]]]:
+    return {
+        "mdd": MDD.decompose_positive,
+    }

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -23,7 +23,7 @@ from typing import List, AbstractSet, Optional, Dict, Tuple, Any, Callable, cast
 import numpy as np
 
 from ..expressions.core import Expression, ListLike, BoolVal, Operator
-from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.globalconstraints import GlobalConstraint, MDD
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import NDVarArray, cpm_array
 
@@ -60,11 +60,15 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 
     newlist: List[Expression] = []
     todolist: List[Expression] = []  # these still need to be decomposed
+    decompose_positive = get_positive_decompositions()
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
+            elif expr.name in decompose_positive:
+                global_constraint = expr
+                exprs, toplevel_exprs = global_constraint.decompose_positive()
             else:
                 exprs, toplevel_exprs = expr.decompose()
             # both might contain globals too
@@ -76,6 +80,20 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             newlist.append(BoolVal(expr))
         elif expr.has_subexpr():
             # decompose its arguments
+            if expr.name == "->" and isinstance(expr.args[1], GlobalConstraint):
+                if expr.args[1].name in decompose_positive:
+
+                    if decompose_custom is not None and expr.name in decompose_custom:
+                        exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]],
+                                                     decompose_custom[expr.name](expr))
+                    else:
+                        global_constraint = expr.args[1]
+                        exprs, toplevel_exprs = global_constraint.decompose_positive()
+
+                    print("exprs: ", exprs)
+                    newlist.extend(expr.args[0].implies(e) for e in exprs)
+                    newlist.extend(toplevel_exprs)
+
             changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
             if changed:
                 expr = copy.copy(expr)
@@ -249,3 +267,9 @@ def _decompose_in_tree_args(args: ListLike[Any],
             newargs.append(arg)
 
     return (changed, newargs, toplevel)
+
+
+def get_positive_decompositions():
+    return dict(
+        mdd=MDD.decompose_positive
+    )

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -60,11 +60,11 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 
     newlist: List[Expression] = []
     todolist: List[Expression] = []  # these still need to be decomposed
-    decompose_positive = get_positive_decompositions()
+    positive_decomps = get_positive_decompositions()
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
             # toplevel/positive global constraint, decompose
-            positive_decomp = decompose_positive.get(expr.name)
+            positive_decomp = positive_decomps.get(expr.name)
             if decompose_custom is not None and expr.name in decompose_custom:
                 exprs, toplevel_exprs = cast(Tuple[List[Expression], List[Expression]], decompose_custom[expr.name](expr))
             elif positive_decomp is not None:
@@ -79,23 +79,37 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             # TODO: violates type!!!
             newlist.append(BoolVal(expr))
         elif expr.has_subexpr():
-
             if expr.name == "->" and isinstance(expr.args[1], GlobalConstraint):
-                # special case: positively reified global constraint, use positive decomposition
-                positive_decomp = decompose_positive.get(expr.args[1].name)
+                global_constraint = expr.args[1]
+                positive_decomp = positive_decomps.get(global_constraint.name)
+
                 if positive_decomp is not None:
-                    global_constraint = expr.args[1]
+                    # Special case: use positive decomposition
                     exprs, toplevel_exprs = positive_decomp(global_constraint)
+
                     newlist.extend(expr.args[0].implies(e) for e in exprs)
                     newlist.extend(toplevel_exprs)
+                    already_decomposed = True
+                else:
+                    already_decomposed = False
             else:
-                # decompose its arguments
-                changed, newargs, rec_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+                already_decomposed = False
+
+            if not already_decomposed:
+                changed, newargs, rec_toplevel = _decompose_in_tree_args(
+                    expr.args,
+                    supported=supported,
+                    supported_reified=supported_reified,
+                    csemap=csemap,
+                    decompose_custom=decompose_custom,
+                )
+
                 if changed:
                     expr = copy.copy(expr)
                     expr.update_args(newargs)
-                    if len(rec_toplevel) > 0:
+                    if rec_toplevel:
                         todolist.extend(rec_toplevel)
+
                 newlist.append(expr)
         else:
             newlist.append(expr)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -75,7 +75,7 @@ from .normalize import toplevel_list, simplify_boolean
 from ..exceptions import TransformationNotImplementedError
 
 from ..expressions.core import Comparison, Expression, Operator, BoolVal
-from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent
+from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
@@ -623,6 +623,7 @@ def get_linear_decompositions():
     return dict(
         alldifferent=AllDifferent.decompose_linear,
         element=Element.decompose_linear,
+        table=Table.decompose_linear
     )
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -75,7 +75,7 @@ from .normalize import toplevel_list, simplify_boolean
 from ..exceptions import TransformationNotImplementedError
 
 from ..expressions.core import Comparison, Expression, Operator, BoolVal
-from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table
+from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table, Regular
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
@@ -623,7 +623,8 @@ def get_linear_decompositions():
     return dict(
         alldifferent=AllDifferent.decompose_linear,
         element=Element.decompose_linear,
-        table=Table.decompose_linear
+        table=Table.decompose_linear,
+        regular=Regular.decompose_linear
     )
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -169,6 +169,7 @@ def global_constraints(solver):
         elif name == "ShortTable":
             yield cp.ShortTable(NUM_ARGS, [[0,"*",2], ["*","*",1]])
         elif name == "MDD":
+            yield cp.MDD(cp.intvar(lb=0, ub=1, shape=3, name="x"), [("r", 0, "n1"), ("n1", 0, "n2"), ("n2", 0, "t")])
             yield cp.MDD(NUM_ARGS, [("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
             ("n4", 0, "t"), ("n5", 1, "t")])
             yield cp.MDD(NUM_ARGS, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -168,6 +168,12 @@ def global_constraints(solver):
             yield cp.NegativeTable(NUM_ARGS, [[0, 1, 2], [1, 2, 0], [1, 0, 2]])
         elif name == "ShortTable":
             yield cp.ShortTable(NUM_ARGS, [[0,"*",2], ["*","*",1]])
+        elif name == "MDD":
+            yield cp.MDD(NUM_ARGS, [("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),
+            ("n4", 0, "t"), ("n5", 1, "t")])
+            yield cp.MDD(NUM_ARGS, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),
+                          ("2", 1, "2,1"), ("1", 2, "1,2"), ("4", 3, "1,2"), ("3", 2, "3,2"),
+                          ("2,1", 1, "snk"), ("2,1", 2, "snk"), ("1,2", 3, "snk"), ("3,2", 2, "snk")])
         elif name == "IfThenElse":
             yield cp.IfThenElse(*BOOL_ARGS)
         elif name == "InDomain":

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -269,9 +269,9 @@ class TestArrayExpressions:
             res *= v.value()
         assert y.value() == res
         # with axis arg
-        x = intvar(0,5,shape=(10,10), name="x")
+        x = intvar(0,5,shape=(10,4), name="x")
         y = intvar(0, 1000, shape=10, name="y")
-        model = cp.Model(y == x.prod(axis=0))
+        model = cp.Model(y == x.prod(axis=1))  # y[i] = product(x[i,:])
         model.solve()
         for i,vv in enumerate(x):
             res = 1

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -252,6 +252,17 @@ class TestTransLinearize:
         assert str(lin_cons[1]) == "sum([1, 1, 3] * [x, y, ~b]) >= 5"
 
 
+    def test_mdd(self):
+
+        x = cp.intvar(1, 4, shape=3, name="x")
+
+        cons = cp.MDD(x, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),
+                          ("2", 1, "2,1"), ("1", 2, "1,2"), ("4", 3, "1,2"), ("3", 2, "3,2"),
+                          ("2,1", 1, "snk"), ("2,1", 2, "snk"), ("1,2", 3, "snk"), ("3,2", 2, "snk")])
+        lin_cons = linearize_constraint(decompose_linear([cons]))
+        print("Lin cons: ", lin_cons)
+        assert len(lin_cons) == 1
+        assert str(lin_cons) == "[sum(sum(x[0] == 2, x[0] == 1, x[0] == 4, x[0] == 3) == 1, (sum(x[0] == 2)) == (sum(x[1] == 1)), (sum(x[0] == 1)) == (sum(BV3)), (sum(x[0] == 4)) == (sum(x[1] == 3)), (sum(x[0] == 3)) == (sum(BV4)), (sum(x[1] == 1)) == ((x[2] == 1) + (BV5)), ((BV3) + (x[1] == 3)) == (sum(x[2] == 3)), sum(x[2] == 1, BV5, x[2] == 3, BV4) == 1, ((BV3) + (BV4)) == (x[1] == 2), ((BV5) + (BV4)) == (x[2] == 2)) >= 10]"
 
 
 

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -251,20 +251,6 @@ class TestTransLinearize:
         assert str(lin_cons[0]) == "sum([1, 1, -15] * [x, y, ~b]) <= 5"
         assert str(lin_cons[1]) == "sum([1, 1, 3] * [x, y, ~b]) >= 5"
 
-    @pytest.mark.skip(reason="solver dependent")
-    def test_mdd(self):
-
-        x = cp.intvar(1, 4, shape=3, name="x")
-
-        cons = cp.MDD(x, [("src", 2, "2"), ("src", 1, "1"), ("src", 4, "4"), ("src", 3, "3"),
-                          ("2", 1, "2,1"), ("1", 2, "1,2"), ("4", 3, "1,2"), ("3", 2, "3,2"),
-                          ("2,1", 1, "snk"), ("2,1", 2, "snk"), ("1,2", 3, "snk"), ("3,2", 2, "snk")])
-        lin_cons = linearize_constraint(decompose_linear([cons]))
-        print("Lin cons: ", lin_cons)
-        assert len(lin_cons) == 1
-        assert str(lin_cons) == "[sum(sum(x[0] == 2, x[0] == 1, x[0] == 4, x[0] == 3) == 1, (sum(x[0] == 2)) == (sum(x[1] == 1)), (sum(x[0] == 1)) == (sum(BV3)), (sum(x[0] == 4)) == (sum(x[1] == 3)), (sum(x[0] == 3)) == (sum(BV4)), (sum(x[1] == 1)) == ((x[2] == 1) + (BV5)), ((BV3) + (x[1] == 3)) == (sum(x[2] == 3)), sum(x[2] == 1, BV5, x[2] == 3, BV4) == 1, ((BV3) + (BV4)) == (x[1] == 2), ((BV5) + (BV4)) == (x[2] == 2)) >= 10]"
-
-
 
 
 class TestConstRhs:

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -251,7 +251,7 @@ class TestTransLinearize:
         assert str(lin_cons[0]) == "sum([1, 1, -15] * [x, y, ~b]) <= 5"
         assert str(lin_cons[1]) == "sum([1, 1, 3] * [x, y, ~b]) >= 5"
 
-
+    @pytest.mark.skip(reason="solver dependent")
     def test_mdd(self):
 
         x = cp.intvar(1, 4, shape=3, name="x")

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -6,7 +6,7 @@ from cpmpy.expressions.utils import flatlist
 from cpmpy.transformations.decompose_global import decompose_in_tree
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl  # to reset counters
 from cpmpy.transformations.linearize import decompose_linear
-
+import pytest
 
 class TestTransfDecomp:
 
@@ -185,15 +185,19 @@ class TestTransfDecomp:
         assert set(map(str, decompose_linear([cons]))) == \
                             {"sum([20, 30, 40] * [a == 1, a == 2, a == 3]) == 8"}  # a == 0 is False (a in 1..3) 
 
-        # test table
-        cons = cp.Table(x, [[1,1], [2,3]])
-        assert set(map(str, decompose_linear([cons]))) == \
-                            {'((a == 1) and (b == 1)) or ((a == 2) and (b == 3))'}
 
         # test count
         cons = cp.Count(x, 2) >= 1
         assert set(map(str, decompose_linear([cons]))) == \
                             {'(a == 2) + (b == 2) >= 1'}
+
+    @pytest.mark.xfail(reason="New linear table decomposition")
+    def test_decompose_linear_table(self):
+        # test table
+        x = cp.intvar(1, 3, shape=2, name=("a", "b"))
+        cons = cp.Table(x, [[1, 1], [2, 3]])
+        assert set(map(str, decompose_linear([cons]))) == \
+               {'((a == 1) and (b == 1)) or ((a == 2) and (b == 3))'}
 
     def test_issue_546(self):
         # https://github.com/CPMpy/cpmpy/issues/546

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -1,4 +1,3 @@
-import unittest
 import cpmpy as cp
 from cpmpy.expressions.globalconstraints import GlobalConstraint
 from cpmpy.expressions.globalfunctions import GlobalFunction
@@ -19,7 +18,7 @@ class TestTransfDecomp:
         bv = cp.boolvar(name="bv")
 
         cons = [cp.AllDifferent(ivs)]
-        assert str(decompose_in_tree(cons)) == "[and((x) != (y), (x) != (z), (y) != (z))]"
+        assert str(decompose_in_tree(cons)) == "[(x) != (y), (x) != (z), (y) != (z)]"
         assert str(decompose_in_tree(cons, supported={"alldifferent"})) == str(cons)
 
         # reified
@@ -137,13 +136,16 @@ class TestTransfDecomp:
 
         cons = MyGlobal1([x])
         assert set(map(str,decompose_in_tree([cons], supported={"myglobalfunc","max"}))) == \
-                            {'((myglobalfunc(x[0],x[1])) + 5 <= 0) and (max(x[0],x[1]) == 1)',
+                            {'(myglobalfunc(x[0],x[1])) + 5 <= 0',
+                             'max(x[0],x[1]) == 1',
                              '(x[0]) + (x[1]) >= 3'}
 
         # decompose all
         assert set(map(str, decompose_in_tree([cons], supported={"max"}))) == \
-                            {'(((x[0]) + (x[1])) + 5 <= 0) and (max(x[0],x[1]) == 1)',
-                             '(x[0]) + (x[1]) >= 3','x[0] != 0'}
+                            {'((x[0]) + (x[1])) + 5 <= 0',
+                             'max(x[0],x[1]) == 1',
+                             '(x[0]) + (x[1]) >= 3',
+                             'x[0] != 0'}
 
         # nested case
         bv = cp.boolvar(name="bv")
@@ -155,7 +157,8 @@ class TestTransfDecomp:
 
         assert set(map(str, decompose_in_tree([cons], supported={"max"}))) == \
                             {'(bv) == ((((x[0]) + (x[1])) + 5 <= 0) and (max(x[0],x[1]) == 1))',
-                             '(x[0]) + (x[1]) >= 3', 'x[0] != 0'}
+                             '(x[0]) + (x[1]) >= 3',
+                             'x[0] != 0'}
 
 
     def test_decompose_linear(self):
@@ -165,10 +168,14 @@ class TestTransfDecomp:
 
         cons = cp.AllDifferent(x)
         assert set(map(str, decompose_linear([cons]))) == \
-                            {"and((a == 1) + (b == 1) <= 1, (a == 2) + (b == 2) <= 1, (a == 3) + (b == 3) <= 1)"}
+                            {'(a == 1) + (b == 1) <= 1',
+                             '(a == 2) + (b == 2) <= 1',
+                             '(a == 3) + (b == 3) <= 1'}
         # second call gives same result (no ivarmap state)
         assert set(map(str, decompose_linear([cons]))) == \
-                            {"and((a == 1) + (b == 1) <= 1, (a == 2) + (b == 2) <= 1, (a == 3) + (b == 3) <= 1)"}
+                            {'(a == 1) + (b == 1) <= 1',
+                             '(a == 2) + (b == 2) <= 1',
+                             '(a == 3) + (b == 3) <= 1'}
 
         # nested
         cons = bv == cp.AllDifferent(x)
@@ -202,9 +209,9 @@ class TestTransfDecomp:
 
         cons = cp.AllDifferent(arr)
         assert set(map(str, decompose_linear([cons]))) == \
-                            {'and(sum(a == 1, b == 1, False) <= 1, '
-                             'sum(a == 2, b == 2, True) <= 1, '
-                             'sum(a == 3, b == 3, False) <= 1)'}
+                            {'sum(a == 1, b == 1, False) <= 1',
+                             'sum(a == 2, b == 2, True) <= 1',
+                             'sum(a == 3, b == 3, False) <= 1'}
 
         # also test full transformation stack
         if "gurobi" in cp.SolverLookup.solvernames():  # otherwise, not supported


### PR DESCRIPTION
Building on #924, #949 and #980, I implemented a linear decomposition of the Regular global constraint using the MDD global. To convert the DFA to an MDD, I used Algorithm 1 in:
"A Regular Language Membership Constraint for Finite Sequences of Variables", Gilles Pesant, 2004
to convert a DFA to a layered graph (equivalent to an MDD). The advantage here is that transitions that cannot lead to an accepting state will not be part of the resulting layered graph.

By doing this, we can also take advantage of the positive decomposition for MDDs when the Regular global is top-level or positively reified. (Same goes for Table in #945)