### PR TITLE
Selective channeling for Exact

### DIFF
--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -148,6 +148,7 @@ class CPM_exact(SolverInterface):
         self.encoding = None
         self.ivarmap = dict()
         self._channeled_ivars = set()
+        self.reified_channeling_threshold = 1000
 
         # for solving with assumption variables,
         self.assumption_dict = None
@@ -526,7 +527,11 @@ class CPM_exact(SolverInterface):
         cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap, channeling="none")
+        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap,
+                                               ivarmap=self.ivarmap,
+                                               channeling="used",
+                                               channeling_domain_threshold=self.reified_channeling_threshold,
+                                               channeled=self._channeled_ivars)
         cpm_cons = add_intvar_channeling_constraints(cpm_cons,
                                                      self.ivarmap,
                                                      channeled=self._channeled_ivars,

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -60,10 +60,11 @@ from ..expressions.variables import intvar, boolvar, _BoolVarImpl, NegBoolView, 
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.flatten_model import flatten_constraint, flatten_objective
 from ..transformations.get_variables import get_variables
-from ..transformations.linearize import linearize_constraint, only_positive_bv, only_positive_bv_wsum, decompose_linear, decompose_linear_objective, linearize_constraint, linearize_reified_variables
+from ..transformations.linearize import linearize_constraint, only_positive_bv, only_positive_bv_wsum, decompose_linear, decompose_linear_objective, linearize_constraint, linearize_reified_variables, add_intvar_channeling_constraints
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions, safen_objective
+from ..transformations.int2bool import decode_int_varmap, clear_int_varmap_values
 from ..expressions.globalconstraints import DirectConstraint
 from ..expressions.utils import flatlist, argvals, argval, is_any_list, is_num
 from ..exceptions import NotSupportedError
@@ -145,6 +146,8 @@ class CPM_exact(SolverInterface):
 
         # can override encoding of variables
         self.encoding = None
+        self.ivarmap = dict()
+        self._channeled_ivars = set()
 
         # for solving with assumption variables,
         self.assumption_dict = None
@@ -166,6 +169,7 @@ class CPM_exact(SolverInterface):
             self.objective_value_ = None
             for cpm_var in self.user_vars:
                 cpm_var._value = None
+            clear_int_varmap_values(self.ivarmap)
             return
 
         # fill in variable values
@@ -173,6 +177,7 @@ class CPM_exact(SolverInterface):
         exact_vals = self.xct_solver.getLastSolutionFor(self.solver_vars(lst_vars))
         for cpm_var, val in zip(lst_vars,exact_vals):
             cpm_var._value = bool(val) if isinstance(cpm_var, _BoolVarImpl) else val # xct value is always an int
+        decode_int_varmap(self.ivarmap, lambda bv: self.xct_solver.getLastSolutionFor([self.solver_var(bv)])[0])
 
     def solve(self, time_limit:Optional[float]=None, assumptions:Optional[Iterable[_BoolVarImpl]]=None, **kwargs):
         """
@@ -446,7 +451,11 @@ class CPM_exact(SolverInterface):
         obj, flat_cons = flatten_objective(obj, csemap=self._csemap)
         obj = only_positive_bv_wsum(obj)  # remove negboolviews
 
-        self.add(safe_cons + decomp_cons + flat_cons)
+        cons = add_intvar_channeling_constraints(safe_cons + decomp_cons + flat_cons,
+                                                 self.ivarmap,
+                                                 channeled=self._channeled_ivars,
+                                                 extra_exprs=obj)
+        self.add(cons)
 
         # make objective function or variable and post
         xct_cfvars,xct_rhs = self._make_numexpr(obj,0)
@@ -517,7 +526,11 @@ class CPM_exact(SolverInterface):
         cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
         cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
         cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
+        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap, channeling="none")
+        cpm_cons = add_intvar_channeling_constraints(cpm_cons,
+                                                     self.ivarmap,
+                                                     channeled=self._channeled_ivars,
+                                                     extra_exprs=self.objective_ if self.has_objective() else [])
         cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
         cpm_cons = only_implies(cpm_cons, csemap=self._csemap)  # anything that can create full reif should go above...
         cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum","wsum","->","mul"}), csemap=self._csemap)  # the core of the MIP-linearization

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -148,7 +148,6 @@ class CPM_exact(SolverInterface):
         self.encoding = None
         self.ivarmap = dict()
         self._channeled_ivars = set()
-        self.reified_channeling_threshold = 1000
 
         # for solving with assumption variables,
         self.assumption_dict = None
@@ -530,7 +529,6 @@ class CPM_exact(SolverInterface):
         cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap,
                                                ivarmap=self.ivarmap,
                                                channeling="used",
-                                               channeling_domain_threshold=self.reified_channeling_threshold,
                                                channeled=self._channeled_ivars)
         cpm_cons = add_intvar_channeling_constraints(cpm_cons,
                                                      self.ivarmap,

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -64,7 +64,6 @@ from ..transformations.linearize import linearize_constraint, only_positive_bv, 
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions, safen_objective
-from ..transformations.int2bool import decode_int_varmap, clear_int_varmap_values
 from ..expressions.globalconstraints import DirectConstraint
 from ..expressions.utils import flatlist, argvals, argval, is_any_list, is_num, is_int
 from ..exceptions import NotSupportedError
@@ -169,7 +168,10 @@ class CPM_exact(SolverInterface):
             self.objective_value_ = None
             for cpm_var in self.user_vars:
                 cpm_var._value = None
-            clear_int_varmap_values(self.ivarmap)
+            for enc in self.ivarmap.values():
+                enc._x._value = None
+                for bv in enc.vars():
+                    bv._value = None
             return
 
         # fill in variable values
@@ -177,7 +179,11 @@ class CPM_exact(SolverInterface):
         exact_vals = self.xct_solver.getLastSolutionFor(self.solver_vars(lst_vars))
         for cpm_var, val in zip(lst_vars,exact_vals):
             cpm_var._value = bool(val) if isinstance(cpm_var, _BoolVarImpl) else val # xct value is always an int
-        decode_int_varmap(self.ivarmap, lambda bv: self.xct_solver.getLastSolutionFor([self.solver_var(bv)])[0])
+        for enc in self.ivarmap.values():
+            for bv in enc.vars():
+                val = self.xct_solver.getLastSolutionFor([self.solver_var(bv)])[0]
+                bv._value = None if val is None else bool(val)
+            enc._x._value = enc.decode()
 
     def solve(self, time_limit:Optional[float]=None, assumptions:Optional[Iterable[_BoolVarImpl]]=None, **kwargs):
         """

--- a/cpmpy/transformations/int2bool.py
+++ b/cpmpy/transformations/int2bool.py
@@ -479,23 +479,3 @@ def replace_int_user_vars(user_vars, ivarmap):
     return bool_user_vars
 
 
-def decode_int_varmap(ivarmap, value_of):
-    """Decode all integer variables in ``ivarmap`` from their encoding variables.
-
-    ``value_of`` is a callable that maps a CPMpy Boolean variable to its solver
-    value. The helper first fills the encoding Boolean values, then uses the
-    encoding's decode method to set the integer variable value.
-    """
-    for enc in ivarmap.values():
-        for bv in enc.vars():
-            val = value_of(bv)
-            bv._value = None if val is None else bool(val)
-        enc._x._value = enc.decode()
-
-
-def clear_int_varmap_values(ivarmap):
-    """Clear values of all integer variables and encoding Booleans in ``ivarmap``."""
-    for enc in ivarmap.values():
-        enc._x._value = None
-        for bv in enc.vars():
-            bv._value = None

--- a/cpmpy/transformations/int2bool.py
+++ b/cpmpy/transformations/int2bool.py
@@ -477,3 +477,25 @@ def replace_int_user_vars(user_vars, ivarmap):
             # extends set with encoding variables of `x`
             bool_user_vars.update(ivarmap[x.name].vars())
     return bool_user_vars
+
+
+def decode_int_varmap(ivarmap, value_of):
+    """Decode all integer variables in ``ivarmap`` from their encoding variables.
+
+    ``value_of`` is a callable that maps a CPMpy Boolean variable to its solver
+    value. The helper first fills the encoding Boolean values, then uses the
+    encoding's decode method to set the integer variable value.
+    """
+    for enc in ivarmap.values():
+        for bv in enc.vars():
+            val = value_of(bv)
+            bv._value = None if val is None else bool(val)
+        enc._x._value = enc.decode()
+
+
+def clear_int_varmap_values(ivarmap):
+    """Clear values of all integer variables and encoding Booleans in ``ivarmap``."""
+    for enc in ivarmap.values():
+        enc._x._value = None
+        for bv in enc.vars():
+            bv._value = None

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -67,7 +67,7 @@ Optional post-linearisation transformations:
 """
 
 import copy
-from typing import AbstractSet, Sequence, Optional
+from typing import AbstractSet, Any, Mapping, MutableSet, Sequence, Optional
 
 import cpmpy as cp
 import numpy as np
@@ -79,7 +79,7 @@ from .decompose_global import decompose_in_tree, decompose_objective
 from .normalize import toplevel_list, simplify_boolean
 from ..exceptions import TransformationNotImplementedError
 
-from ..expressions.core import Comparison, Expression, Operator, BoolVal
+from ..expressions.core import BoolExprLike, Comparison, Expression, ExprLike, Operator, BoolVal
 from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
@@ -782,7 +782,9 @@ def _extract_var_from_lhs(lhs):
     return None
 
 
-def _used_encoded_intvars(exprs, ivarmap, channeled=None):
+def _used_encoded_intvars(exprs: Sequence[ExprLike],
+                          ivarmap: Mapping[str, IntVarEnc],
+                          channeled: Optional[AbstractSet[str]] = None) -> list[_NumVarImpl]:
     """Return native integer variables in ``exprs`` that have unchanneled encodings.
 
     Encoded Boolean variables do not count as use of the original integer
@@ -798,9 +800,9 @@ def _used_encoded_intvars(exprs, ivarmap, channeled=None):
     if not candidates:
         return []
 
-    found = {}
+    found: dict[str, _NumVarImpl] = {}
 
-    def extract(lst):
+    def extract(lst: Any) -> None:
         for e in lst:
             if not candidates:
                 return
@@ -825,7 +827,10 @@ def _used_encoded_intvars(exprs, ivarmap, channeled=None):
     return list(found.values())
 
 
-def add_intvar_channeling_constraints(constraints, ivarmap, channeled=None, extra_exprs=None):
+def add_intvar_channeling_constraints(constraints: Sequence[BoolExprLike],
+                                      ivarmap: Mapping[str, IntVarEnc],
+                                      channeled: Optional[MutableSet[str]] = None,
+                                      extra_exprs: Optional[ExprLike | Sequence[ExprLike]] = None) -> list[BoolExprLike]:
     """
     Add value-channeling constraints for encoded integer vars used in expressions.
     Needed when a solver uses both an encoding of a intvar and an encoding thereof.

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -676,7 +676,6 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     toplevel = []
     bv_map = {}  # bv -> (var, val)
     enc_map = {}  # var -> encoding
-    channeling_mode = {}
     for var, vals in var_vals.items():
         # check if we should linearize the reified variables
         lb, ub = var.lb, var.ub
@@ -687,12 +686,10 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         # encode the values
         enc, domain_constraint = _encode_int_var(my_ivarmap, var, "direct", csemap=csemap)
         enc_map[var] = enc
-        mode = channeling
-        channeling_mode[var] = mode
         
         # domain and channeling constraints
         toplevel.extend(domain_constraint) # with the overwritten Bools
-        if mode == "all" and (channeled is None or var.name not in channeled):
+        if channeling == "all" and (channeled is None or var.name not in channeled):
             # also post the var=wsum mapping
             terms, k = enc.encode_term()
             # var == wsum + k :: var - wsum == k
@@ -722,7 +719,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         constraints = newcons
 
     if channeling == "used":
-        used_encodings = {var.name: enc for var, enc in enc_map.items() if channeling_mode[var] == "used"}
+        used_encodings = {var.name: enc for var, enc in enc_map.items()}
         for var in _used_encoded_intvars(constraints, used_encodings, channeled=channeled):
             terms, k = used_encodings[var.name].encode_term()
             ws = [1] + [-w for (w, _) in terms]

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -33,6 +33,8 @@ To get a good linearisation, solver backends typically apply these transformatio
 - Put constraints in flat normal form (:func:`~cpmpy.transformations.flatten_model.flatten_constraint`).
 - Apply :func:`linearize_reified_variables` to replace reified equalities of the form
   ``bv == (x == val)`` by a single direct encoding of ``x`` (must be done before implication-only normalisation).
+- If an external ``ivarmap`` is used and encoded integer variables still occur as integer variables,
+  add the required ``x == encoded(x)`` links with :func:`add_intvar_channeling_constraints`.
 - Ensure implications are of the form ``bv -> <expr>`` (:func:`~cpmpy.transformations.reification.only_implies`).
 - Call :func:`linearize_constraint` to transform the inequalities, strict equalities and implications.
 - Optionally run post-passes such as :func:`only_positive_bv` (e.g. for ILP solvers that do not support NegBoolView)
@@ -51,6 +53,7 @@ Main transformations:
 Helper functions:
 - :func:`canonical_comparison`: Canonicalize comparison expressions (variables on left, constants on right).
 - :func:`get_linear_decompositions`: Returns the custom linear decomposition map for global constraints.
+- :func:`add_intvar_channeling_constraints`: Adds channeling constraints for encoded integer variables stored in an ``ivarmap``.
 
 Optional post-linearisation transformations:
 - :func:`only_positive_bv`: Transforms constraints so only :class:`~cpmpy.expressions.variables._BoolVarImpl` variables appear positively

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -83,7 +83,7 @@ from ..expressions.core import BoolExprLike, Comparison, Expression, ExprLike, O
 from ..expressions.globalconstraints import GlobalConstraint, DirectConstraint, AllDifferent, Table
 from ..expressions.globalfunctions import GlobalFunction, Element
 from ..expressions.utils import is_bool, is_num, is_int, eval_comparison, get_bounds, is_true_cst, is_false_cst
-from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _NumVarImpl
+from ..expressions.variables import _BoolVarImpl, boolvar, NegBoolView, _IntVarImpl, _NumVarImpl
 from .int2bool import IntVarEnc, _encode_int_var
 
 
@@ -784,7 +784,7 @@ def _extract_var_from_lhs(lhs):
 
 def _used_encoded_intvars(exprs: Sequence[ExprLike],
                           ivarmap: Mapping[str, IntVarEnc],
-                          channeled: Optional[AbstractSet[str]] = None) -> list[_NumVarImpl]:
+                          channeled: Optional[AbstractSet[str]] = None) -> list[_IntVarImpl]:
     """Return native integer variables in ``exprs`` that have unchanneled encodings.
 
     Encoded Boolean variables do not count as use of the original integer
@@ -800,7 +800,7 @@ def _used_encoded_intvars(exprs: Sequence[ExprLike],
     if not candidates:
         return []
 
-    found: dict[str, _NumVarImpl] = {}
+    found: dict[str, _IntVarImpl] = {}
 
     def extract(lst: Any) -> None:
         for e in lst:
@@ -808,7 +808,7 @@ def _used_encoded_intvars(exprs: Sequence[ExprLike],
                 return
 
             if isinstance(e, Expression):
-                if isinstance(e, _NumVarImpl):
+                if isinstance(e, _IntVarImpl):
                     if not e.is_bool() and e.name in candidates:
                         found[e.name] = e
                         candidates.remove(e.name)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -637,19 +637,20 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     has at least min_values such reifications: remove those implications and add
     the 'direct' encoding of x.
 
-    If ivarmap is None, both sum(bvs)==1 and wsum(values, bvs)==var are posted.
-    If ivarmap is not None, the encoding is added to ivarmap and only sum(bvs)==1
-    (the domain constraint) is posted by default; the solver can then choose to
-    eliminate the vars, decode the vars from the encoding, or post the wsums itself
-    anyway.
+    The domain constraints for the encoding are always posted. Channeling
+    constraints link the native integer variable to its Boolean encoding; they
+    may be skipped only when a later solver transformation owns that link, e.g.
+    by replacing the integer variable with its encoding.
 
     The ``channeling`` argument controls when to post the wsum channeling constraints:
     - ``"all"``: post them for every encoded integer variable
-    - ``"none"``: post none of them
+    - ``"none"``: post none; the caller must add/replace/decode from ``ivarmap``
     - ``"used"``: post them only if the integer variable still occurs after the
       reified equalities have been removed
-    - ``None``: preserve historical behavior, ``"all"`` when ``ivarmap`` is
-      ``None`` and ``"none"`` otherwise
+    - ``None``: use the default for the selected ownership model: post all
+      channeling constraints when this function owns the encoding map
+      (``ivarmap is None``), and leave channeling to the caller when an
+      external ``ivarmap`` is provided
 
     If ``channeled`` is provided, it is treated as a set of integer variable
     names that already have channeling constraints. Newly created channeling
@@ -695,7 +696,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
             # var == wsum + k :: var - wsum == k
             ws = [1] + [-w for (w, _) in terms]
             bs = [var] + [b for (_, b) in terms]
-            toplevel.append(Operator("wsum", (ws, bs)) == k)  
+            toplevel.append(Operator("wsum", (ws, bs)) == k)
             if channeled is not None:
                 channeled.add(var.name)
         

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -628,7 +628,8 @@ def get_linear_decompositions():
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 
 
-def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None, channeling=None):
+def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None, channeling=None,
+                                channeling_domain_threshold=None, channeled=None):
     """
     Replace reified (BV <-> (x == val)) implications with direct encoding when a variable
     has at least min_values such reifications: remove those implications and add
@@ -648,6 +649,13 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     - ``None``: preserve historical behavior, ``"all"`` when ``ivarmap`` is
       ``None`` and ``"none"`` otherwise
 
+    If ``channeling_domain_threshold`` is set with ``channeling="used"``, then
+    variables with a smaller domain are still fully channeled.
+
+    If ``channeled`` is provided, it is treated as a set of integer variable
+    names that already have channeling constraints. Newly created channeling
+    constraints are recorded in that set.
+
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
     """
     # this transformation can only be done if there is a csemap
@@ -666,6 +674,7 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     toplevel = []
     bv_map = {}  # bv -> (var, val)
     enc_map = {}  # var -> encoding
+    channeling_mode = {}
     for var, vals in var_vals.items():
         # check if we should linearize the reified variables
         lb, ub = var.lb, var.ub
@@ -676,16 +685,22 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         # encode the values
         enc, domain_constraint = _encode_int_var(my_ivarmap, var, "direct", csemap=csemap)
         enc_map[var] = enc
+        mode = channeling
+        if mode == "used" and channeling_domain_threshold is not None and var.ub + 1 - var.lb < channeling_domain_threshold:
+            mode = "all"
+        channeling_mode[var] = mode
         
         # domain and channeling constraints
         toplevel.extend(domain_constraint) # with the overwritten Bools
-        if channeling == "all":
+        if mode == "all" and (channeled is None or var.name not in channeled):
             # also post the var=wsum mapping
             terms, k = enc.encode_term()
             # var == wsum + k :: var - wsum == k
             ws = [1] + [-w for (w, _) in terms]
             bs = [var] + [b for (_, b) in terms]
             toplevel.append(Operator("wsum", (ws, bs)) == k)  
+            if channeled is not None:
+                channeled.add(var.name)
         
         # store the bvs that no longer need to be reified
         for val, bv in vals:
@@ -709,11 +724,13 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     if channeling == "used":
         used_vars = get_variables(constraints)
         for var, enc in enc_map.items():
-            if var in used_vars:
+            if channeling_mode[var] == "used" and var in used_vars and (channeled is None or var.name not in channeled):
                 terms, k = enc.encode_term()
                 ws = [1] + [-w for (w, _) in terms]
                 bs = [var] + [b for (_, b) in terms]
                 toplevel.append(Operator("wsum", (ws, bs)) == k)
+                if channeled is not None:
+                    channeled.add(var.name)
 
     return constraints + toplevel
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -684,24 +684,6 @@ def linearize_reified_variables(constraints:list[Expression],
     my_ivarmap = ivarmap if ivarmap is not None else {}
     var_vals, var_bounds = csemap.get_reified_varvalbounds()
 
-    current_bvs = set()
-
-    def collect_bvs(exprs):
-        for expr in exprs:
-            if isinstance(expr, _BoolVarImpl):
-                current_bvs.add(expr)
-                current_bvs.add(~expr)
-            elif isinstance(expr, _NumVarImpl):
-                continue
-            elif isinstance(expr, Expression):
-                collect_bvs(expr.args)
-            elif isinstance(expr, np.ndarray) and expr.dtype == object:
-                collect_bvs(expr.flat)
-            elif isinstance(expr, (list, tuple, np.flatiter)):
-                collect_bvs(expr)
-
-    collect_bvs(constraints)
-
     # decide the encoding to use for each variable
     var_encodings = dict() # var -> (encoding, vals)
     candidate_vars = list(var_vals) + [var for var in var_bounds if var not in var_vals]
@@ -712,11 +694,11 @@ def linearize_reified_variables(constraints:list[Expression],
 
         direct_vals = [
             (val, bv) for val, bv in var_vals.get(var, [])
-            if lb <= val <= ub and bv in current_bvs
+            if lb <= val <= ub
         ]  # only the valid values, in bounds!
         order_vals = [
             (val, bv) for val, bv in var_bounds.get(var, [])
-            if lb < val <= ub and bv in current_bvs
+            if lb < val <= ub
         ]  # only the valid values, exclude lb
 
         if len(direct_vals) >= len(order_vals):

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -652,9 +652,8 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
       (``ivarmap is None``), and leave channeling to the caller when an
       external ``ivarmap`` is provided
 
-    If ``channeled`` is provided, it is treated as a set of integer variable
-    names that already have channeling constraints. Newly created channeling
-    constraints are recorded in that set.
+    ``channeled`` is an optional set of variable names that have already been encoded.
+
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
     """
@@ -787,20 +786,15 @@ def _used_encoded_intvars(exprs, ivarmap, channeled=None):
 
 
 def add_intvar_channeling_constraints(constraints, ivarmap, channeled=None, extra_exprs=None):
-    """Add value-channeling constraints for encoded integer vars used in expressions.
-
-    This is useful for solvers that keep native integer variables but also use
-    direct encodings for repeated reified equalities. If an encoded integer
-    variable later appears in a native numeric expression, the native variable
-    must be linked to its Boolean encoding.
+    """
+    Add value-channeling constraints for encoded integer vars used in expressions.
+    Needed when a solver uses both an encoding of a intvar and an encoding thereof.
 
     ``constraints`` is returned with the necessary channeling constraints
     appended. ``extra_exprs`` can be used to inspect expressions that are not in
     the returned constraint list, such as an objective.
 
-    If ``channeled`` is provided, it is treated as a set of integer variable
-    names that already have channeling constraints. Newly created channeling
-    constraints are recorded in that set.
+    ``channeled`` is an optional set of variable names that have already been encoded.
     """
     constraints = list(constraints)
     exprs = constraints if extra_exprs is None else constraints + (extra_exprs if isinstance(extra_exprs, list) else [extra_exprs])

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -67,6 +67,7 @@ import copy
 from typing import AbstractSet, Sequence, Optional
 
 import cpmpy as cp
+import numpy as np
 from cpmpy.transformations.get_variables import get_variables
 from .cse import CSEMap
 
@@ -722,15 +723,14 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         constraints = newcons
 
     if channeling == "used":
-        used_vars = get_variables(constraints)
-        for var, enc in enc_map.items():
-            if channeling_mode[var] == "used" and var in used_vars and (channeled is None or var.name not in channeled):
-                terms, k = enc.encode_term()
-                ws = [1] + [-w for (w, _) in terms]
-                bs = [var] + [b for (_, b) in terms]
-                toplevel.append(Operator("wsum", (ws, bs)) == k)
-                if channeled is not None:
-                    channeled.add(var.name)
+        used_encodings = {var.name: enc for var, enc in enc_map.items() if channeling_mode[var] == "used"}
+        for var in _used_encoded_intvars(constraints, used_encodings, channeled=channeled):
+            terms, k = used_encodings[var.name].encode_term()
+            ws = [1] + [-w for (w, _) in terms]
+            bs = [var] + [b for (_, b) in terms]
+            toplevel.append(Operator("wsum", (ws, bs)) == k)
+            if channeled is not None:
+                channeled.add(var.name)
 
     return constraints + toplevel
 
@@ -744,6 +744,49 @@ def _extract_var_from_lhs(lhs):
         if isinstance(arg, _NumVarImpl) and not arg.is_bool():
             return arg
     return None
+
+
+def _used_encoded_intvars(exprs, ivarmap, channeled=None):
+    """Return native integer variables in ``exprs`` that have unchanneled encodings.
+
+    Encoded Boolean variables do not count as use of the original integer
+    variable. The scan stops once every unchanneled candidate from ``ivarmap``
+    has been found.
+    """
+    if not ivarmap:
+        return []
+
+    candidates = set(ivarmap)
+    if channeled is not None:
+        candidates.difference_update(channeled)
+    if not candidates:
+        return []
+
+    found = {}
+
+    def extract(lst):
+        for e in lst:
+            if not candidates:
+                return
+
+            if isinstance(e, Expression):
+                if isinstance(e, _NumVarImpl):
+                    if not e.is_bool() and e.name in candidates:
+                        found[e.name] = e
+                        candidates.remove(e.name)
+                elif e.name == "wsum":
+                    extract(e.args[1])  # skip data in arg0
+                elif e.name == "table":
+                    extract(e.args[0])  # skip data in arg1
+                else:
+                    extract(e.args)
+            elif isinstance(e, np.ndarray) and e.dtype == object:
+                extract(e.flat)
+            elif isinstance(e, (list, tuple, np.flatiter)):
+                extract(e)
+
+    extract((exprs,))
+    return list(found.values())
 
 
 def add_intvar_channeling_constraints(constraints, ivarmap, channeled=None, extra_exprs=None):
@@ -764,12 +807,11 @@ def add_intvar_channeling_constraints(constraints, ivarmap, channeled=None, extr
     """
     constraints = list(constraints)
     exprs = constraints if extra_exprs is None else constraints + (extra_exprs if isinstance(extra_exprs, list) else [extra_exprs])
-    for var in get_variables(exprs):
-        if isinstance(var, _NumVarImpl) and not var.is_bool() and var.name in ivarmap and (channeled is None or var.name not in channeled):
-            terms, k = ivarmap[var.name].encode_term()
-            ws = [1] + [-w for (w, _) in terms]
-            bs = [var] + [b for (_, b) in terms]
-            constraints.append(Operator("wsum", (ws, bs)) == k)
-            if channeled is not None:
-                channeled.add(var.name)
+    for var in _used_encoded_intvars(exprs, ivarmap, channeled=channeled):
+        terms, k = ivarmap[var.name].encode_term()
+        ws = [1] + [-w for (w, _) in terms]
+        bs = [var] + [b for (_, b) in terms]
+        constraints.append(Operator("wsum", (ws, bs)) == k)
+        if channeled is not None:
+            channeled.add(var.name)
     return constraints

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -628,7 +628,7 @@ def get_linear_decompositions():
     # Should we add Gleb's table decomposition? or is it not non-reifiable?
 
 
-def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None):
+def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None, channeling=None):
     """
     Replace reified (BV <-> (x == val)) implications with direct encoding when a variable
     has at least min_values such reifications: remove those implications and add
@@ -636,8 +636,17 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
 
     If ivarmap is None, both sum(bvs)==1 and wsum(values, bvs)==var are posted.
     If ivarmap is not None, the encoding is added to ivarmap and only sum(bvs)==1
-    (the domain constraint) is posted; the solver can then choose to eliminate the
-    vars, or post the wsums itself anyway.
+    (the domain constraint) is posted by default; the solver can then choose to
+    eliminate the vars, decode the vars from the encoding, or post the wsums itself
+    anyway.
+
+    The ``channeling`` argument controls when to post the wsum channeling constraints:
+    - ``"all"``: post them for every encoded integer variable
+    - ``"none"``: post none of them
+    - ``"used"``: post them only if the integer variable still occurs after the
+      reified equalities have been removed
+    - ``None``: preserve historical behavior, ``"all"`` when ``ivarmap`` is
+      ``None`` and ``"none"`` otherwise
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
     """
@@ -645,12 +654,18 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
     if csemap is None:
         return constraints
 
+    if channeling is None:
+        channeling = "all" if ivarmap is None else "none"
+    if channeling not in {"all", "none", "used"}:
+        raise ValueError(f"Unsupported channeling mode {channeling!r}, expected 'all', 'none', or 'used'")
+
     var_vals = csemap.get_reified_varvals()
     
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
     toplevel = []
     bv_map = {}  # bv -> (var, val)
+    enc_map = {}  # var -> encoding
     for var, vals in var_vals.items():
         # check if we should linearize the reified variables
         lb, ub = var.lb, var.ub
@@ -660,10 +675,11 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
 
         # encode the values
         enc, domain_constraint = _encode_int_var(my_ivarmap, var, "direct", csemap=csemap)
+        enc_map[var] = enc
         
         # domain and channeling constraints
         toplevel.extend(domain_constraint) # with the overwritten Bools
-        if ivarmap is None:
+        if channeling == "all":
             # also post the var=wsum mapping
             terms, k = enc.encode_term()
             # var == wsum + k :: var - wsum == k
@@ -690,6 +706,15 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
             newcons.append(con)
         constraints = newcons
 
+    if channeling == "used":
+        used_vars = get_variables(constraints)
+        for var, enc in enc_map.items():
+            if var in used_vars:
+                terms, k = enc.encode_term()
+                ws = [1] + [-w for (w, _) in terms]
+                bs = [var] + [b for (_, b) in terms]
+                toplevel.append(Operator("wsum", (ws, bs)) == k)
+
     return constraints + toplevel
 
 
@@ -702,3 +727,32 @@ def _extract_var_from_lhs(lhs):
         if isinstance(arg, _NumVarImpl) and not arg.is_bool():
             return arg
     return None
+
+
+def add_intvar_channeling_constraints(constraints, ivarmap, channeled=None, extra_exprs=None):
+    """Add value-channeling constraints for encoded integer vars used in expressions.
+
+    This is useful for solvers that keep native integer variables but also use
+    direct encodings for repeated reified equalities. If an encoded integer
+    variable later appears in a native numeric expression, the native variable
+    must be linked to its Boolean encoding.
+
+    ``constraints`` is returned with the necessary channeling constraints
+    appended. ``extra_exprs`` can be used to inspect expressions that are not in
+    the returned constraint list, such as an objective.
+
+    If ``channeled`` is provided, it is treated as a set of integer variable
+    names that already have channeling constraints. Newly created channeling
+    constraints are recorded in that set.
+    """
+    constraints = list(constraints)
+    exprs = constraints if extra_exprs is None else constraints + (extra_exprs if isinstance(extra_exprs, list) else [extra_exprs])
+    for var in get_variables(exprs):
+        if isinstance(var, _NumVarImpl) and not var.is_bool() and var.name in ivarmap and (channeled is None or var.name not in channeled):
+            terms, k = ivarmap[var.name].encode_term()
+            ws = [1] + [-w for (w, _) in terms]
+            bs = [var] + [b for (_, b) in terms]
+            constraints.append(Operator("wsum", (ws, bs)) == k)
+            if channeled is not None:
+                channeled.add(var.name)
+    return constraints

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -630,7 +630,7 @@ def get_linear_decompositions():
 
 
 def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=None, channeling=None,
-                                channeling_domain_threshold=None, channeled=None):
+                                channeled=None):
     """
     Replace reified (BV <-> (x == val)) implications with direct encoding when a variable
     has at least min_values such reifications: remove those implications and add
@@ -649,9 +649,6 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
       reified equalities have been removed
     - ``None``: preserve historical behavior, ``"all"`` when ``ivarmap`` is
       ``None`` and ``"none"`` otherwise
-
-    If ``channeling_domain_threshold`` is set with ``channeling="used"``, then
-    variables with a smaller domain are still fully channeled.
 
     If ``channeled`` is provided, it is treated as a set of integer variable
     names that already have channeling constraints. Newly created channeling
@@ -687,8 +684,6 @@ def linearize_reified_variables(constraints, min_values=3, csemap=None, ivarmap=
         enc, domain_constraint = _encode_int_var(my_ivarmap, var, "direct", csemap=csemap)
         enc_map[var] = enc
         mode = channeling
-        if mode == "used" and channeling_domain_threshold is not None and var.ub + 1 - var.lb < channeling_domain_threshold:
-            mode = "all"
         channeling_mode[var] = mode
         
         # domain and channeling constraints

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -546,6 +546,22 @@ class TestSolvers:
         s = cp.SolverLookup.get("exact", m)
         assert s.solveAll(display=_trixor_callback) ==7
 
+    @pytest.mark.skipif(not CPM_exact.supported(),
+                        reason="Exact not installed")
+    def test_exact_decodes_unchanneled_reified_int(self):
+        a = cp.intvar(1, 3, name="a")
+        assert cp.Model((a == 1) | (a == 2)).solve(solver="exact")
+        assert a.value() in (1, 2)
+
+    @pytest.mark.skipif(not CPM_exact.supported(),
+                        reason="Exact not installed")
+    def test_exact_channels_encoded_int_used_in_objective(self):
+        a = cp.intvar(1, 3, name="a")
+        model = cp.Model((a == 1) | (a == 2), maximize=a)
+        assert model.solve(solver="exact")
+        assert a.value() == 2
+        assert model.objective_value() == 2
+
     @pytest.mark.skipif(not CPM_exact.supported(), 
                         reason="Exact not installed")
     def test_parameters_to_exact(self):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -742,7 +742,7 @@ class TestLinearizeReifiedVariablesThreshold:
         out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == str(cpm_cons)
 
-    def test_linearize_non_ocurring_int_var(self):
+    def test_linearize_non_ocurring_int_var_direct(self):
         """For an integer solver, we can omit the channelling constraint if the encoded integer variable does not occur in any constraint. Note: `a` and `b` are encoded (because at least 2 equality reifications occur), `c` is not encoded (no reifications). We see `b` occurs as an integer variable in a constraint, so channelling is required, but the int var `a` does not occur in any constraint, so no channelling is required. `c` is not encoded."""
         b, c = cp.intvar(1, 3, name="b"), cp.intvar(1, 3, name="c")
         out = linearize_reified_variables(
@@ -754,3 +754,18 @@ class TestLinearizeReifiedVariablesThreshold:
         )
         assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), (BV[b == 1]) or (BV[b == 2]), (b) + (c) == 3, sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1, sum(BV[b == 1], BV[b == 2], BV[b == 3]) == 1, sum([1, 0, -1, -2] * [b, BV[b == 1], BV[b == 2], BV[b == 3]]) == 1]", "The `a` var does occur"
 
+    def test_linearize_non_ocurring_int_var_order(self):
+        """For an integer solver, we can omit the channelling constraint if the encoded integer variable does not occur in any constraint. Note: `a` and `b` are encoded (because at least 2 equality reifications occur), `c` is not encoded (no reifications). We see `b` occurs as an integer variable in a constraint, so channelling is required, but the int var `a` does not occur in any constraint, so no channelling is required. `c` is not encoded."""
+        a = self.a
+        self.csemap = CSEMap()
+        cpm_cons = self.linearize((a < 1) | (a <= 2))
+        
+        b, c = cp.intvar(1, 3, name="b"), cp.intvar(1, 3, name="c")
+        out = linearize_reified_variables(
+            self.cpm_cons + self.linearize([(b > 2) | (b <= 1), b + c == 3]),
+            min_values=2,
+            csemap=self.csemap,
+            ivarmap=self.ivarmap,
+            channeling="used",
+        )
+        assert str(out) == "[(BV0) or (BV1), (a == 1) == (BV0), (a == 2) == (BV1), (BV[b >= 3]) or (~BV[b >= 2]), (b) + (c) == 3, (BV[b >= 3]) -> (BV[b >= 2]), sum([1, -1, -1] * [b, BV[b >= 2], BV[b >= 3]]) == 1]", "The `a` var does occur"

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -734,7 +734,7 @@ class TestLinearizeReifiedVariablesThreshold:
         assert str(order_out) == "[(BV[a >= 2]) or (BV[a >= 3]), (BV[a >= 3]) -> (BV[a >= 2])]"
         assert str(direct_out) == str(cpm_cons)
     
-    def test_linearize_reified_inequalities_variations(self):
+    def test_linearize_reified_inequalities_not_enough(self):
         """Do not order-encode when only one non-tautological threshold remains."""
         a = self.a
         self.csemap = CSEMap()

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -737,6 +737,7 @@ class TestLinearizeReifiedVariablesThreshold:
     def test_linearize_reified_inequalities_variations(self):
         """Do not order-encode when only one non-tautological threshold remains."""
         a = self.a
+        self.csemap = CSEMap()
         cpm_cons = self.linearize((a < 1) | (a <= 2))
         out = linearize_reified_variables(cpm_cons, min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == str(cpm_cons)

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -677,22 +677,3 @@ class TestLinearizeReifiedVariablesThreshold:
         )
         assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), (BV[b == 1]) or (BV[b == 2]), (b) + (c) == 3, sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1, sum(BV[b == 1], BV[b == 2], BV[b == 3]) == 1, sum([1, 0, -1, -2] * [b, BV[b == 1], BV[b == 2], BV[b == 3]]) == 1]", "The `a` var does occur"
 
-    def test_exact_decodes_unchanneled_reified_int(self):
-        from cpmpy.solvers import CPM_exact
-        if not CPM_exact.supported():
-            pytest.skip("Exact not installed")
-
-        a = cp.intvar(1, 3, name="a")
-        assert cp.Model((a == 1) | (a == 2)).solve(solver="exact")
-        assert a.value() in (1, 2)
-
-    def test_exact_channels_encoded_int_used_in_objective(self):
-        from cpmpy.solvers import CPM_exact
-        if not CPM_exact.supported():
-            pytest.skip("Exact not installed")
-
-        a = cp.intvar(1, 3, name="a")
-        model = cp.Model((a == 1) | (a == 2), maximize=a)
-        assert model.solve(solver="exact")
-        assert a.value() == 2
-        assert model.objective_value() == 2

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -657,6 +657,8 @@ class TestLinearizeReifiedVariablesThreshold:
         out = linearize_reified_variables(self.linearize((a >= 1) | (a >= 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == "[(BV[a >= 1]) or (BV[a >= 2]), sum([1, -1] * (BV[a >= 2], BV[a >= 1])) <= 0, sum([1, -1] * (BV[a >= 3], BV[a >= 2])) <= 0]"
     
+    
+    @pytest.mark.xfail(reason="aspirational")
     def test_linearize_reified_inequalities_variations(self):
         """Use order encoding on inequalities and replace other types of inequality expressions"""
         a = self.a

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -665,10 +665,34 @@ class TestLinearizeReifiedVariablesThreshold:
         out = linearize_reified_variables(self.linearize((a < 1) | (a <= 2) | (a > 2)), min_values=2, csemap=self.csemap, ivarmap=self.ivarmap)
         assert str(out) == "[(~BV[a >= 1]) or (~BV[a >= 3]) or (BV[a >= 3]), sum([1, -1] * (BV[a >= 2], BV[a >= 1])) <= 0, sum([1, -1] * (BV[a >= 3], BV[a >= 2])) <= 0]"
 
-    @pytest.mark.xfail(reason="aspirational")
     def test_linearize_non_ocurring_int_var(self):
         """For an integer solver, we can omit the channelling constraint if the encoded integer variable does not occur in any constraint. Note: `a` and `b` are encoded (because at least 2 equality reifications occur), `c` is not encoded (no reifications). We see `b` occurs as an integer variable in a constraint, so channelling is required, but the int var `a` does not occur in any constraint, so no channelling is required. `c` is not encoded."""
         b, c = cp.intvar(1, 3, name="b"), cp.intvar(1, 3, name="c")
-        out = linearize_reified_variables(self.cpm_cons + self.linearize([(b == 1) | (b == 2), b + c == 3]), min_values=2, csemap=self.csemap)
-        assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), (BV[b == 1]) or (BV[b == 2]), (b) + (c) == 3, sum([BV[a == 1], BV[a == 2], BV[a == 3]]) == 1, sum([BV[b == 1], BV[b == 2], BV[b == 3]]) == 1, sum([1, 0, -1, -2] * [b, BV[b == 1], BV[b == 2], BV[b == 3]]) == 1]", "The `a` var does occur"
+        out = linearize_reified_variables(
+            self.cpm_cons + self.linearize([(b == 1) | (b == 2), b + c == 3]),
+            min_values=2,
+            csemap=self.csemap,
+            ivarmap=self.ivarmap,
+            channeling="used",
+        )
+        assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), (BV[b == 1]) or (BV[b == 2]), (b) + (c) == 3, sum(BV[a == 1], BV[a == 2], BV[a == 3]) == 1, sum(BV[b == 1], BV[b == 2], BV[b == 3]) == 1, sum([1, 0, -1, -2] * [b, BV[b == 1], BV[b == 2], BV[b == 3]]) == 1]", "The `a` var does occur"
 
+    def test_exact_decodes_unchanneled_reified_int(self):
+        from cpmpy.solvers import CPM_exact
+        if not CPM_exact.supported():
+            pytest.skip("Exact not installed")
+
+        a = cp.intvar(1, 3, name="a")
+        assert cp.Model((a == 1) | (a == 2)).solve(solver="exact")
+        assert a.value() in (1, 2)
+
+    def test_exact_channels_encoded_int_used_in_objective(self):
+        from cpmpy.solvers import CPM_exact
+        if not CPM_exact.supported():
+            pytest.skip("Exact not installed")
+
+        a = cp.intvar(1, 3, name="a")
+        model = cp.Model((a == 1) | (a == 2), maximize=a)
+        assert model.solve(solver="exact")
+        assert a.value() == 2
+        assert model.objective_value() == 2


### PR DESCRIPTION
When an integer variable is encoded (for now only directly, but with #994 this can also be orderly) a solver without an ivarmap (so any non-SAT solver) will post both defining ```sum(bvs) == 1``` as well as channeling ```wsum(ws, bvs) == iv``` to the solver. However, the channeling constraints are not necessary when the ```iv``` is not actually used in any constraint or the objective. This PR adds an ivarmap to Exact and allows for selective posting of channeling constraints, i.e. only when actually necessary.