### PR TITLE
use order encoding for inequalities

### DIFF
--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -55,10 +55,12 @@ class CSEMap:
                                                       dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]]:
         """Collect bv <-> var == val and bv <-> var >= val expressions in flat_map."""
 
+        comps = frozenset({"==", ">="})
+
         var_vals = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var == val: var -> [(val, bv)]
         var_bounds = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var >= val: var -> [(val, bv)]
         for expr, bv in self.flat_map.items():
-            if expr.name in {"==", ">="}:
+            if expr.name in comps:
                 var, val = expr.args
                 if isinstance(var, _IntVarImpl) and is_int(val):
                     target = var_vals if expr.name == "==" else var_bounds

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -63,6 +63,18 @@ class CSEMap:
 
         return var_vals
 
+    def get_reified_varbounds(self) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
+        """collect all bv <-> var >= val expressions in flat_map"""
+
+        var_bounds = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var: [val, bv]
+        for expr, bv in self.flat_map.items():
+            if expr.name == ">=":
+                var, val = expr.args
+                if isinstance(var, _IntVarImpl) and is_int(val):
+                    var_bounds.setdefault(var, []).append((val, bv))
+
+        return var_bounds
+
     def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, Optional[Expression]]:
         """
         Make an auxiliary variable for the given expression
@@ -108,5 +120,5 @@ class CSEMap:
                 new_expr = Comparison("==", lhs, rhs)
                 new_expr._has_subexpr = expr._has_subexpr
                 return new_expr, True
-            
+
         return expr, False

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -51,29 +51,17 @@ class CSEMap:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr, default)
 
-    def get_reified_varvals(self) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
-        """collect all bv <-> var == val expressions in flat_map"""
+    def get_reified_comparisons(self, cmp) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
+        """collect all bv <-> var cmp val expressions in flat_map, where cmp can be `==` or `>=`"""
         
         var_vals = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var: [val, bv]
         for expr, bv in self.flat_map.items():
-            if expr.name == "==":
+            if expr.name == cmp:
                 var, val = expr.args
                 if isinstance(var, _IntVarImpl) and is_int(val):
                     var_vals.setdefault(var, []).append((val, bv))
 
         return var_vals
-
-    def get_reified_varbounds(self) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
-        """collect all bv <-> var >= val expressions in flat_map"""
-
-        var_bounds = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var: [val, bv]
-        for expr, bv in self.flat_map.items():
-            if expr.name == ">=":
-                var, val = expr.args
-                if isinstance(var, _IntVarImpl) and is_int(val):
-                    var_bounds.setdefault(var, []).append((val, bv))
-
-        return var_bounds
 
     def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, Optional[Expression]]:
         """

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -51,17 +51,20 @@ class CSEMap:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr, default)
 
-    def get_reified_varval_comparisons(self, cmp) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
-        """collect all bv <-> var cmp val expressions in flat_map, where cmp can be `==` or `>=`"""
-        
-        var_vals = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var: [val, bv]
+    def get_reified_varval_comparisons(self) -> tuple[dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]],
+                                                      dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]]:
+        """Collect bv <-> var == val and bv <-> var >= val expressions in flat_map."""
+
+        var_vals = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var == val: var -> [(val, bv)]
+        var_bounds = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var >= val: var -> [(val, bv)]
         for expr, bv in self.flat_map.items():
-            if expr.name == cmp:
+            if expr.name in {"==", ">="}:
                 var, val = expr.args
                 if isinstance(var, _IntVarImpl) and is_int(val):
-                    var_vals.setdefault(var, []).append((val, bv))
+                    target = var_vals if expr.name == "==" else var_bounds
+                    target.setdefault(var, []).append((val, bv))
 
-        return var_vals
+        return var_vals, var_bounds
 
     def get_or_make_var(self, expr: Expression) -> tuple[_IntVarImpl, Optional[Expression]]:
         """

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -52,7 +52,7 @@ class CSEMap:
         return self.decomp_map.get(expr, default)
 
     def get_reified_varvalbounds(self) -> tuple[dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]],
-                                                      dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]]:
+                                                dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]]:
         """Collect bv <-> var == val and bv <-> var >= val expressions in flat_map."""
 
         comps = frozenset({"==", ">="})

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -51,7 +51,7 @@ class CSEMap:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr, default)
 
-    def get_reified_comparisons(self, cmp) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
+    def get_reified_varval_comparisons(self, cmp) -> dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]:
         """collect all bv <-> var cmp val expressions in flat_map, where cmp can be `==` or `>=`"""
         
         var_vals = dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]()  # var: [val, bv]

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -51,7 +51,7 @@ class CSEMap:
         """Get the decomposition of the given global constraint or global function."""
         return self.decomp_map.get(expr, default)
 
-    def get_reified_varval_comparisons(self) -> tuple[dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]],
+    def get_reified_varvalbounds(self) -> tuple[dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]],
                                                       dict[_IntVarImpl, list[tuple[int, _BoolVarImpl]]]]:
         """Collect bv <-> var == val and bv <-> var >= val expressions in flat_map."""
 

--- a/cpmpy/transformations/int2bool.py
+++ b/cpmpy/transformations/int2bool.py
@@ -236,13 +236,6 @@ class IntVarEnc(ABC):
                 k += weight
         return k
 
-    def encode_value_constraint(self):
-        """Return constraint linking the original integer variable to its Boolean encoding."""
-        terms, k = self.encode_term()
-        weights = [1] + [-w for (w, _) in terms]
-        variables = [self._x] + [b for (_, b) in terms]
-        return Operator("wsum", (weights, variables)) == k
-
     @abstractmethod
     def encode_domain_constraint(self):
         """

--- a/cpmpy/transformations/int2bool.py
+++ b/cpmpy/transformations/int2bool.py
@@ -236,6 +236,13 @@ class IntVarEnc(ABC):
                 k += weight
         return k
 
+    def encode_value_constraint(self):
+        """Return constraint linking the original integer variable to its Boolean encoding."""
+        terms, k = self.encode_term()
+        weights = [1] + [-w for (w, _) in terms]
+        variables = [self._x] + [b for (_, b) in terms]
+        return Operator("wsum", (weights, variables)) == k
+
     @abstractmethod
     def encode_domain_constraint(self):
         """

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -80,7 +80,7 @@ from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, 
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
-from .int2bool import IntVarEncDirect, IntVarEncOrder, _encode_int_var
+from .int2bool import IntVarEncDirect, IntVarEncOrder, _encode_int_var, _encode_lin_expr
 
 
 
@@ -666,10 +666,14 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
             if len(vals) < min_values:
                 continue  # do not encode
 
-            enc, domain_constraint = _encode_int_var(my_ivarmap, var, encoding, csemap=csemap)
+            _, domain_constraint = _encode_int_var(my_ivarmap, var, encoding, csemap=csemap)
             toplevel.extend(domain_constraint)
             if ivarmap is None:
-                toplevel.append(enc.encode_value_constraint())
+                terms, extra_domain_constraints, k = _encode_lin_expr(my_ivarmap, [var], [1], encoding, csemap=csemap)
+                assert extra_domain_constraints == []
+                weights = [1] + [-w for (w, _) in terms]
+                variables = [var] + [b for (_, b) in terms]
+                toplevel.append(Operator("wsum", (weights, variables)) == k)
 
             for val, bv in vals:
                 bv_map[bv] = (var, val)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -63,6 +63,7 @@ Optional post-linearisation transformations:
   in linear constraints.
 """
 
+from collections import defaultdict
 import copy
 from typing import AbstractSet, Sequence, Optional
 
@@ -629,17 +630,20 @@ def get_linear_decompositions():
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 
 
-def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None):
+def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMap]=None, ivarmap=None):
     """
     Replace reified (BV <-> (x == val)) implications with direct encoding and
     reified (BV <-> (x >= val)) implications with order encoding when a variable
     has at least min_values such reifications: remove those implications and add
     the corresponding encoding of x.
 
-    If ivarmap is None, both sum(bvs)==1 and wsum(values, bvs)==var are posted.
-    If ivarmap is not None, the encoding is added to ivarmap and only sum(bvs)==1
-    (the domain constraint) is posted; the solver can then choose to eliminate the
-    vars, or post the wsums itself anyway.
+    If ivarmap is None, both sum(bvs)==1 and channeling constraints are posted.
+    If ivarmap is not None, the encoding is added to ivarmap and only (the domain constraint) is posted; 
+    the solver can then choose to eliminate the variables, or post the channeling constraints itself anyway.
+
+    If both BV <-> (x == val) and BV <-> (x >= val) are present, we prefer the direct encoding;
+    reified (x >= val) constraints are left untouched in that case. 
+    (TODO re-use direct encoding vars to replace comparison?)
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
     """
@@ -649,57 +653,73 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     if csemap is None:
         return constraints
 
-    var_vals = csemap.get_reified_comparisons("==")
-    var_bounds = csemap.get_reified_comparisons(">=")
-    
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
-    toplevel = []
+
+    var_vals = csemap.get_reified_varval_comparisons("==")
+    var_bounds = csemap.get_reified_varval_comparisons(">=")
+
+    # decide the encoding to use for each variable
+    var_encodings = dict() # var -> (encoding, vals)
+    for var, vals in var_vals.items():
+        lb, ub = var.lb, var.ub
+        vals = [(val, bv) for val, bv in vals if lb <= val <= ub]  # only the valid values, in bounds!
+        if len(vals) >= min_values and var.name not in my_ivarmap:
+            var_encodings[var] = ("direct", vals)
     
-    def encode_reified_comparisons(var_comparisons, encoding, valid_value, existing_encoding=None):
-        bv_map = {}  # bv -> (var, val)
-        for var, vals in var_comparisons.items():
-            if (existing_encoding is not None and var.name in my_ivarmap
-                    and not isinstance(my_ivarmap[var.name], existing_encoding)):
-                continue  # another encoding already represents this variable
+    for var, vals in var_bounds.items():
+        lb, ub = var.lb, var.ub
+        vals = [(val, bv) for val, bv in vals if lb < val <= ub]  # only the valid values, exclude lb
+        if len(vals) >= min_values and var not in var_encodings and var.name not in my_ivarmap:
+            var_encodings[var] = ("order", vals) # no encoding exists for this variable yet, use order encoding
+    
+    
+    toplevel = []
 
-            vals = [(val, bv) for val, bv in vals if valid_value(var, val)]
-            if len(vals) < min_values:
-                continue  # do not encode
+    bv_map = {}  # (bv, encoding) -> (var, val)
 
-            _, domain_constraint = _encode_int_var(my_ivarmap, var, encoding, csemap=csemap)
-            toplevel.extend(domain_constraint)
-            if ivarmap is None:
-                terms, extra_domain_constraints, k = _encode_lin_expr(my_ivarmap, [var], [1], encoding, csemap=csemap)
-                assert extra_domain_constraints == []
-                weights = [1] + [-w for (w, _) in terms]
-                variables = [var] + [b for (_, b) in terms]
-                toplevel.append(Operator("wsum", (weights, variables)) == k)
+    for var, (encoding, vals) in var_encodings.items():
+        
+        # encode the values
+        enc, domain_constraint = _encode_int_var(my_ivarmap, var, encoding, csemap=csemap)
+        
+        # domain and channeling constraints
+        toplevel.extend(domain_constraint) # with the overwritten Bools
+        if ivarmap is None:
+            # also post the var=wsum mapping
+            terms, k = enc.encode_term()
+            # var == wsum + k :: var - wsum == k
+            ws = [1] + [-w for (w, _) in terms]
+            bs = [var] + [b for (_, b) in terms]
+            toplevel.append(Operator("wsum", (ws, bs)) == k)  
+        
+        # store the bvs that no longer need to be reified
+        for val, bv in vals:
+            bv_map[(bv, encoding)] = (var, val)
 
-            for val, bv in vals:
-                bv_map[bv] = (var, val)
-        return bv_map
-
-    bv_maps = {
-        "==": encode_reified_comparisons(var_vals, "direct", lambda var, val: var.lb <= val <= var.ub, IntVarEncDirect),
-        ">=": encode_reified_comparisons(var_bounds, "order", lambda var, val: var.lb < val <= var.ub, IntVarEncOrder),
-    }
-
-    if any(len(bv_map) > 0 for bv_map in bv_maps.values()):
-        # Now clean up and remove the '(var == val) == bv' and '(var >= val) == bv' constraints:
+    if len(bv_map) > 0:
+        # Now clean up and remove the '(var == val) == bv' constraints:
         newcons = []
         for con in constraints:
-            if con.name == '==' and con.args[0].name in bv_maps:
-                # potential '(var == val) == bv' or '(var >= val) == bv'
-                lhs, bv = con.args
-                bv_map = bv_maps[lhs.name]
-                if bv in bv_map:
-                    var, val = bv_map[bv]
+            if con.name == '==': # its a reification
+                if con.args[0].name == '==' and (bv, "direct") in bv_map:
+                    # potential '(var == val) == bv'
+                    lhs, bv = con.args
+                    var, val = bv_map[(bv, "direct")]
                     (lhs_var, lhs_val) = lhs.args
-                    if lhs_val == val and lhs_var == var:
+                    if encoding == "direct" and lhs_val == val and lhs_var == var:
+                        continue  # do not keep
+                
+                if con.args[0].name == '>=' and (bv, "order") in bv_map:
+                    # potential '(var >= val) == bv'
+                    lhs, bv = con.args
+                    var, val = bv_map[(bv, "order")]
+                    (lhs_var, lhs_val) = lhs.args
+                    if encoding == "order" and lhs_val == val and lhs_var == var:
                         continue  # do not keep
             newcons.append(con)
-        constraints = newcons
+        
+        return newcons + toplevel
 
     return constraints + toplevel
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -709,14 +709,14 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
                     # potential '(var == val) == bv'
                     var, val = bv_map[(bv, "direct")]
                     (lhs_var, lhs_val) = lhs.args
-                    if encoding == "direct" and lhs_val == val and lhs_var == var:
+                    if lhs_val == val and lhs_var == var:
                         continue  # do not keep
                 
                 if con.args[0].name == '>=' and (bv, "order") in bv_map:
                     # potential '(var >= val) == bv'
                     var, val = bv_map[(bv, "order")]
                     (lhs_var, lhs_val) = lhs.args
-                    if encoding == "order" and lhs_val == val and lhs_var == var:
+                    if lhs_val == val and lhs_var == var:
                         continue  # do not keep
             newcons.append(con)
         

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -80,7 +80,7 @@ from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, 
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
-from .int2bool import _encode_int_var
+from .int2bool import IntVarEnc, _encode_int_var
 
 
 
@@ -629,7 +629,10 @@ def get_linear_decompositions():
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 
 
-def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMap]=None, ivarmap=None):
+def linearize_reified_variables(constraints:list[Expression], 
+                                min_values:int=3, 
+                                csemap:Optional[CSEMap]=None, 
+                                ivarmap:Optional[dict[str, IntVarEnc]] = None) -> list[Expression]:
     """
     Replace reified (BV <-> (x == val)) implications with direct encoding and
     reified (BV <-> (x >= val)) implications with order encoding when a variable
@@ -678,9 +681,8 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
             var_encodings[var] = (encoding, vals)
     
     
-    toplevel = []
-
     bv_map = {}  # (bv, encoding) -> (var, val)
+    toplevel = []
 
     for var, (encoding, vals) in var_encodings.items():
         
@@ -723,8 +725,9 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
             newcons.append(con)
         
         return newcons + toplevel
-
-    return constraints + toplevel
+    
+    assert len(toplevel) == 0, "cannot have toplevel constraints if len(bv_map) == 0"
+    return constraints
 
 
 def _extract_var_from_lhs(lhs):

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -655,8 +655,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
 
-    var_vals = csemap.get_reified_varval_comparisons("==")
-    var_bounds = csemap.get_reified_varval_comparisons(">=")
+    var_vals, var_bounds = csemap.get_reified_varval_comparisons()
 
     # decide the encoding to use for each variable
     var_encodings = dict() # var -> (encoding, vals)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -640,8 +640,9 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
     If ivarmap is not None, the encoding is added to ivarmap and only (the domain constraint) is posted; 
     the solver can then choose to eliminate the variables, or post the channeling constraints itself anyway.
 
-    If both BV <-> (x == val) and BV <-> (x >= val) are present, we prefer the direct encoding;
-    reified (x >= val) constraints are left untouched in that case. 
+    If both BV <-> (x == val) and BV <-> (x >= val) are present, choose the
+    encoding type that occurs most often for that variable. Ties prefer the
+    direct encoding.
     (TODO re-use direct encoding vars to replace comparison?)
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
@@ -659,21 +660,22 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
 
     # decide the encoding to use for each variable
     var_encodings = dict() # var -> (encoding, vals)
-    for var, vals in var_vals.items():
+    candidate_vars = list(var_vals) + [var for var in var_bounds if var not in var_vals]
+    for var in candidate_vars:
         lb, ub = var.lb, var.ub
         if var.name in my_ivarmap:
             continue
-        vals = [(val, bv) for val, bv in vals if lb <= val <= ub]  # only the valid values, in bounds!
+
+        direct_vals = [(val, bv) for val, bv in var_vals.get(var, []) if lb <= val <= ub]  # only the valid values, in bounds!
+        order_vals = [(val, bv) for val, bv in var_bounds.get(var, []) if lb < val <= ub]  # only the valid values, exclude lb
+
+        if len(direct_vals) >= len(order_vals):
+            encoding, vals = "direct", direct_vals
+        else:
+            encoding, vals = "order", order_vals
+
         if len(vals) >= min_values:
-            var_encodings[var] = ("direct", vals)
-    
-    for var, vals in var_bounds.items():
-        lb, ub = var.lb, var.ub
-        if var.name in my_ivarmap or var in var_encodings:
-            continue
-        vals = [(val, bv) for val, bv in vals if lb < val <= ub]  # only the valid values, exclude lb
-        if len(vals) >= min_values:
-            var_encodings[var] = ("order", vals) # no encoding exists for this variable yet, use order encoding
+            var_encodings[var] = (encoding, vals)
     
     
     toplevel = []

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -642,75 +642,54 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
     """
+    assert min_values > 0
+    
     # this transformation can only be done if there is a csemap
     if csemap is None:
         return constraints
 
-    var_vals = csemap.get_reified_varvals()
-    var_bounds = csemap.get_reified_varbounds()
+    var_vals = csemap.get_reified_comparisons("==")
+    var_bounds = csemap.get_reified_comparisons(">=")
     
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
     toplevel = []
-    bv_map = {}  # bv -> (var, val)
-    for var, vals in var_vals.items():
-        # check if we should linearize the reified variables
-        lb, ub = var.lb, var.ub
-        vals = [(val, bv) for val, bv in vals if lb <= val <= ub]  # only the valid values, in bounds!
-        if len(vals) < min_values:
-            continue  # do not encode
+    
+    def encode_reified_comparisons(var_comparisons, encoding, valid_value, existing_encoding=None):
+        bv_map = {}  # bv -> (var, val)
+        for var, vals in var_comparisons.items():
+            if (existing_encoding is not None and var.name in my_ivarmap
+                    and not isinstance(my_ivarmap[var.name], existing_encoding)):
+                continue  # another encoding already represents this variable
 
-        # encode the values
-        enc, domain_constraint = _encode_int_var(my_ivarmap, var, "direct", csemap=csemap)
-        
-        # domain and channeling constraints
-        toplevel.extend(domain_constraint) # with the overwritten Bools
-        if ivarmap is None:
-            # also post the var=wsum mapping
-            terms, k = enc.encode_term()
-            # var == wsum + k :: var - wsum == k
-            ws = [1] + [-w for (w, _) in terms]
-            bs = [var] + [b for (_, b) in terms]
-            toplevel.append(Operator("wsum", (ws, bs)) == k)  
-        
-        # store the bvs that no longer need to be reified
-        for val, bv in vals:
-            bv_map[bv] = (var, val)
+            vals = [(val, bv) for val, bv in vals if valid_value(var, val)]
+            if len(vals) < min_values:
+                continue  # do not encode
 
-    bound_bv_map = {}  # bv -> (var, val)
-    for var, vals in var_bounds.items():
-        if var.name in my_ivarmap and not isinstance(my_ivarmap[var.name], IntVarEncOrder):
-            continue  # another encoding already represents this variable
+            enc, domain_constraint = _encode_int_var(my_ivarmap, var, encoding, csemap=csemap)
+            toplevel.extend(domain_constraint)
+            if ivarmap is None:
+                toplevel.append(enc.encode_value_constraint())
 
-        if len(vals) < min_values:
-            continue  # do not encode
+            for val, bv in vals:
+                bv_map[bv] = (var, val)
+        return bv_map
 
-        lb, ub = var.lb, var.ub
-        # order encoding has one Boolean per non-trivial lower bound threshold
-        vals = [(val, bv) for val, bv in vals if lb < val <= ub]
-        if len(vals) == 0:
-            continue  # do not encode
+    bv_maps = {
+        "==": encode_reified_comparisons(var_vals, "direct", lambda var, val: var.lb <= val <= var.ub),
+        ">=": encode_reified_comparisons(var_bounds, "order", lambda var, val: var.lb < val <= var.ub, IntVarEncOrder),
+    }
 
-        _, domain_constraint = _encode_int_var(my_ivarmap, var, "order", csemap=csemap)
-        toplevel.extend(domain_constraint)
-
-        for val, bv in vals:
-            bound_bv_map[bv] = (var, val)
-
-    if len(bv_map) > 0 or len(bound_bv_map) > 0:
+    if any(len(bv_map) > 0 for bv_map in bv_maps.values()):
         # Now clean up and remove the '(var == val) == bv' and '(var >= val) == bv' constraints:
         newcons = []
         for con in constraints:
-            if con.name == '==' and con.args[0].name in {'==', '>='}:
+            if con.name == '==' and con.args[0].name in bv_maps:
                 # potential '(var == val) == bv' or '(var >= val) == bv'
-                lhs,bv = con.args
-                if lhs.name == '==' and bv in bv_map:
-                    (var, val) = bv_map[bv]
-                    (lhs_var, lhs_val) = lhs.args
-                    if lhs_val == val and lhs_var == var:
-                        continue  # do not keep
-                elif lhs.name == '>=' and bv in bound_bv_map:
-                    (var, val) = bound_bv_map[bv]
+                lhs, bv = con.args
+                bv_map = bv_maps[lhs.name]
+                if bv in bv_map:
+                    var, val = bv_map[bv]
                     (lhs_var, lhs_val) = lhs.args
                     if lhs_val == val and lhs_var == var:
                         continue  # do not keep

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -655,7 +655,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
 
-    var_vals, var_bounds = csemap.get_reified_varval_comparisons()
+    var_vals, var_bounds = csemap.get_reified_varvalbounds()
 
     # decide the encoding to use for each variable
     var_encodings = dict() # var -> (encoding, vals)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -669,10 +669,10 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
     
     for var, vals in var_bounds.items():
         lb, ub = var.lb, var.ub
-        if var.name in my_ivarmap:
+        if var.name in my_ivarmap or var in var_encodings:
             continue
         vals = [(val, bv) for val, bv in vals if lb < val <= ub]  # only the valid values, exclude lb
-        if len(vals) >= min_values and var not in var_encodings:
+        if len(vals) >= min_values:
             var_encodings[var] = ("order", vals) # no encoding exists for this variable yet, use order encoding
     
     

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -661,14 +661,18 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
     var_encodings = dict() # var -> (encoding, vals)
     for var, vals in var_vals.items():
         lb, ub = var.lb, var.ub
+        if var.name in my_ivarmap:
+            continue
         vals = [(val, bv) for val, bv in vals if lb <= val <= ub]  # only the valid values, in bounds!
-        if len(vals) >= min_values and var.name not in my_ivarmap:
+        if len(vals) >= min_values:
             var_encodings[var] = ("direct", vals)
     
     for var, vals in var_bounds.items():
         lb, ub = var.lb, var.ub
+        if var.name in my_ivarmap:
+            continue
         vals = [(val, bv) for val, bv in vals if lb < val <= ub]  # only the valid values, exclude lb
-        if len(vals) >= min_values and var not in var_encodings and var.name not in my_ivarmap:
+        if len(vals) >= min_values and var not in var_encodings:
             var_encodings[var] = ("order", vals) # no encoding exists for this variable yet, use order encoding
     
     

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -639,14 +639,14 @@ def linearize_reified_variables(constraints:list[Expression],
     has at least min_values such reifications: remove those implications and add
     the corresponding encoding of x.
 
-    If ivarmap is None, both sum(bvs)==1 and channeling constraints are posted.
+    If ivarmap is None, both consistency constraints and channeling constraints are posted.
     If ivarmap is not None, the encoding is added to ivarmap and only (the domain constraint) is posted; 
     the solver can then choose to eliminate the variables, or post the channeling constraints itself anyway.
 
     If both BV <-> (x == val) and BV <-> (x >= val) are present, choose the
     encoding type that occurs most often for that variable. Ties prefer the
     direct encoding.
-    (TODO re-use direct encoding vars to replace comparison?)
+    (TODO: add both encodings and channel between them?)
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
     """

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -80,7 +80,7 @@ from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, 
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
-from .int2bool import _encode_int_var
+from .int2bool import IntVarEncOrder, _encode_int_var
 
 
 
@@ -630,9 +630,10 @@ def get_linear_decompositions():
 
 def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None):
     """
-    Replace reified (BV <-> (x == val)) implications with direct encoding when a variable
+    Replace reified (BV <-> (x == val)) implications with direct encoding and
+    reified (BV <-> (x >= val)) implications with order encoding when a variable
     has at least min_values such reifications: remove those implications and add
-    the 'direct' encoding of x.
+    the corresponding encoding of x.
 
     If ivarmap is None, both sum(bvs)==1 and wsum(values, bvs)==var are posted.
     If ivarmap is not None, the encoding is added to ivarmap and only sum(bvs)==1
@@ -646,6 +647,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         return constraints
 
     var_vals = csemap.get_reified_varvals()
+    var_bounds = csemap.get_reified_varbounds()
     
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
@@ -675,15 +677,40 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         for val, bv in vals:
             bv_map[bv] = (var, val)
 
-    if len(bv_map) > 0:
-        # Now clean up and remove the '(var == val) == bv' constraints:
+    bound_bv_map = {}  # bv -> (var, val)
+    for var, vals in var_bounds.items():
+        if var.name in my_ivarmap and not isinstance(my_ivarmap[var.name], IntVarEncOrder):
+            continue  # another encoding already represents this variable
+
+        if len(vals) < min_values:
+            continue  # do not encode
+
+        lb, ub = var.lb, var.ub
+        # order encoding has one Boolean per non-trivial lower bound threshold
+        vals = [(val, bv) for val, bv in vals if lb < val <= ub]
+        if len(vals) == 0:
+            continue  # do not encode
+
+        _, domain_constraint = _encode_int_var(my_ivarmap, var, "order", csemap=csemap)
+        toplevel.extend(domain_constraint)
+
+        for val, bv in vals:
+            bound_bv_map[bv] = (var, val)
+
+    if len(bv_map) > 0 or len(bound_bv_map) > 0:
+        # Now clean up and remove the '(var == val) == bv' and '(var >= val) == bv' constraints:
         newcons = []
         for con in constraints:
-            if con.name == '==' and con.args[0].name == '==':
-                # potential '(var == val) == bv'
+            if con.name == '==' and con.args[0].name in {'==', '>='}:
+                # potential '(var == val) == bv' or '(var >= val) == bv'
                 lhs,bv = con.args
-                if bv in bv_map:
+                if lhs.name == '==' and bv in bv_map:
                     (var, val) = bv_map[bv]
+                    (lhs_var, lhs_val) = lhs.args
+                    if lhs_val == val and lhs_var == var:
+                        continue  # do not keep
+                elif lhs.name == '>=' and bv in bound_bv_map:
+                    (var, val) = bound_bv_map[bv]
                     (lhs_var, lhs_val) = lhs.args
                     if lhs_val == val and lhs_var == var:
                         continue  # do not keep

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -63,7 +63,6 @@ Optional post-linearisation transformations:
   in linear constraints.
 """
 
-from collections import defaultdict
 import copy
 from typing import AbstractSet, Sequence, Optional
 
@@ -81,7 +80,7 @@ from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, 
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
-from .int2bool import IntVarEncDirect, IntVarEncOrder, _encode_int_var, _encode_lin_expr
+from .int2bool import _encode_int_var
 
 
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -702,9 +702,9 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
         newcons = []
         for con in constraints:
             if con.name == '==': # its a reification
+                lhs, bv = con.args
                 if con.args[0].name == '==' and (bv, "direct") in bv_map:
                     # potential '(var == val) == bv'
-                    lhs, bv = con.args
                     var, val = bv_map[(bv, "direct")]
                     (lhs_var, lhs_val) = lhs.args
                     if encoding == "direct" and lhs_val == val and lhs_var == var:
@@ -712,7 +712,6 @@ def linearize_reified_variables(constraints, min_values=3, csemap:Optional[CSEMa
                 
                 if con.args[0].name == '>=' and (bv, "order") in bv_map:
                     # potential '(var >= val) == bv'
-                    lhs, bv = con.args
                     var, val = bv_map[(bv, "order")]
                     (lhs_var, lhs_val) = lhs.args
                     if encoding == "order" and lhs_val == val and lhs_var == var:

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -80,7 +80,7 @@ from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, 
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
-from .int2bool import IntVarEncOrder, _encode_int_var
+from .int2bool import IntVarEncDirect, IntVarEncOrder, _encode_int_var
 
 
 
@@ -676,7 +676,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         return bv_map
 
     bv_maps = {
-        "==": encode_reified_comparisons(var_vals, "direct", lambda var, val: var.lb <= val <= var.ub),
+        "==": encode_reified_comparisons(var_vals, "direct", lambda var, val: var.lb <= val <= var.ub, IntVarEncDirect),
         ">=": encode_reified_comparisons(var_bounds, "order", lambda var, val: var.lb < val <= var.ub, IntVarEncOrder),
     }
 

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -648,15 +648,15 @@ class TestLinearizeReifiedVariablesThreshold:
         out = linearize_reified_variables(self.linearize((a != 1) | (a != 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == "[(~BV[a == 1]) or (~BV[a == 2]), sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1]"
 
+    def test_linearize_reified_inequalities(self):
+        """Use order encoding on inequalities and replace `a>=k` expressions"""
+        a = self.a
+        self.csemap = CSEMap()
+        out = linearize_reified_variables(self.linearize((a >= 2) | (a >= 3)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
     
     # The following tests are marked with `xfail` because they are expected to fail, because they are not yet implemented; to see the current output compared with the desired output in the test, run with `pytest --runxfail`
     
-    @pytest.mark.xfail(reason="aspirational")
-    def test_linearize_reified_inequalities(self):
-        """Use order encoding on inequalities and replace `a>=1` expressions"""
-        a = self.a
-        out = linearize_reified_variables(self.linearize((a >= 1) | (a >= 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
-        assert str(out) == "[(BV[a >= 1]) or (BV[a >= 2]), sum([1, -1] * (BV[a >= 2], BV[a >= 1])) <= 0, sum([1, -1] * (BV[a >= 3], BV[a >= 2])) <= 0]"
 
     @pytest.mark.xfail(reason="aspirational")
     def test_linearize_reified_inequalities_variations(self):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -660,8 +660,8 @@ class TestLinearizeReifiedVariablesThreshold:
         """Canonicalize expression where the const is on the lhs"""
         a = self.a
         self.csemap = CSEMap()
-        out = linearize_reified_variables(self.linearize((1 <= a) | (2 >= a)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
-        assert str(out) == "[(BV2) or (~BV3), (a >= 1) == (BV2), (a >= 3) == (BV3)]"
+        out = linearize_reified_variables(self.linearize((2 <= a) | (1 >= a) | (3 <= a)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == "[or(BV[a >= 2], ~BV[a >= 2], BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
         
     def test_linearize_reified_inequalities_no_ivarmap(self):
         """Use order encoding on inequalities and post the channel when keeping the int var."""

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -7,6 +7,7 @@ from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective
 from cpmpy.transformations.linearize import linearize_constraint, linearize_reified_variables, decompose_linear, canonical_comparison, only_positive_bv, only_positive_coefficients, only_positive_bv_wsum_const, only_positive_bv_wsum
 from cpmpy.transformations.decompose_global import decompose_in_tree
+from cpmpy.transformations.int2bool import IntVarEncDirect, IntVarEncOrder
 from cpmpy.transformations.normalize import toplevel_list
 from cpmpy.transformations.reification import only_bv_reifies, only_implies
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
@@ -654,6 +655,63 @@ class TestLinearizeReifiedVariablesThreshold:
         self.csemap = CSEMap()
         out = linearize_reified_variables(self.linearize((a >= 2) | (a >= 3)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
+
+    def test_linearize_reified_inequalities_no_ivarmap(self):
+        """Use order encoding on inequalities and post the channel when keeping the int var."""
+        a = self.a
+        self.csemap = CSEMap()
+        out = linearize_reified_variables(self.linearize((a >= 2) | (a >= 3)), min_values=2, csemap=self.csemap)
+        assert str(out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2]), sum([1, -1, -1] * [a, BV[a >= 2], BV[a >= 3]]) == 1]"
+
+    def test_linearize_reified_inequalities_ignores_low_out_of_domain_threshold(self):
+        """Out-of-domain order thresholds should not count towards min_values."""
+        a = self.a
+        self.csemap = CSEMap()
+        cpm_cons = self.linearize((a >= 0) | (a >= 2))
+        out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == str(cpm_cons)
+
+    def test_linearize_reified_inequalities_ignores_high_out_of_domain_threshold(self):
+        """Out-of-domain order thresholds should not count towards min_values."""
+        a = self.a
+        self.csemap = CSEMap()
+        cpm_cons = self.linearize((a >= 10) | (a >= 2))
+        out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == str(cpm_cons)
+
+    def test_linearize_reified_upper_bounds_out_of_domain(self):
+        """Out-of-domain upper-bound reifications are left untouched by this pass."""
+        a = self.a
+        self.csemap = CSEMap()
+        cpm_cons = self.linearize((a <= 10) | (a <= -2))
+        out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == str(cpm_cons)
+
+    def test_linearize_reified_same_var_direct_then_order(self):
+        """An existing direct encoding keeps later order reifications explicit."""
+        a = self.a
+        self.csemap = CSEMap()
+
+        direct_out = linearize_reified_variables(self.linearize((a == 1) | (a == 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        cpm_cons = self.linearize((a >= 2) | (a >= 3))
+        order_out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+
+        assert isinstance(self.ivarmap["a"], IntVarEncDirect)
+        assert str(direct_out) == "[(BV[a == 1]) or (BV[a == 2]), sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1]"
+        assert str(order_out) == str(cpm_cons)
+
+    def test_linearize_reified_same_var_order_then_direct(self):
+        """An existing order encoding keeps later direct reifications explicit."""
+        a = self.a
+        self.csemap = CSEMap()
+
+        order_out = linearize_reified_variables(self.linearize((a >= 2) | (a >= 3)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        cpm_cons = self.linearize((a == 1) | (a == 2))
+        direct_out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+
+        assert isinstance(self.ivarmap["a"], IntVarEncOrder)
+        assert str(order_out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
+        assert str(direct_out) == str(cpm_cons)
     
     # The following tests are marked with `xfail` because they are expected to fail, because they are not yet implemented; to see the current output compared with the desired output in the test, run with `pytest --runxfail`
     
@@ -664,6 +722,14 @@ class TestLinearizeReifiedVariablesThreshold:
         a = self.a
         out = linearize_reified_variables(self.linearize((a < 1) | (a <= 2) | (a > 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == "[(~BV[a >= 1]) or (~BV[a >= 3]) or (BV[a >= 3]), sum([1, -1] * (BV[a >= 2], BV[a >= 1])) <= 0, sum([1, -1] * (BV[a >= 3], BV[a >= 2])) <= 0]"
+
+    @pytest.mark.xfail(reason="aspirational")
+    def test_linearize_reified_reversed_inequality(self):
+        """Use order encoding for reversed inequalities such as `1 >= a`."""
+        a = self.a
+        self.csemap = CSEMap()
+        out = linearize_reified_variables(self.linearize((1 >= a) | (a >= 3)), min_values=1, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == "[(~BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
 
     @pytest.mark.xfail(reason="aspirational")
     def test_linearize_non_ocurring_int_var(self):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -655,7 +655,14 @@ class TestLinearizeReifiedVariablesThreshold:
         self.csemap = CSEMap()
         out = linearize_reified_variables(self.linearize((a >= 2) | (a >= 3)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
-
+        
+    def test_linearize_reified_inequality_misordered(self):
+        """Canonicalize expression where the const is on the lhs"""
+        a = self.a
+        self.csemap = CSEMap()
+        out = linearize_reified_variables(self.linearize((1 <= a) | (2 >= a)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
+        assert str(out) == "[(BV2) or (~BV3), (a >= 1) == (BV2), (a >= 3) == (BV3)]"
+        
     def test_linearize_reified_inequalities_no_ivarmap(self):
         """Use order encoding on inequalities and post the channel when keeping the int var."""
         a = self.a
@@ -727,7 +734,7 @@ class TestLinearizeReifiedVariablesThreshold:
         a = self.a
         self.csemap = CSEMap()
         out = linearize_reified_variables(self.linearize((a < 2) | (a <= 2) | (a < 3)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
-        assert str(out) == "[or(~BV2, ~BV3, ~BV3), (a >= 2) == (BV2), (a >= 3) == (BV3)]"
+        assert str(out) == "[or(~BV[a >= 2], ~BV[a >= 3], ~BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
         
     @pytest.mark.xfail(reason="aspirational")
     def test_linearize_non_ocurring_int_var(self):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -670,6 +670,20 @@ class TestLinearizeReifiedVariablesThreshold:
         out = linearize_reified_variables(self.linearize((a >= 2) | (a >= 3)), min_values=2, csemap=self.csemap)
         assert str(out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2]), sum([1, -1, -1] * [a, BV[a >= 2], BV[a >= 3]]) == 1]"
 
+    def test_linearize_reified_prefers_more_frequent_encoding(self):
+        """Choose order encoding when more order reifications than direct ones occur."""
+        a = cp.intvar(1, 4, name="a")
+        self.csemap = CSEMap()
+        out = linearize_reified_variables(
+            self.linearize((a == 1) | (a == 2) | (a >= 2) | (a >= 3) | (a >= 4)),
+            min_values=2,
+            csemap=self.csemap,
+            ivarmap=self.ivarmap,
+        )
+
+        assert isinstance(self.ivarmap["a"], IntVarEncOrder)
+        assert str(out) == "[or(BV2, BV3, BV[a >= 2], BV[a >= 3], BV[a >= 4]), (a == 1) == (BV2), (a == 2) == (BV3), (BV[a >= 3]) -> (BV[a >= 2]), (BV[a >= 4]) -> (BV[a >= 3])]"
+
     def test_linearize_reified_inequalities_ignores_low_out_of_domain_threshold(self):
         """Out-of-domain order thresholds should not count towards min_values."""
         a = self.a
@@ -735,4 +749,3 @@ class TestLinearizeReifiedVariablesThreshold:
         b, c = cp.intvar(1, 3, name="b"), cp.intvar(1, 3, name="c")
         out = linearize_reified_variables(self.cpm_cons + self.linearize([(b == 1) | (b == 2), b + c == 3]), min_values=2, csemap=self.csemap)
         assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), (BV[b == 1]) or (BV[b == 2]), (b) + (c) == 3, sum([BV[a == 1], BV[a == 2], BV[a == 3]]) == 1, sum([BV[b == 1], BV[b == 2], BV[b == 3]]) == 1, sum([1, 0, -1, -2] * [b, BV[b == 1], BV[b == 2], BV[b == 3]]) == 1]", "The `a` var does occur"
-

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -724,14 +724,6 @@ class TestLinearizeReifiedVariablesThreshold:
         assert str(out) == "[(~BV[a >= 1]) or (~BV[a >= 3]) or (BV[a >= 3]), sum([1, -1] * (BV[a >= 2], BV[a >= 1])) <= 0, sum([1, -1] * (BV[a >= 3], BV[a >= 2])) <= 0]"
 
     @pytest.mark.xfail(reason="aspirational")
-    def test_linearize_reified_reversed_inequality(self):
-        """Use order encoding for reversed inequalities such as `1 >= a`."""
-        a = self.a
-        self.csemap = CSEMap()
-        out = linearize_reified_variables(self.linearize((1 >= a) | (a >= 3)), min_values=1, csemap=self.csemap, ivarmap=self.ivarmap)
-        assert str(out) == "[(~BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
-
-    @pytest.mark.xfail(reason="aspirational")
     def test_linearize_non_ocurring_int_var(self):
         """For an integer solver, we can omit the channelling constraint if the encoded integer variable does not occur in any constraint. Note: `a` and `b` are encoded (because at least 2 equality reifications occur), `c` is not encoded (no reifications). We see `b` occurs as an integer variable in a constraint, so channelling is required, but the int var `a` does not occur in any constraint, so no channelling is required. `c` is not encoded."""
         b, c = cp.intvar(1, 3, name="b"), cp.intvar(1, 3, name="c")

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -721,13 +721,6 @@ class TestLinearizeReifiedVariablesThreshold:
         assert str(direct_out) == str(cpm_cons)
     
     # The following tests are marked with `xfail` because they are expected to fail, because they are not yet implemented; to see the current output compared with the desired output in the test, run with `pytest --runxfail`
-
-    @pytest.mark.xfail(reason="aspirational")
-    def test_linearize_reified_inequalities(self):
-        """Use order encoding on inequalities and replace `a>=1` expressions"""
-        a = self.a
-        out = linearize_reified_variables(self.linearize((a >= 1) | (a >= 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
-        assert str(out) == "[(BV[a >= 1]) or (BV[a >= 2]), sum([1, -1] * (BV[a >= 2], BV[a >= 1])) <= 0, sum([1, -1] * (BV[a >= 3], BV[a >= 2])) <= 0]"
     
     def test_linearize_reified_inequalities_variations(self):
         """Use order encoding on inequalities and replace other types of inequality expressions"""


### PR DESCRIPTION
This PR makes sure an order encoding is used for inequalities. Do note that I had to create a fresh CSEMap in the tests because there is already a linearization with equalities in the setup and currently CPMpy does not support multiple encodings for the same variable. I do remember Henk saying this might be something that is useful, but it is clearly outside of the scope of this PR.