### PR TITLE
Fast path solver var

### DIFF
--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -55,7 +55,7 @@ from packaging.version import Version
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
 from ..expressions.core import Expression, Comparison, Operator
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
-from ..expressions.utils import is_num, is_any_list, is_boolexpr
+from ..expressions.utils import is_num, is_int, is_any_list, is_boolexpr
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions
@@ -263,30 +263,33 @@ class CPM_template(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var): # shortcut, eases posting constraints
+        if isinstance(cpm_var, _NumVarImpl):
+            # [GUIDELINE] some solver interfaces explicitely create variables on a solver object
+            #       then use self.TPL_solver.NewBoolVar(...) instead of TEMPLATEpy.NewBoolVar(...)
+
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    revar = TEMPLATEpy.negate(self.solver_var(cpm_var._bv))
+                else:
+                    revar = TEMPLATEpy.NewBoolVar(str(cpm_var))
+            else:
+                revar = TEMPLATEpy.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # [GUIDELINE] some solver interfaces explicitely create variables on a solver object
-        #       then use self.TPL_solver.NewBoolVar(...) instead of TEMPLATEpy.NewBoolVar(...)
-
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return TEMPLATEpy.negate(self.solver_var(cpm_var._bv))
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = TEMPLATEpy.NewBoolVar(str(cpm_var))
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = TEMPLATEpy.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-
-        # return from cache
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     # [GUIDELINE] if TEMPLATE does not support objective functions, you can delete this function definition

--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -266,9 +266,7 @@ class CPM_template(SolverInterface):
             or returns a constant if the variable is a constant
         """
         if isinstance(cpm_var, _NumVarImpl):
-            # [GUIDELINE] some solver interfaces explicitely create variables on a solver object
-            #       then use self.TPL_solver.NewBoolVar(...) instead of TEMPLATEpy.NewBoolVar(...)
-
+            
             name = cpm_var.name
             revar = self._varmap.get(name)
             if revar is not None:

--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -278,9 +278,9 @@ class CPM_template(SolverInterface):
                     # special case, negative-bool-view: work directly on var inside the view
                     revar = TEMPLATEpy.negate(self.solver_var(cpm_var._bv))
                 else:
-                    revar = TEMPLATEpy.NewBoolVar(str(cpm_var))
+                    revar = TEMPLATEpy.NewBoolVar(name)
             else:
-                revar = TEMPLATEpy.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+                revar = TEMPLATEpy.NewIntVar(cpm_var.lb, cpm_var.ub, name)
             self._varmap[name] = revar
             return revar
 

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -91,11 +91,6 @@ class CPM_choco(SolverInterface):
                                     "min", "max", "div", "mod", "pow", "abs", "mul", "count", "element", "nvalue", "among"})
     supported_reified_global_constraints = supported_global_constraints  # choco supports everything reified
 
-    # min and max bounds for integer variables
-    # https://github.com/chocoteam/choco-solver/blob/master/solver/src/main/java/org/chocosolver/solver/variables/IntVar.java#L43
-    MIN_INTEGER_BOUND = -2e31 // 100
-    MAX_INTEGER_BOUND = 2e31 // 100
-
     @staticmethod
     def supported():
         # try to import the package
@@ -333,16 +328,13 @@ class CPM_choco(SolverInterface):
                     revar = self.chc_model.bool_not_view(self.solver_var(cpm_var._bv))
                 else:
                     revar = self.chc_model.boolvar(name=name)
-            elif cpm_var.lb >= self.MIN_INTEGER_BOUND and cpm_var.ub <= self.MAX_INTEGER_BOUND:
-                revar = self.chc_model.intvar(cpm_var.lb, cpm_var.ub, name=name)
             else:
-                raise ChocoBoundsException(f"Choco does not accept variables with bounds outside of range ({self.MIN_INTEGER_BOUND}..{self.MAX_INTEGER_BOUND})")
+                revar = self.chc_model.intvar(cpm_var.lb, cpm_var.ub, name=name)
+           
             self._varmap[name] = revar
             return revar
 
         if is_int(cpm_var):  # shortcut, eases posting constraints
-            if cpm_var < self.MIN_INTEGER_BOUND or cpm_var > self.MAX_INTEGER_BOUND:
-                raise ChocoBoundsException(f"Choco does not accept integer literals with bounds outside of range ({self.MIN_INTEGER_BOUND}..{self.MAX_INTEGER_BOUND})")
             return int(cpm_var)
 
         raise NotImplementedError("Not a known var {}".format(cpm_var))
@@ -385,21 +377,12 @@ class CPM_choco(SolverInterface):
 
 
     def _to_var(self, val):
-        from pychoco.variables.intvar import IntVar
-        if is_int(val):
-            # Choco accepts only int32, not int64
-            if val < -2147483646 or val > 2147483646:
-                raise ChocoBoundsException(
-                    "Choco does not accept integer literals with bounds outside of range (-2147483646..2147483646)")
-            return self.chc_model.intvar(int(val), int(val))  # convert to "variable"
-        elif isinstance(val, _NumVarImpl):
+        if isinstance(val, _NumVarImpl):
             return self.solver_var(val)  # use variable
+        elif is_int(val):
+            return self.chc_model.intvar(int(val), int(val))  # convert to "variable"
         else:
             raise ValueError(f"Cannot convert {val} of type {type(val)} to Choco variable, expected int or NumVarImpl")
-
-        # elif isinstance(val, IntVar):
-        #     return val
-        # return None
 
     def _to_vars(self, vals):
         if is_any_list(vals):

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -91,6 +91,11 @@ class CPM_choco(SolverInterface):
                                     "min", "max", "div", "mod", "pow", "abs", "mul", "count", "element", "nvalue", "among"})
     supported_reified_global_constraints = supported_global_constraints  # choco supports everything reified
 
+    # min and max bounds for integer variables
+    # https://github.com/chocoteam/choco-solver/blob/master/solver/src/main/java/org/chocosolver/solver/variables/IntVar.java#L43
+    MIN_INTEGER_BOUND = -2e31 // 100
+    MAX_INTEGER_BOUND = 2e31 // 100
+
     @staticmethod
     def supported():
         # try to import the package
@@ -309,38 +314,46 @@ class CPM_choco(SolverInterface):
 
         return len(sols)
 
+    def _check_bounds(self, val):
+        
+        if val > 2e31 / 100:
+            raise ChocoBoundsException("Choco does not accept variables with bounds outside of range (-2e31..2e31)")
+        if val < -2e31 / 100:
+            raise ChocoBoundsException("Choco does not accept variables with bounds outside of range (-2e31..2e31)")
+
+
     def solver_var(self, cpm_var):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
-            if not is_int(cpm_var):
-                raise ValueError(f"Choco only accepts integer constants, got {cpm_var} of type {type(cpm_var)}")
-            if cpm_var < -2147483646 or cpm_var > 2147483646:
-                raise ChocoBoundsException(
-                    "Choco does not accept integer literals with bounds outside of range (-2147483646..2147483646)")
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    revar = self.chc_model.bool_not_view(self.solver_var(cpm_var._bv))
+                else:
+                    revar = self.chc_model.boolvar(name=name)
+            elif cpm_var.lb >= self.MIN_INTEGER_BOUND and cpm_var.ub <= self.MAX_INTEGER_BOUND:
+                revar = self.chc_model.intvar(cpm_var.lb, cpm_var.ub, name=name)
+            else:
+                raise ChocoBoundsException(f"Choco does not accept variables with bounds outside of range ({self.MIN_INTEGER_BOUND}..{self.MAX_INTEGER_BOUND})")
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            if cpm_var < self.MIN_INTEGER_BOUND or cpm_var > self.MAX_INTEGER_BOUND:
+                raise ChocoBoundsException(f"Choco does not accept integer literals with bounds outside of range ({self.MIN_INTEGER_BOUND}..{self.MAX_INTEGER_BOUND})")
             return int(cpm_var)
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return self.chc_model.bool_not_view(self.solver_var(cpm_var._bv))
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.chc_model.boolvar(name=str(cpm_var.name))
-            elif isinstance(cpm_var, _IntVarImpl):
-                if cpm_var.lb < -2147483646 or cpm_var.ub > 2147483646:
-                    raise ChocoBoundsException(
-                        "Choco does not accept variables with bounds outside of range (-2147483646..2147483646)")
-                revar = self.chc_model.intvar(cpm_var.lb, cpm_var.ub, name=str(cpm_var.name))
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
     def objective(self, expr, minimize):
         """

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -314,14 +314,6 @@ class CPM_choco(SolverInterface):
 
         return len(sols)
 
-    def _check_bounds(self, val):
-        
-        if val > 2e31 / 100:
-            raise ChocoBoundsException("Choco does not accept variables with bounds outside of range (-2e31..2e31)")
-        if val < -2e31 / 100:
-            raise ChocoBoundsException("Choco does not accept variables with bounds outside of range (-2e31..2e31)")
-
-
     def solver_var(self, cpm_var):
         """
             Creates solver variable for cpmpy variable

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -55,7 +55,7 @@ from typing import Optional, List
 
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
-from ..expressions.utils import argvals, argval, eval_comparison, flatlist, is_any_list, is_bool, is_num
+from ..expressions.utils import argvals, argval, eval_comparison, flatlist, is_any_list, is_bool, is_num, is_int
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.comparison import only_numexpr_equality
@@ -267,28 +267,31 @@ class CPM_cplex(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                # special case, negative-bool-view (not supported as first-class var; use 1-bv in constraints)
+                if isinstance(cpm_var, NegBoolView):
+                    raise ValueError("Negative literals should not be part of any equation. "
+                                    "Should have been removed by the only_positive_bv() transformation. "
+                                    "See /transformations/linearize for more details")
+                revar = self.cplex_model.binary_var(name)
+            else:
+                revar = self.cplex_model.integer_var(cpm_var.lb, cpm_var.ub, name=name)
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view
-        if isinstance(cpm_var, NegBoolView):
-            raise ValueError("Negative literals should not be part of any equation. "
-                            "Should have been removed by the only_positive_bv() transformation. "
-                            "See /transformations/linearize for more details")
-
-        # create if it does not exit
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.cplex_model.binary_var(cpm_var.name)
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.cplex_model.integer_var(cpm_var.lb, cpm_var.ub, name=str(cpm_var))
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-
-        # return from cache
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -241,9 +241,6 @@ class CPM_cpo(SolverInterface):
             for cpm_var in self.user_vars:
                 sol_var = self.solver_var(cpm_var)
                 if isinstance(cpm_var,_BoolVarImpl):
-                    # because cp optimizer does not have boolean variables we use an integer var x with domain 0, 1
-                    # and then replace a boolvar by x == 1
-                    sol_var = sol_var.children[0]
                     cpm_var._value = bool(self.cpo_result.get_var_solution(sol_var).get_value())
                 else:
                     cpm_var._value = self.cpo_result.get_var_solution(sol_var).get_value()
@@ -309,9 +306,6 @@ class CPM_cpo(SolverInterface):
                 sol_var = self.solver_var(cpm_var)
                 cpm_value = cpm_var._value
                 if isinstance(cpm_var, _BoolVarImpl):
-                    # because cp optimizer does not have boolean variables we use an integer var x with domain 0, 1
-                    # and then replace a boolvar by x == 1
-                    sol_var = sol_var.children[0]
                     cpm_value = int(cpm_value)
                 solvars.append(sol_var)
                 vals.append(cpm_value)
@@ -355,16 +349,16 @@ class CPM_cpo(SolverInterface):
             docp = self.get_docp()
             if cpm_var.is_bool():
                 if isinstance(cpm_var, NegBoolView):
-                    # special case, negative-bool-view: work directly on var inside the view
-                    revar = docp.modeler.logical_not(self.solver_var(cpm_var._bv))
+                    raise ValueError("Negative literals cannot be created in `solver_var()` for cpo, use `_cpo_expr()` instead")
                 else:
                     # note that a binary var is an integer var with domain (0,1), you cannot do boolean operations on it.
-                    # we should add == 1 to turn it into a boolean expression
-                    revar = docp.expression.binary_var(name) == 1
+                    revar = docp.expression.binary_var(name)
             else:
                 revar = docp.expression.integer_var(min=cpm_var.lb, max=cpm_var.ub, name=name)
+            
             self._varmap[name] = revar
-            self.cpo_model.add(revar >= cpm_var.lb)  # ensure the model also has the variable
+             # ensure the model also has the variable, just creating the variable is not enough
+            self.cpo_model.add(revar >= cpm_var.lb) 
             return revar
 
         if is_int(cpm_var):  # shortcut, eases posting constraints
@@ -454,13 +448,13 @@ class CPM_cpo(SolverInterface):
 
         for cpm_con in self.transform(cpm_expr):
             # translate each expression tree, then post straight away
-            cpo_con = self._cpo_expr(cpm_con)
+            cpo_con = self._cpo_expr(cpm_con, boolexpr=True)
             self.cpo_model.add(cpo_con)
 
         return self
     __add__ = add  # avoid redirect in superclass
 
-    def _cpo_expr(self, cpm_con):
+    def _cpo_expr(self, cpm_con, boolexpr=False):
         """
             CP Optimizer supports nested expressions,
             so we recursively translate our expressions to theirs.
@@ -470,8 +464,8 @@ class CPM_cpo(SolverInterface):
         """
         dom = self.get_docp().modeler
         if is_any_list(cpm_con):
-            # arguments can be lists
-            return [self._cpo_expr(con) for con in cpm_con]
+            # arguments can be lists, assume boolexpr is same for all arguments
+            return [self._cpo_expr(con, boolexpr=boolexpr) for con in cpm_con]
 
         elif isinstance(cpm_con, BoolVal):
             return cpm_con.args[0]
@@ -479,7 +473,15 @@ class CPM_cpo(SolverInterface):
         elif is_num(cpm_con):
             return cpm_con
 
-        elif isinstance(cpm_con, _NumVarImpl):
+        elif isinstance(cpm_con, _NumVarImpl): # handle variables
+            if isinstance(cpm_con, NegBoolView):
+                if boolexpr:
+                    return self.solver_var(cpm_con._bv) == 0
+                else:
+                    return 1 - self.solver_var(cpm_con._bv)
+            elif cpm_con.is_bool() and boolexpr:
+                return self.solver_var(cpm_con) == 1
+            # else: integer variable, or boolean variable used as integer
             return self.solver_var(cpm_con)
 
         # Operators: base (bool), lhs=numexpr, lhs|rhs=boolexpr (reified ->)
@@ -487,13 +489,13 @@ class CPM_cpo(SolverInterface):
             arity, _ = Operator.allowed[cpm_con.name]
             # 'and'/n, 'or'/n, '->'/2
             if cpm_con.name == 'and':
-                return dom.logical_and(self._cpo_expr(cpm_con.args))
+                return dom.logical_and(self._cpo_expr(cpm_con.args, boolexpr=True))
             elif cpm_con.name == 'or':
-                return dom.logical_or(self._cpo_expr(cpm_con.args))
+                return dom.logical_or(self._cpo_expr(cpm_con.args, boolexpr=True))
             elif cpm_con.name == '->':
-                return dom.if_then(*self._cpo_expr(cpm_con.args))
+                return dom.if_then(*self._cpo_expr(cpm_con.args, boolexpr=True))
             elif cpm_con.name == 'not':
-                return dom.logical_not(self._cpo_expr(cpm_con.args[0]))
+                return dom.logical_not(self._cpo_expr(cpm_con.args[0], boolexpr=True))
 
             # 'sum'/n, 'wsum'/2
             elif cpm_con.name == 'sum':
@@ -572,7 +574,7 @@ class CPM_cpo(SolverInterface):
                     else:
                         task_demand = dom.pulse(task, get_bounds(h))
                         if is_present is not None:
-                            cons += [dom.if_then(self.solver_var(is_present[i]),
+                            cons += [dom.if_then(self._cpo_expr(is_present[i], boolexpr=True),
                                                  self._cpo_expr(h) == dom.height_at_start(task, task_demand))]
                         else:
                             cons += [self._cpo_expr(h) == dom.height_at_start(task, task_demand)]
@@ -681,7 +683,7 @@ class CPM_cpo(SolverInterface):
             extra_cons += [dom.if_then(dom.presence_of(task), dom.start_of(task) == self._cpo_expr(start)),
                            dom.if_then(dom.presence_of(task), dom.size_of(task) == self._cpo_expr(dur))]
             if is_optional: # enforce presence of task
-                extra_cons += [dom.presence_of(task) == self.solver_var(is_present)]
+                extra_cons += [dom.presence_of(task) == self._cpo_expr(is_present, boolexpr=True)]
             return task, extra_cons
         else:
             task = docp.expression.interval_var(start=get_bounds(start), size=get_bounds(dur), end=get_bounds(end), optional=is_optional)
@@ -689,7 +691,7 @@ class CPM_cpo(SolverInterface):
                            dom.if_then(dom.presence_of(task), dom.size_of(task) ==  self._cpo_expr(dur)),
                            dom.if_then(dom.presence_of(task), dom.end_of(task) == self._cpo_expr(end))]
             if is_optional: # enforce presence of task
-                extra_cons += [dom.presence_of(task) == self.solver_var(is_present)]
+                extra_cons += [dom.presence_of(task) == self._cpo_expr(is_present, boolexpr=True)]
             return task, extra_cons
 
 
@@ -790,11 +792,10 @@ try:
             if len(self._cpm_vars):
                 # populate values before printing
                 for cpm_var in self._cpm_vars:
+                    sol_var = self._varmap[cpm_var.name]
                     if isinstance(cpm_var, _BoolVarImpl):
-                        sol_var = self._varmap[cpm_var.name].children[0]
                         cpm_var._value = bool(sres.get_var_solution(sol_var).get_value())
                     elif isinstance(cpm_var, _IntVarImpl):
-                        sol_var = self._varmap[cpm_var.name]
                         cpm_var._value = sres.get_var_solution(sol_var).get_value()
                     else:
                         raise NotImplementedError(f"Unexpected variable type {type(cpm_var)}")

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -51,7 +51,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.globalconstraints import Cumulative, CumulativeOptional, GlobalConstraint, NoOverlap, NoOverlapOptional
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
-from ..expressions.utils import is_num, is_any_list, eval_comparison, argval, argvals, get_bounds, get_nonneg_args, implies
+from ..expressions.utils import is_num, is_int, is_any_list, eval_comparison, argval, argvals, get_bounds, get_nonneg_args, implies
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
@@ -342,31 +342,35 @@ class CPM_cpo(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        docp = self.get_docp()
-        if is_num(cpm_var): # shortcut, eases posting constraints
+
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            docp = self.get_docp()
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    revar = docp.modeler.logical_not(self.solver_var(cpm_var._bv))
+                else:
+                    # note that a binary var is an integer var with domain (0,1), you cannot do boolean operations on it.
+                    # we should add == 1 to turn it into a boolean expression
+                    revar = docp.expression.binary_var(name) == 1
+            else:
+                revar = docp.expression.integer_var(min=cpm_var.lb, max=cpm_var.ub, name=name)
+            self._varmap[name] = revar
+            self.cpo_model.add(revar >= cpm_var.lb)  # ensure the model also has the variable
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return (self.solver_var(cpm_var._bv) == 0)
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                # note that a binary var is an integer var with domain (0,1), you cannot do boolean operations on it.
-                # we should add == 1 to turn it into a boolean expression
-                revar = docp.expression.binary_var(str(cpm_var)) == 1
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = docp.expression.integer_var(min=cpm_var.lb, max=cpm_var.ub, name=str(cpm_var))
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-            self.cpo_model.add(revar >= cpm_var.lb) # ensure the model also has the variable
-
-        # return from cache
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
     def objective(self, expr, minimize=True):
         """

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -65,7 +65,7 @@ from ..transformations.reification import only_implies, reify_rewrite, only_bv_r
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions, safen_objective
 from ..expressions.globalconstraints import DirectConstraint
-from ..expressions.utils import flatlist, argvals, argval, is_any_list, is_num
+from ..expressions.utils import flatlist, argvals, argval, is_any_list, is_num, is_int
 from ..exceptions import NotSupportedError
 
 import numpy as np
@@ -393,33 +393,34 @@ class CPM_exact(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                # special case, negative-bool-view. Should be eliminated in linearize
+                if isinstance(cpm_var, NegBoolView):
+                    raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
+                self.xct_solver.addVariable(name)
+            else:
+                lb, ub = cpm_var.get_bounds()
+                if self.encoding is None:
+                    encoding = "order" if ub-lb < 8 else "log"  # heuristic bound
+                else:
+                    encoding = self.encoding  # can also force it
+                self.xct_solver.addVariable(name, lb, ub, encoding)
+            self._varmap[name] = name
+            return name
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view. Should be eliminated in linearize
-        if isinstance(cpm_var, NegBoolView):
-            raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
-
-        # return it if it already exists
-        if cpm_var.name in self._varmap:
-            return self._varmap[cpm_var.name]
-
-        # create if it does not exist
-        revar = str(cpm_var)
-        if isinstance(cpm_var, _BoolVarImpl):
-            self.xct_solver.addVariable(revar)
-        elif isinstance(cpm_var, _IntVarImpl):
-            lb, ub = cpm_var.get_bounds()
-            if self.encoding is None:
-                encoding = "order" if ub-lb < 8 else "log" # heuristic bound
-            else:
-                encoding = self.encoding # can also force it
-            self.xct_solver.addVariable(revar, lb, ub, encoding)
-        else:
-            raise NotImplementedError("Not a known var {}".format(cpm_var))
-        self._varmap[cpm_var.name] = revar
-        return revar
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def objective(self, expr, minimize):

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -481,9 +481,6 @@ class CPM_gcs(SolverInterface):
         # NB: GCS supports a small number of simple expressions as the reifying term
         # e.g. (x > 3) -> constraint could in principle be supported in the future.
         cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        str_rep = ""
-        for c in cpm_cons:
-            str_rep += str(c) + '\n'
         return cpm_cons
 
     def verify(self, name=None, location=".", time_limit=None, display_output=False, veripb_args=[]):

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -62,7 +62,7 @@ from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callbac
 from ..expressions.core import Comparison, Operator, BoolVal, ExprLike
 from ..expressions.variables import _BoolVarImpl, _IntVarImpl, _NumVarImpl, NegBoolView, boolvar
 from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.utils import is_num, is_any_list
+from ..expressions.utils import is_int, is_any_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint, get_or_make_var
@@ -371,29 +371,32 @@ class CPM_gcs(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var): # shortcut, eases posting constraints
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    # gcs only works with integer variables, so not(x) = -x + 1
+                    revar = self.gcs.add_constant(self.gcs.negate(self.solver_var(cpm_var._bv)), 1)
+                else:
+                    # Bool vars are just int vars with [0, 1] domain
+                    revar = self.gcs.create_integer_variable(0, 1, self._gcs_safe_name(name))
+            else:
+                revar = self.gcs.create_integer_variable(cpm_var.lb, cpm_var.ub, self._gcs_safe_name(name))
+            self._varmap[name] = revar  # save actual name, not gcs_safe name
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return self.gcs.create_integer_constant(cpm_var)
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            # gcs only works with integer variables, so not(x) = -x + 1
-            return self.gcs.add_constant(self.gcs.negate(self.solver_var(cpm_var._bv)), 1)
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            name = self._gcs_safe_name(str(cpm_var))
-            if isinstance(cpm_var, _BoolVarImpl):
-                # Bool vars are just int vars with [0, 1] domain
-                revar = self.gcs.create_integer_variable(0, 1, name)
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.gcs.create_integer_variable(cpm_var.lb, cpm_var.ub, name)
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar # save actual name, not gcs_safe name
-
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
     def solver_vars(self, cpm_vars: Iterable[ExprLike]) -> list[Any]:
         """

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -49,7 +49,7 @@ import cpmpy as cp
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
-from ..expressions.utils import argvals, argval, is_any_list, is_num
+from ..expressions.utils import argvals, argval, is_any_list, is_num, is_int
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.comparison import only_numexpr_equality
@@ -254,27 +254,29 @@ class CPM_gurobi(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var): # shortcut, eases posting constraints
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            from gurobipy import GRB
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
+                revar = self.grb_model.addVar(vtype=GRB.BINARY, name=name)
+            else:
+                revar = self.grb_model.addVar(cpm_var.lb, cpm_var.ub, vtype=GRB.INTEGER, name=str(cpm_var))
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view. Should be eliminated in linearize
-        if isinstance(cpm_var, NegBoolView):
-            raise NotSupportedError("Negative literals should not be left as part of any equation. Please report.")
-
-        # create if it does not exit
-        if cpm_var.name not in self._varmap:
-            from gurobipy import GRB
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.grb_model.addVar(vtype=GRB.BINARY, name=cpm_var.name)
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.grb_model.addVar(cpm_var.lb, cpm_var.ub, vtype=GRB.INTEGER, name=str(cpm_var))
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-
-        # return from cache
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -251,9 +251,6 @@ class CPM_hexaly(SolverInterface):
             or returns a constant if the variable is a constant
         """
         if isinstance(cpm_var, _NumVarImpl):
-            # special case, negative-bool-view
-            # work directly on var inside the view
-            
             name = cpm_var.name
             revar = self._varmap.get(name)
             if revar is not None:
@@ -262,14 +259,15 @@ class CPM_hexaly(SolverInterface):
             # not yet created, make a new solver var
             if cpm_var.is_bool():
                 if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view, work directly on var inside the view
                     revar = ~self.solver_var(cpm_var._bv)
                 else:
                     revar = self.hex_model.bool()
+                    revar.set_name(name)
             else:
                 revar = self.hex_model.int(cpm_var.lb, cpm_var.ub)
+                revar.set_name(name)
             
-            # set name of variable
-            revar.set_name(str(cpm_var))
             self._varmap[name] = revar
             return revar
 

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -47,7 +47,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
-from ..expressions.utils import argval, argvals, is_num, is_any_list, eval_comparison, flatlist
+from ..expressions.utils import argval, argvals, is_num, is_int, is_any_list, eval_comparison, flatlist
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
@@ -248,29 +248,35 @@ class CPM_hexaly(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var): # shortcut, eases posting constraints
-            return cpm_var
+        if isinstance(cpm_var, _NumVarImpl):
+            # special case, negative-bool-view
+            # work directly on var inside the view
+            
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return ~self.solver_var(cpm_var._bv)
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.hex_model.bool()
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.hex_model.int(cpm_var.lb, cpm_var.ub)
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    revar = ~self.solver_var(cpm_var._bv)
+                else:
+                    revar = self.hex_model.bool()
             else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
+                revar = self.hex_model.int(cpm_var.lb, cpm_var.ub)
+            
             # set name of variable
             revar.set_name(str(cpm_var))
-            self._varmap[cpm_var.name] = revar
+            self._varmap[name] = revar
+            return revar
 
-        # return from cache
-        return self._varmap[cpm_var.name]
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            return cpm_var
+
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -48,7 +48,7 @@ import numpy.typing as npt
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import BoolVal, Comparison, Operator
-from ..expressions.utils import is_num
+from ..expressions.utils import is_num, is_int
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.comparison import only_numexpr_equality
@@ -133,30 +133,34 @@ class CPM_highs(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                # negative bool views should have been eliminated by transformations
+                if isinstance(cpm_var, NegBoolView):
+                    raise NotSupportedError(
+                        "Negative literals should not be part of any equation. "
+                        "They should have been removed by only_positive_bv()/only_positive_bv_wsum. "
+                        "See /transformations/linearize for more details."
+                    )
+                revar = self.highs.addBinary().index
+            else:
+                revar = self.highs.addIntegral(lb=cpm_var.lb, ub=cpm_var.ub).index
+
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # negative bool views should have been eliminated by transformations
-        if isinstance(cpm_var, NegBoolView):
-            raise NotSupportedError(
-                "Negative literals should not be part of any equation. "
-                "They should have been removed by only_positive_bv()/only_positive_bv_wsum. "
-                "See /transformations/linearize for more details."
-            )
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                hvar = self.highs.addBinary()
-            elif isinstance(cpm_var, _IntVarImpl):
-                hvar = self.highs.addIntegral(lb=cpm_var.lb, ub=cpm_var.ub)
-            else:
-                raise NotSupportedError(f"Not a known HiGHS variable type: {cpm_var}")
-
-            self._varmap[cpm_var.name] = hvar.index
-
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
     def _row_from_linexpr(self, linexpr) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.float64], int|float]:
         """

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -73,7 +73,7 @@ from ..expressions.python_builtins import any as cpm_any
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl, NegBoolView, cpm_array
 from ..expressions.globalconstraints import Cumulative, DirectConstraint, GlobalCardinalityCount
 from ..expressions.globalfunctions import Multiplication
-from ..expressions.utils import is_num, is_any_list, argvals, argval, get_nonneg_args
+from ..expressions.utils import is_int, is_any_list, argvals, argval, get_nonneg_args
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..exceptions import MinizincPathException, NotSupportedError
 from ..transformations.get_variables import get_variables
@@ -519,48 +519,48 @@ class CPM_minizinc(SolverInterface):
     def solver_var(self, cpm_var) -> str:
         """
             Creates solver variable for cpmpy variable
-            or returns from cache if previously created.
+            or returns from cache if previously created
+            or returns a constant if the variable is a constant
 
             Returns:
                 minizinc-friendly 'string' name of var.
-
-            .. warning::
-                WARNING, this assumes it is never given a 'NegBoolView'
-                might not be true... e.g. in revar after solve?
         """
-        if is_num(cpm_var):
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            mzn_var = name.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '')
+
+            # test if the name is a valid minizinc identifier
+            if not self.mzn_name_pattern.search(mzn_var):
+                raise MinizincNameException("Minizinc only accept names with alphabetic characters, digits and underscores." 
+                                            "First character must be an alphabetic character")
+            if mzn_var in self.keywords:
+                raise MinizincNameException(f"This variable name is a disallowed keyword in MiniZinc: {mzn_var}")
+
+            if cpm_var.is_bool():
+                # Assumes it is never given a 'NegBoolView'
+                if isinstance(cpm_var, NegBoolView):
+                    raise NotSupportedError("Negative literals are not handled here. Please report.")
+                self.mzn_model.add_string(f"var bool: {mzn_var};\n")
+            else:
+                if cpm_var.lb < -2147483646 or cpm_var.ub > 2147483646:
+                    raise MinizincBoundsException("minizinc does not accept variables with bounds outside "
+                                                  "of range (-2147483646..2147483646)")
+                self.mzn_model.add_string(f"var {cpm_var.lb}..{cpm_var.ub}: {mzn_var};\n")
+            self._varmap[name] = mzn_var
+            return mzn_var
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             if cpm_var < -2147483646 or cpm_var > 2147483646:
                 raise MinizincBoundsException(
                     "minizinc does not accept integer literals with bounds outside of range (-2147483646..2147483646)")
             return str(cpm_var)
 
-        # Assumes it is never given a 'NegBoolView'
-        if isinstance(cpm_var, NegBoolView):
-            raise NotSupportedError("Negative literals are not handled here. Please report.")
-
-        if cpm_var.name not in self._varmap:
-            # clean the varname
-            varname = cpm_var.name
-            mzn_var = varname.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '')
-
-            # test if the name is a valid minizinc identifier
-            if not self.mzn_name_pattern.search(mzn_var):
-                raise MinizincNameException("Minizinc only accept names with alphabetic characters, "
-                                            "digits and underscores. "
-                                "First character must be an alphabetic character")
-            if mzn_var in self.keywords:
-                raise MinizincNameException(f"This variable name is a disallowed keyword in MiniZinc: {mzn_var}")
-
-            if isinstance(cpm_var, _BoolVarImpl):
-                self.mzn_model.add_string(f"var bool: {mzn_var};\n")
-            elif isinstance(cpm_var, _IntVarImpl):
-                if cpm_var.lb < -2147483646 or cpm_var.ub > 2147483646:
-                    raise MinizincBoundsException("minizinc does not accept variables with bounds outside "
-                                                  "of range (-2147483646..2147483646)")
-                self.mzn_model.add_string(f"var {cpm_var.lb}..{cpm_var.ub}: {mzn_var};\n")
-            self._varmap[cpm_var.name] = mzn_var
-
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
     def objective(self, expr, minimize):
         """

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -531,20 +531,22 @@ class CPM_minizinc(SolverInterface):
             if revar is not None:
                 return revar
 
+            # Assumes it is never given a 'NegBoolView', handled in self.add
+            if isinstance(cpm_var, NegBoolView):
+                raise NotSupportedError("Negative literals are not handled here. Please report.")
+                
+
             # not yet created, make a new solver var
             mzn_var = name.replace(',', '_').replace('.', '_').replace(' ', '_').replace('[', '_').replace(']', '')
 
             # test if the name is a valid minizinc identifier
             if not self.mzn_name_pattern.search(mzn_var):
                 raise MinizincNameException("Minizinc only accept names with alphabetic characters, digits and underscores." 
-                                            "First character must be an alphabetic character")
+                                            f"First character must be an alphabetic character: {mzn_var}")
             if mzn_var in self.keywords:
                 raise MinizincNameException(f"This variable name is a disallowed keyword in MiniZinc: {mzn_var}")
 
             if cpm_var.is_bool():
-                # Assumes it is never given a 'NegBoolView'
-                if isinstance(cpm_var, NegBoolView):
-                    raise NotSupportedError("Negative literals are not handled here. Please report.")
                 self.mzn_model.add_string(f"var bool: {mzn_var};\n")
             else:
                 if cpm_var.lb < -2147483646 or cpm_var.ub > 2147483646:

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -314,24 +314,25 @@ class CPM_ortools(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        # fast-path: a CPMpy variable that has already been mapped
         if isinstance(cpm_var, _NumVarImpl):
-            revar = self._varmap.get(cpm_var.name)
+            name = cpm_var.name
+            revar = self._varmap.get(name)
             if revar is not None:
                 return revar
 
-            # special case, negative-bool-view: work directly on var inside the view
-            if isinstance(cpm_var, NegBoolView):
-                return self.solver_var(cpm_var._bv).Not()
-
             # not yet created, make a new solver var
             if cpm_var.is_bool():
-                revar = self.ort_model.NewBoolVar(str(cpm_var))
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    revar = self.solver_var(cpm_var._bv).Not()
+                else:
+                    revar = self.ort_model.NewBoolVar(name)
             else:
-                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, name)
             
-            self._varmap[cpm_var.name] = revar
+            self._varmap[name] = revar
             return revar
 
         if is_int(cpm_var):  # shortcut, eases posting constraints

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -315,25 +315,29 @@ class CPM_ortools(SolverInterface):
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
         """
-        if is_num(cpm_var):  # shortcut, eases posting constraints
+        # fast-path: a CPMpy variable that has already been mapped
+        if isinstance(cpm_var, _NumVarImpl):
+            revar = self._varmap.get(cpm_var.name)
+            if revar is not None:
+                return revar
+
+            # special case, negative-bool-view: work directly on var inside the view
+            if isinstance(cpm_var, NegBoolView):
+                return self.solver_var(cpm_var._bv).Not()
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                revar = self.ort_model.NewBoolVar(str(cpm_var))
+            else:
+                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
+            
+            self._varmap[cpm_var.name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return self.solver_var(cpm_var._bv).Not()
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.ort_model.NewBoolVar(str(cpm_var))
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.ort_model.NewIntVar(cpm_var.lb, cpm_var.ub, str(cpm_var))
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def objective(self, expr, minimize):

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -43,8 +43,8 @@ from typing import Iterable, Optional, List, Any
 
 from ..exceptions import NotSupportedError
 from ..expressions.core import BoolVal, Comparison
-from ..expressions.utils import eval_comparison
-from ..expressions.variables import NegBoolView, _BoolVarImpl, _IntVarImpl
+from ..expressions.utils import eval_comparison, is_int
+from ..expressions.variables import NegBoolView, _BoolVarImpl, _NumVarImpl
 from ..transformations.flatten_model import flatten_constraint
 from ..transformations.get_variables import get_variables
 from ..transformations.int2bool import _decide_encoding, _encode_int_var, int2bool
@@ -215,23 +215,40 @@ class CPM_pindakaas(SolverInterface):
         return has_sol
 
     def solver_var(self, cpm_var):
-        if isinstance(cpm_var, NegBoolView):  # negative literal
-            # get inner variable and return its negated solver var
-            return ~self.solver_var(cpm_var._bv)
-        elif isinstance(cpm_var, _BoolVarImpl):  # positive literal
-            # insert if new
-            if cpm_var.name not in self._varmap:
-                self._varmap[cpm_var.name] = self.pdk_solver.new_var()
-            return self._varmap[cpm_var.name]
-        elif isinstance(cpm_var, _IntVarImpl):  # intvar
-            if cpm_var.name not in self.ivarmap:
-                enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
-                self.add(cons)
+        """
+            Creates solver variable for cpmpy variable
+            or returns from cache if previously created
+            or returns a constant if the variable is a constant
+        """
+        if isinstance(cpm_var, _NumVarImpl):
+
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):  # negative literal
+                    # get inner variable and return its negated solver var
+                    revar = ~self.solver_var(cpm_var._bv)
+                else:
+                    revar = self.pdk_solver.new_var()
+            
             else:
-                enc = self.ivarmap[cpm_var.name]
-            return self.solver_vars(enc.vars())
-        else:
-            raise TypeError(f"Unexpected type: {cpm_var}")
+                if name not in self.ivarmap:
+                    enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
+                    self.add(cons)
+                else:
+                    enc = self.ivarmap[name]
+                revar = self.solver_vars(enc.vars())
+            
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            return cpm_var
+
+        raise TypeError(f"Unexpected type: {cpm_var}")
 
     def transform(self, cpm_expr):
         cpm_cons = toplevel_list(cpm_expr)

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -49,7 +49,7 @@ from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.globalconstraints import Cumulative, GlobalConstraint, NoOverlap
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar, boolvar
-from ..expressions.utils import is_num, is_any_list, get_bounds
+from ..expressions.utils import is_num, is_int, is_any_list, get_bounds
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import canonical_comparison
 from ..transformations.normalize import toplevel_list
@@ -294,31 +294,30 @@ class CPM_pumpkin(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
 
-        if is_num(cpm_var):
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    revar = self.solver_var(cpm_var._bv).negate()
+                else:
+                    revar = self.pum_solver.new_boolean_variable(name=name)
+            else:
+                revar = self.pum_solver.new_integer_variable(cpm_var.lb, cpm_var.ub, name=name)
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return self.solver_var(cpm_var._bv).negate()
-
-        # create if it does not exist
-        if isinstance(cpm_var, _NumVarImpl):
-            if cpm_var.name not in self._varmap:
-                if isinstance(cpm_var, _BoolVarImpl):
-                    revar = self.pum_solver.new_boolean_variable(name=str(cpm_var))
-                elif isinstance(cpm_var, _IntVarImpl):
-                    revar = self.pum_solver.new_integer_variable(cpm_var.lb, cpm_var.ub, name=str(cpm_var))
-                else:
-                    raise NotImplementedError("Not a known var {}".format(cpm_var))
-                self._varmap[cpm_var.name] = revar
-
-            # return from cache
-            return self._varmap[cpm_var.name]
-        
-        raise ValueError(f"Not a known var {cpm_var}")
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
 

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -61,7 +61,7 @@ from ..expressions.core import Comparison, Operator, BoolVal
 from ..expressions.variables import _NumVarImpl, _BoolVarImpl, _IntVarImpl, NegBoolView
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.linearize import only_positive_coefficients, decompose_linear
-from ..expressions.utils import flatlist
+from ..expressions.utils import flatlist, is_int
 from ..transformations.get_variables import get_variables
 from ..transformations.flatten_model import flatten_constraint
 from ..transformations.linearize import linearize_constraint, linearize_reified_variables
@@ -313,32 +313,37 @@ class CPM_pysat(SolverInterface):
     def solver_var(self, cpm_var):
         """
             Creates solver variable for cpmpy variable
-            or returns from cache if previously created.
+            or returns from cache if previously created
+            or returns a constant if the variable is a constant
 
             Transforms cpm_var into CNF literal using ``self.pysat_vpool``
             (positive or negative integer).
 
             So vpool is the varmap (we don't use _varmap here).
         """
-
-        # special case, negative-bool-view
-        # work directly on var inside the view
         if isinstance(cpm_var, BoolVal):
             return cpm_var
-        elif isinstance(cpm_var, NegBoolView):
-            # just a view, get actual var identifier, return -id
-            return -self.pysat_vpool.id(cpm_var._bv.name)
-        elif isinstance(cpm_var, _BoolVarImpl):
-            return self.pysat_vpool.id(cpm_var.name)
-        elif isinstance(cpm_var, _IntVarImpl):  # intvar
-            if cpm_var.name not in self.ivarmap:
+
+        if isinstance(cpm_var, _NumVarImpl):
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: just a view, get actual var identifier, return -id
+                    return -self.pysat_vpool.id(cpm_var._bv.name)
+                return self.pysat_vpool.id(cpm_var.name)
+
+            # intvar
+            name = cpm_var.name
+            if name not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
                 self.add(cons)
             else:
-                enc = self.ivarmap[cpm_var.name]
+                enc = self.ivarmap[name]
             return self.solver_vars(enc.vars())
-        else:
-            raise NotImplementedError(f"CPM_pysat: variable {cpm_var} not supported")
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            return cpm_var
+
+        raise NotImplementedError(f"CPM_pysat: variable {cpm_var} not supported")
 
     def transform(self, cpm_expr):
         """

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -321,24 +321,24 @@ class CPM_pysat(SolverInterface):
 
             So vpool is the varmap (we don't use _varmap here).
         """
-        if isinstance(cpm_var, BoolVal):
-            return cpm_var
-
         if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
             if cpm_var.is_bool():
                 if isinstance(cpm_var, NegBoolView):
                     # special case, negative-bool-view: just a view, get actual var identifier, return -id
-                    return -self.pysat_vpool.id(cpm_var._bv.name)
-                return self.pysat_vpool.id(cpm_var.name)
+                    return -self.pysat_vpool.id(cpm_var._bv.name) # use name of inner variable, not ~bv as name
+                return self.pysat_vpool.id(name)
 
             # intvar
-            name = cpm_var.name
             if name not in self.ivarmap:
                 enc, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
                 self.add(cons)
             else:
                 enc = self.ivarmap[name]
             return self.solver_vars(enc.vars())
+
+        if isinstance(cpm_var, BoolVal):
+            return cpm_var
 
         if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -49,9 +49,9 @@ from typing import Iterable, Optional
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, BoolVal
-from ..expressions.variables import _BoolVarImpl, NegBoolView, boolvar
+from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, boolvar
 from ..expressions.globalconstraints import DirectConstraint
-from ..expressions.utils import is_bool, argvals, is_any_list
+from ..expressions.utils import is_bool, is_int, argvals, is_any_list
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list, simplify_boolean
@@ -256,25 +256,35 @@ class CPM_pysdd(SolverInterface):
     def solver_var(self, cpm_var):
         """
             Creates solver variable for cpmpy variable
+            or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            # just a view, get actual var identifier, return -id
-            return -self.solver_var(cpm_var._bv)
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
 
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                # make new var, add at end (what is best here??)
-                self.pysdd_manager.add_var_after_last()
-                n = self.pysdd_manager.var_count()
-                revar = self.pysdd_manager.vars[n]
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: just a view, get actual var identifier, return -id
+                    revar = -self.solver_var(cpm_var._bv)
+                else:
+                    # make new var, add at end (what is best here??)
+                    self.pysdd_manager.add_var_after_last()
+                    n = self.pysdd_manager.var_count()
+                    revar = self.pysdd_manager.vars[n]
             else:
                 raise NotImplementedError(f"CPM_pysdd: non-Boolean variable {cpm_var} not supported")
-            self._varmap[cpm_var.name] = revar
+            
+            self._varmap[name] = revar
+            return revar
 
-        return self._varmap[cpm_var.name]
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            return cpm_var
+
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
     def transform(self, cpm_expr):
         """

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -31,7 +31,7 @@ from ..expressions.core import BoolVal, Comparison, Operator
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
 from ..expressions.globalconstraints import DirectConstraint, GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
-from ..expressions.utils import is_num, is_true_cst, is_false_cst
+from ..expressions.utils import is_num, is_int, is_true_cst, is_false_cst
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.flatten_model import flatten_constraint, flatten_objective
 from ..transformations.get_variables import get_variables
@@ -188,27 +188,34 @@ class CPM_scip(SolverInterface):
 
 
     def solver_var(self, cpm_var):
-        if is_num(cpm_var): # shortcut, eases posting constraints
+        """
+            Creates solver variable for cpmpy variable
+            or returns from cache if previously created
+            or returns a constant if the variable is a constant
+        """
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                # special case, negative-bool-view (not supported as first-class var; use 1-bv in constraints)
+                if isinstance(cpm_var, NegBoolView):
+                    raise NotSupportedError(
+                        "Negative literals should not be part of any equation. See /transformations/linearize for more details"
+                    )
+                revar = self.scip_model.addVar(vtype='B', name=name)
+            else:
+                revar = self.scip_model.addVar(lb=cpm_var.lb, ub=cpm_var.ub, vtype='I', name=name)
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
             return cpm_var
 
-        # special case, negative-bool-view (not supported as first-class var; use 1-bv in constraints)
-        if isinstance(cpm_var, NegBoolView):
-            raise NotSupportedError(
-                "Negative literals should not be part of any equation. See /transformations/linearize for more details"
-            )
-
-        # create if it does not exist
-        if cpm_var.name not in self._varmap:
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = self.scip_model.addVar(vtype='B', name=cpm_var.name)
-            elif isinstance(cpm_var, _IntVarImpl):
-                revar = self.scip_model.addVar(lb=cpm_var.lb, ub=cpm_var.ub, vtype='I', name=cpm_var.name)
-            else:
-                raise NotImplementedError("Not a known var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
-
-        # return from cache
-        return self._varmap[cpm_var.name]
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def objective(self, expr, minimize=True):

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -175,6 +175,7 @@ class SolverInterface(object):
         """
            Creates solver variable for cpmpy variable
            or returns from cache if previously created
+           or returns a constant if the variable is a constant
         """
         return None
 

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -271,33 +271,36 @@ class CPM_z3(SolverInterface):
         """
             Creates solver variable for cpmpy variable
             or returns from cache if previously created
+            or returns a constant if the variable is a constant
         """
         import z3
 
-        if is_num(cpm_var): # shortcut, eases posting constraints
-            return cpm_var
+        if isinstance(cpm_var, _NumVarImpl):
 
-        # special case, negative-bool-view
-        # work directly on var inside the view
-        if isinstance(cpm_var, NegBoolView):
-            return z3.Not(self.solver_var(cpm_var._bv))
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
 
-        # create if it does not exit
-        if cpm_var.name not in self._varmap:
-            # we assume al variables are user variables (because nested expressions)
-            self.user_vars.add(cpm_var)
-            if isinstance(cpm_var, _BoolVarImpl):
-                revar = z3.Bool(str(cpm_var))
-            elif isinstance(cpm_var, _IntVarImpl):
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    revar = z3.Not(self.solver_var(cpm_var._bv))
+                else:
+                    revar = z3.Bool(str(cpm_var))
+
+            else:
                 revar = z3.Int(str(cpm_var))
                 # set bounds
                 self.z3_solver.add(revar >= cpm_var.lb)
                 self.z3_solver.add(revar <= cpm_var.ub)
-            else:
-                raise NotImplementedError("Not a know var {}".format(cpm_var))
-            self._varmap[cpm_var.name] = revar
+            self._varmap[name] = revar
+            return revar
 
-        return self._varmap[cpm_var.name]
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            return cpm_var
+
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
 
 
     def has_objective(self):

--- a/tests/test_solverinterface.py
+++ b/tests/test_solverinterface.py
@@ -187,10 +187,9 @@ def test_solver_var(solver):
     
     try:
         solver_bool = solver.solver_var(bool_var)
-        solver_neg_bool = solver.solver_var(neg_bool_var)
-        
-        # Both should return something
         assert solver_bool is not None
+
+        solver_neg_bool = solver.solver_var(neg_bool_var)
         assert solver_neg_bool is not None
     
     except (NotSupportedError, ValueError) as e: # TODO: fix consistency among solvers

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 import numpy as np
 import cpmpy as cp
+from cpmpy.expressions.globalconstraints import GlobalConstraint
 from cpmpy.expressions.utils import argvals
 
 from cpmpy.solvers.pysat import CPM_pysat
@@ -1107,11 +1108,18 @@ class TestSupportedSolvers:
         """
         if solver == 'pysdd':
             pytest.skip(reason=f"{solver} does not support integer decision variables")
+
+        class DummyConstraint(GlobalConstraint):
+            def __init__(self, args):
+                super().__init__("dummy_constraint", tuple(args))
+
+            def decompose(self):
+                return [], []
         
         x = cp.intvar(1, 4, shape=1)
         # Dubious constraint which enforces nothing, gets decomposed to empty list
         # -> resulting CP model is empty
-        m = cp.Model([cp.AllDifferentExceptN([x], 1)])
+        m = cp.Model(DummyConstraint([x]))
         s = cp.SolverLookup().get(solver, m)
         assert len(s.user_vars) == 1 # check if var captured as a user_var
 


### PR DESCRIPTION
As discussed in previous PRs, proposal for a fast path for solver var
Three main things:

1. First check if it is a variable (most common case)
2. Avoid checking for _IntVarImpl and _BoolVarImpl (just do var.is_bool())
3. Use is_int instead of is_num in final check

dev/time_ortools.py reduces from 3.7s post time to 2.7 post time