### PR TITLE
Varname in varmap instead of variable object

### DIFF
--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -276,17 +276,17 @@ class CPM_template(SolverInterface):
             return TEMPLATEpy.negate(self.solver_var(cpm_var._bv))
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = TEMPLATEpy.NewBoolVar(str(cpm_var))
             elif isinstance(cpm_var, _IntVarImpl):
                 revar = TEMPLATEpy.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
         # return from cache
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     # [GUIDELINE] if TEMPLATE does not support objective functions, you can delete this function definition

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -328,7 +328,7 @@ class CPM_choco(SolverInterface):
             return self.chc_model.bool_not_view(self.solver_var(cpm_var._bv))
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = self.chc_model.boolvar(name=str(cpm_var.name))
             elif isinstance(cpm_var, _IntVarImpl):
@@ -338,9 +338,9 @@ class CPM_choco(SolverInterface):
                 revar = self.chc_model.intvar(cpm_var.lb, cpm_var.ub, name=str(cpm_var.name))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
     def objective(self, expr, minimize):
         """

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -278,17 +278,17 @@ class CPM_cplex(SolverInterface):
                             "See /transformations/linearize for more details")
 
         # create if it does not exit
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = self.cplex_model.binary_var(cpm_var.name)
             elif isinstance(cpm_var, _IntVarImpl):
                 revar = self.cplex_model.integer_var(cpm_var.lb, cpm_var.ub, name=str(cpm_var))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
         # return from cache
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -353,7 +353,7 @@ class CPM_cpo(SolverInterface):
             return (self.solver_var(cpm_var._bv) == 0)
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 # note that a binary var is an integer var with domain (0,1), you cannot do boolean operations on it.
                 # we should add == 1 to turn it into a boolean expression
@@ -362,11 +362,11 @@ class CPM_cpo(SolverInterface):
                 revar = docp.expression.integer_var(min=cpm_var.lb, max=cpm_var.ub, name=str(cpm_var))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
             self.cpo_model.add(revar >= cpm_var.lb) # ensure the model also has the variable
 
         # return from cache
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
     def objective(self, expr, minimize=True):
         """
@@ -787,10 +787,10 @@ try:
                 # populate values before printing
                 for cpm_var in self._cpm_vars:
                     if isinstance(cpm_var, _BoolVarImpl):
-                        sol_var = self._varmap[cpm_var].children[0]
+                        sol_var = self._varmap[cpm_var.name].children[0]
                         cpm_var._value = bool(sres.get_var_solution(sol_var).get_value())
                     elif isinstance(cpm_var, _IntVarImpl):
-                        sol_var = self._varmap[cpm_var]
+                        sol_var = self._varmap[cpm_var.name]
                         cpm_var._value = sres.get_var_solution(sol_var).get_value()
                     else:
                         raise NotImplementedError(f"Unexpected variable type {type(cpm_var)}")

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -402,8 +402,8 @@ class CPM_exact(SolverInterface):
             raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
 
         # return it if it already exists
-        if cpm_var in self._varmap:
-            return self._varmap[cpm_var]
+        if cpm_var.name in self._varmap:
+            return self._varmap[cpm_var.name]
 
         # create if it does not exist
         revar = str(cpm_var)
@@ -418,7 +418,7 @@ class CPM_exact(SolverInterface):
             self.xct_solver.addVariable(revar, lb, ub, encoding)
         else:
             raise NotImplementedError("Not a known var {}".format(cpm_var))
-        self._varmap[cpm_var] = revar
+        self._varmap[cpm_var.name] = revar
         return revar
 
 

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -369,7 +369,7 @@ class CPM_gcs(SolverInterface):
             return self.gcs.add_constant(self.gcs.negate(self.solver_var(cpm_var._bv)), 1)
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 # Bool vars are just int vars with [0, 1] domain
                 revar = self.gcs.create_integer_variable(0, 1, str(cpm_var))
@@ -377,9 +377,9 @@ class CPM_gcs(SolverInterface):
                 revar = self.gcs.create_integer_variable(cpm_var.lb, cpm_var.ub, str(cpm_var))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
     def objective(self, expr, minimize=True):
         """

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -263,7 +263,7 @@ class CPM_gurobi(SolverInterface):
             raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
 
         # create if it does not exit
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             from gurobipy import GRB
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = self.grb_model.addVar(vtype=GRB.BINARY, name=cpm_var.name)
@@ -271,10 +271,10 @@ class CPM_gurobi(SolverInterface):
                 revar = self.grb_model.addVar(cpm_var.lb, cpm_var.ub, vtype=GRB.INTEGER, name=str(cpm_var))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
         # return from cache
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -258,7 +258,7 @@ class CPM_hexaly(SolverInterface):
             return ~self.solver_var(cpm_var._bv)
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = self.hex_model.bool()
             elif isinstance(cpm_var, _IntVarImpl):
@@ -267,10 +267,10 @@ class CPM_hexaly(SolverInterface):
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
             # set name of variable
             revar.set_name(str(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
         # return from cache
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -146,7 +146,7 @@ class CPM_highs(SolverInterface):
             )
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 hvar = self.highs.addBinary()
             elif isinstance(cpm_var, _IntVarImpl):
@@ -154,9 +154,9 @@ class CPM_highs(SolverInterface):
             else:
                 raise NotSupportedError(f"Not a known HiGHS variable type: {cpm_var}")
 
-            self._varmap[cpm_var] = hvar.index
+            self._varmap[cpm_var.name] = hvar.index
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
     def solver_vars_1d(self, cpm_vars):
         """
@@ -164,7 +164,7 @@ class CPM_highs(SolverInterface):
         """
         res = []
         for cpm_var in cpm_vars:
-            solver_var = self._varmap.get(cpm_var, None)
+            solver_var = self._varmap.get(cpm_var.name, None)
             if solver_var is not None:
                 # fast path
                 res.append(solver_var)
@@ -421,9 +421,9 @@ class CPM_highs(SolverInterface):
             solution = self.highs.getSolution()
             col_values = solution.col_value
             for cpm_var in self.user_vars:
-                if cpm_var not in self._varmap:
+                if cpm_var.name not in self._varmap:
                     continue
-                col_idx = self._varmap[cpm_var]
+                col_idx = self._varmap[cpm_var.name]
                 val = col_values[col_idx]
                 if cpm_var.is_bool():
                     cpm_var._value = val >= 0.5

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -538,7 +538,7 @@ class CPM_minizinc(SolverInterface):
         if isinstance(cpm_var, NegBoolView):
             raise NotSupportedError("Negative literals are not handled here. Please report.")
 
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             # clean the varname
             varname = cpm_var.name
             mzn_var = varname.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '')
@@ -558,9 +558,9 @@ class CPM_minizinc(SolverInterface):
                     raise MinizincBoundsException("minizinc does not accept variables with bounds outside "
                                                   "of range (-2147483646..2147483646)")
                 self.mzn_model.add_string(f"var {cpm_var.lb}..{cpm_var.ub}: {mzn_var};\n")
-            self._varmap[cpm_var] = mzn_var
+            self._varmap[cpm_var.name] = mzn_var
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
     def objective(self, expr, minimize):
         """

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -324,16 +324,16 @@ class CPM_ortools(SolverInterface):
             return self.solver_var(cpm_var._bv).Not()
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = self.ort_model.NewBoolVar(str(cpm_var))
             elif isinstance(cpm_var, _IntVarImpl):
                 revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     def objective(self, expr, minimize):
@@ -960,9 +960,9 @@ try:
                 # populate values before printing
                 for cpm_var in self._cpm_vars:
                     if isinstance(cpm_var, _BoolVarImpl):
-                        cpm_var._value = bool(self.Value(self._varmap[cpm_var]))
+                        cpm_var._value = bool(self.Value(self._varmap[cpm_var.name]))
                     elif isinstance(cpm_var, _IntVarImpl):
-                        cpm_var._value = int(self.Value(self._varmap[cpm_var]))
+                        cpm_var._value = int(self.Value(self._varmap[cpm_var.name]))
                     else:
                         raise NotImplementedError(f"Unexpected variable type {type(cpm_var)}")
 

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -306,17 +306,17 @@ class CPM_pumpkin(SolverInterface):
 
         # create if it does not exist
         if isinstance(cpm_var, _NumVarImpl):
-            if cpm_var not in self._varmap:
+            if cpm_var.name not in self._varmap:
                 if isinstance(cpm_var, _BoolVarImpl):
                     revar = self.pum_solver.new_boolean_variable(name=str(cpm_var))
                 elif isinstance(cpm_var, _IntVarImpl):
                     revar = self.pum_solver.new_integer_variable(cpm_var.lb, cpm_var.ub, name=str(cpm_var))
                 else:
                     raise NotImplementedError("Not a known var {}".format(cpm_var))
-                self._varmap[cpm_var] = revar
+                self._varmap[cpm_var.name] = revar
 
             # return from cache
-            return self._varmap[cpm_var]
+            return self._varmap[cpm_var.name]
         
         raise ValueError(f"Not a known var {cpm_var}")
 

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -264,7 +264,7 @@ class CPM_pysdd(SolverInterface):
             return -self.solver_var(cpm_var._bv)
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 # make new var, add at end (what is best here??)
                 self.pysdd_manager.add_var_after_last()
@@ -272,9 +272,9 @@ class CPM_pysdd(SolverInterface):
                 revar = self.pysdd_manager.vars[n]
             else:
                 raise NotImplementedError(f"CPM_pysdd: non-Boolean variable {cpm_var} not supported")
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
     def transform(self, cpm_expr):
         """

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -156,7 +156,7 @@ class CPM_scip(SolverInterface):
             best_sol = self.scip_model.getBestSol()
             assert best_sol is not None, f"Due to status {scip_status}, we expected a solution from SCIP, but there was none. This is a bug, please report on GitHub."
             for cpm_var in self.user_vars:
-                assert cpm_var in self._varmap, f"SCIP: The user variable {cpm_var} was never added to the variable map. This is a bug, please report on GitHub."
+                assert cpm_var.name in self._varmap, f"SCIP: The user variable {cpm_var} was never added to the variable map. This is a bug, please report on GitHub."
                 scip_var = self.solver_var(cpm_var)
                 solver_val = self.scip_model.getSolVal(best_sol, scip_var)
                 if cpm_var.is_bool():
@@ -198,17 +198,17 @@ class CPM_scip(SolverInterface):
             )
 
         # create if it does not exist
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             if isinstance(cpm_var, _BoolVarImpl):
                 revar = self.scip_model.addVar(vtype='B', name=cpm_var.name)
             elif isinstance(cpm_var, _IntVarImpl):
                 revar = self.scip_model.addVar(lb=cpm_var.lb, ub=cpm_var.ub, vtype='I', name=cpm_var.name)
             else:
                 raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
         # return from cache
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -19,7 +19,7 @@
         ExitStatus
 
 """
-from typing import Optional, List, Callable, TypeAlias
+from typing import Any, Optional, List, Callable, TypeAlias
 import warnings
 import time
 from enum import Enum
@@ -77,7 +77,7 @@ class SolverInterface(object):
             - objective_value_: the value of the objective function after solving (or None)
             - user_vars: set(), variables in the original (non-transformed) model,
                            for reverse mapping the values after `solve()`
-            - _varmap: dict(), maps cpmpy variables to native solver variables
+            - _varmap: dict[str, Any], maps cpmpy variable names to native solver variables
         """
         assert(subsolver is None)
 
@@ -87,7 +87,7 @@ class SolverInterface(object):
 
         # initialise variable handling
         self.user_vars = set()  # variables in the original (non-transformed) model
-        self._varmap = dict()  # maps cpmpy variables to native solver variables
+        self._varmap: dict[str, Any] = {}  # maps cpmpy variable names to native solver variables
         self._csemap = CSEMap()  # maps cpmpy expressions to previously created expressions (typically auxiliary variables)
 
         # rest uses own API

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -283,7 +283,7 @@ class CPM_z3(SolverInterface):
             return z3.Not(self.solver_var(cpm_var._bv))
 
         # create if it does not exit
-        if cpm_var not in self._varmap:
+        if cpm_var.name not in self._varmap:
             # we assume al variables are user variables (because nested expressions)
             self.user_vars.add(cpm_var)
             if isinstance(cpm_var, _BoolVarImpl):
@@ -295,9 +295,9 @@ class CPM_z3(SolverInterface):
                 self.z3_solver.add(revar <= cpm_var.ub)
             else:
                 raise NotImplementedError("Not a know var {}".format(cpm_var))
-            self._varmap[cpm_var] = revar
+            self._varmap[cpm_var.name] = revar
 
-        return self._varmap[cpm_var]
+        return self._varmap[cpm_var.name]
 
 
     def has_objective(self):

--- a/examples/advanced/ortools_presolve_propagate.py
+++ b/examples/advanced/ortools_presolve_propagate.py
@@ -21,7 +21,8 @@ s.solve(stop_after_presolve=True, fill_tightened_domains_in_response=True)
 
 # Get bounds from response proto send to the native solver object
 bounds = s.ort_solver.ResponseProto().tightened_variables
-for cpm_var, ort_var in s._varmap.items():
+for cpm_var in s.user_vars:
+    ort_var = s.solver_var(cpm_var)
     # Get bounds for variable
     bound = bounds[ort_var.Index()]
     """

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -181,7 +181,7 @@ class TestSolvers:
             def on_solution_callback(self):
                 # populate values before printing
                 for cpm_var in self.x:
-                    cpm_var._value = self.Value(self.varmap[cpm_var])
+                    cpm_var._value = self.Value(self.varmap[cpm_var.name])
         
                 self.solcount += 1
                 print("x:",self.x.value())


### PR DESCRIPTION
Store the name of variables in the varmap instead of the _NumVarImpl object.

This speeds up looking up the variable in the dict in solver_vars.

The only downside is that there is now no way of iterating over ALL CPMpy vars ever posted to the solver, only the user vars. (using the user_vars set)
