### PR TITLE
ShortTable decomposition

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -715,6 +715,43 @@ class ShortTable(GlobalConstraint):
         arr, tab = self.args
         return [cp.any([cp.all([ai == ri for ai, ri in zip(arr, row) if ri != STAR]) for row in tab])], []
 
+    def decompose_linear(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Linear-friendly decomposition of the ShortTable global constraint using multiple Tables.
+        These Tables are subsequently decomposed into MDDs, which are eventually decomposed into flow constraints.
+        Returns:
+            tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
+        """
+
+        arr, tab = self.args
+
+        # Group tables by STAR pattern
+        groups: defaultdict[tuple[int, ...], list[list[int]]] = defaultdict(list)
+
+        for row in tab.tolist(): # converts to Python ints
+            # Determine STAR pattern
+            star_pattern = tuple(i for i, val in enumerate(row) if val == STAR)
+            # Only include columns without STAR in the table for this pattern
+            reduced_row: list[int] = [val for val in row if val != STAR]
+            groups[star_pattern].append(reduced_row)
+
+        tables: list[Expression] = []
+        channelling_cons: list[Expression] = []
+        lbs, ubs = get_bounds(arr)
+
+        for pattern, reduced_table in groups.items():
+            # columns we keep (without STAR)
+            cols = [i for i in range(len(arr)) if i not in pattern]
+            # auxiliary variables for the columns we keep, with the same bounds as the original variables
+            aux_arr: list[Expression] = [cp.intvar(lb=lbs[i], ub=ubs[i]) for i in cols]
+            tables.append(Table(aux_arr, reduced_table))
+            # constraints to channel the auxiliary array with the original array
+            channelling_cons.append(cp.all([arr[i] == aux_arr[j] for j, i in enumerate(cols)]))
+
+        # Since the tables use auxiliary variables not used anywhere else, they always admit a solution
+        # The ShortTable constraint is satisfied iff at least one channelling constraint is satisfied
+        return [cp.sum(channelling_cons) != 0], tables
+
     def value(self) -> Optional[bool]:
         """
         Returns:

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -76,7 +76,7 @@ from .normalize import toplevel_list, simplify_boolean
 from ..exceptions import TransformationNotImplementedError
 
 from ..expressions.core import Comparison, Expression, Operator, BoolVal
-from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table
+from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table, ShortTable
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
 from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
@@ -624,7 +624,8 @@ def get_linear_decompositions():
     return dict(
         alldifferent=AllDifferent.decompose_linear,
         element=Element.decompose_linear,
-        table=Table.decompose_linear
+        table=Table.decompose_linear,
+        short_table=ShortTable.decompose_linear
     )
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -170,6 +170,7 @@ def global_constraints(solver):
             yield cp.NegativeTable(NUM_ARGS, [[0, 1, 2], [1, 2, 0], [1, 0, 2]])
         elif name == "ShortTable":
             yield cp.ShortTable(NUM_ARGS, [[0,"*",2], ["*","*",1]])
+            yield cp.ShortTable(cp.intvar(lb=0, ub=3, shape=4),[[0, 1, 2, "*"], ["*", 1, "*", 0], [2, 3, 1, "*"], [1, "*", "*", 2]])
         elif name == "MDD":
             yield cp.MDD(cp.intvar(lb=0, ub=1, shape=3, name="x"), [("r", 0, "n1"), ("n1", 0, "n2"), ("n2", 0, "t")])
             yield cp.MDD(NUM_ARGS, [("r", 0, "n1"), ("r", 1, "n2"), ("r", 2, "n3"), ("n1", 2, "n4"), ("n2", 2, "n4"), ("n3", 0, "n5"),


### PR DESCRIPTION
This branch continues on #981 and implements a linear decomposition of the ShortTable global constraint into Tables, which can then be further decomposed into MDDs.

For every "star pattern" (set of columns in which STAR appears) occurring in the original ShortTable, an auxiliary table is constructed with auxiliary variables, which are channelled back to the original variables. The advantage of this is that in the auxiliary table, the columns containing STAR can be ignored.