### PR TITLE
fix tests and test docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -114,7 +114,7 @@ If no `--solver` option is provided:
 
 Tests can be marked with special markers:
 
-- **`@pytest.mark.requires_solver("solver_name_1", "solver_name_2", ...)`** - Test requires a specific solver, one of the listed names
+- **`@pytest.mark.requires_solver("solver_name_1", "solver_name_2", ...)`** - Test runs only for the listed solver(s). The test must declare a **`solver` parameter** (this wires up the `solver` fixture from `conftest.py`). If that solver is not installed, the test is skipped.
 - **`@pytest.mark.requires_dependency("package_name")`** - Test requires a specific Python package
 - **`@pytest.mark.generate_constraints.with_args(generator_function)`** - Parametrise test's "constraint" argument using the provided generator
 - **`@pytest.mark.depends_on_solver`** - Test indirectly depends on solvers
@@ -123,8 +123,8 @@ Tests can be marked with special markers:
 Examples:
 ```python
 @pytest.mark.requires_solver("cplex")
-def test_cplex_specific_feature():
-    # This test only runs if cplex is available
+def test_cplex_specific_feature(solver):
+    # This test only runs if cplex is available; the 'solver' parameter must be present!
     pass
 ```
 
@@ -183,11 +183,11 @@ def test_with_explicit_solvers(solver):
 
 ### Solver-Specific Tests
 
-For tests that only work with specific solvers:
+For tests that only work with specific solvers (do not forget the explicit 'solver' parameter in the function definition):
 
 ```python
 @pytest.mark.requires_solver("cplex")
-def test_cplex_feature():
+def test_cplex_feature(solver):
     # Test cplex-specific functionality
     pass
 ```

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -4,7 +4,7 @@ import cpmpy as cp
 from cpmpy.tools import mss_opt, marco, OCUSException
 from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, optimal_mus, optimal_mus_naive, mss, mcs, ocus, ocus_naive, mus_native
 
-
+@pytest.mark.requires_solver("exact")
 class TestMus:
     def setup_method(self):
         self.mus_func = mus
@@ -89,7 +89,7 @@ class TestMus:
         soft = [x[0] == x[1], x[1] == x[2]]
         hard = [cp.AllDifferent(x)]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard)
+        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver)
         assert len(set(mus_cons)) == 1
         mus_naive_cons = self.naive_func(soft=soft, hard=hard)
         assert len(set(mus_naive_cons)) == 1

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -52,7 +52,7 @@ class TestMus:
             y == 4
         ]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard) # crashes
+        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver) # crashes
         assert set(mus_cons) == set(soft)
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -22,7 +22,7 @@ class TestMus:
             (x[3] > x[1]).implies((x[3] > x[2]) & ((x[3] == 3) | (x[1] == x[2])))
         ]
 
-        assert set(self.mus_func(cons)) == set(cons[:3])
+        assert set(self.mus_func(cons, hard=[], solver=solver)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
 
     def test_bug_191(self, solver):
@@ -34,7 +34,7 @@ class TestMus:
         hard = [~bv]
         soft = [bv]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard, solver="ortools") # crashes
+        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver) # crashes
         assert set(mus_cons) == set(soft)
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
@@ -76,20 +76,14 @@ class TestMus:
 
         # non-determinstic
         #self.assertEqual(set(mus(cons)), set(cons[1:3]))
-        ms = self.mus_func(cons)
+        ms = self.mus_func(cons, solver=solver)
         assert len(ms) < len(cons)
         assert not cp.Model(ms).solve()
         ms = self.naive_func(cons)
         assert len(ms) < len(cons)
         assert not cp.Model(ms).solve()
         # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
-
-@pytest.mark.requires_solver("exact")
-class TestNativeMusExact(TestMus):
-    def setup_method(self):
-        self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver="exact")
-        self.naive_func = mus_naive
-
+        
     def test_decomposed_global(self, solver):
         x = cp.intvar(1, 5, shape=3, name="x")
         soft = [x[0] == x[1], x[1] == x[2]]
@@ -100,11 +94,11 @@ class TestNativeMusExact(TestMus):
         mus_naive_cons = self.naive_func(soft=soft, hard=hard)
         assert len(set(mus_naive_cons)) == 1
 
-
-@pytest.mark.requires_solver("gurobi")
-class TestNativeMusGurobi(TestMus):
+@pytest.mark.requires_solver("exact", "gurobi")
+class TestNativeMus(TestMus):
     def setup_method(self):
-        self.mus_func = lambda soft, hard=[], solver="gurobi": mus_native(soft, hard=hard, solver="gurobi")
+        solver = None
+        self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -10,7 +10,7 @@ class TestMus:
         self.mus_func = mus
         self.naive_func = mus_naive
 
-    def test_circular(self):
+    def test_circular(self, solver):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
         cons = [
@@ -25,7 +25,7 @@ class TestMus:
         assert set(self.mus_func(cons)) == set(cons[:3])
         assert set(self.naive_func(cons)) == set(cons[:3])
 
-    def test_bug_191(self):
+    def test_bug_191(self, solver):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
@@ -39,7 +39,7 @@ class TestMus:
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_bug_191_many_soft(self):
+    def test_bug_191_many_soft(self, solver):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
         when the number of soft constraints > 1.
@@ -57,7 +57,7 @@ class TestMus:
         mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
         assert set(mus_naive_cons) == set(soft)
 
-    def test_wglobal(self):
+    def test_wglobal(self, solver):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
 
@@ -83,13 +83,14 @@ class TestMus:
         assert len(ms) < len(cons)
         assert not cp.Model(ms).solve()
         # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
-@pytest.mark.requires_solver("exact")       
+
+@pytest.mark.requires_solver("exact")
 class TestNativeMusExact(TestMus):
     def setup_method(self):
         self.mus_func = lambda soft, hard=[], solver="exact": mus_native(soft, hard=hard, solver="exact")
         self.naive_func = mus_naive
 
-    def test_decomposed_global(self):
+    def test_decomposed_global(self, solver):
         x = cp.intvar(1, 5, shape=3, name="x")
         soft = [x[0] == x[1], x[1] == x[2]]
         hard = [cp.AllDifferent(x)]


### PR DESCRIPTION
using `requires_solver()` in tests ALSO requires listing a 'solver' parameter in the function definition, otherwise the test is always run