### PR TITLE
Fix special case for not in decompose

### DIFF
--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -22,6 +22,8 @@ import copy
 from typing import AbstractSet, Optional, Dict, Any, Callable, Protocol, cast, overload
 import numpy as np
 
+from cpmpy.transformations.negation import recurse_negation
+
 from .cse import CSEMap
 from ..expressions.core import Expression, BoolVal, Operator
 from ..expressions.globalconstraints import GlobalConstraint
@@ -99,8 +101,12 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             arg_changed, arg_newargs, arg_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
             if arg_changed:
                 changed = True
-                expr = copy.copy(expr)
-                expr.update_args(arg_newargs)
+                if expr.name == "not": # cannot leave negation here, recurse into new expression
+                    assert len(arg_newargs) == 1, "decompose_in_tree: expected a single expression as argument of negation but got {arg_newargs}"
+                    expr = recurse_negation(arg_newargs[0]) # negate the argument
+                else:
+                    expr = copy.copy(expr)
+                    expr.update_args(arg_newargs)
                 if len(arg_toplevel) > 0:
                     todolist.extend(arg_toplevel)
             newlist.append(expr)
@@ -267,8 +273,12 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     rec_changed, rec_newargs, rec_toplevel = _decompose_in_tree_args(arg.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
                     if rec_changed:
                         changed = True
-                        arg = copy.copy(arg)
-                        arg.update_args(rec_newargs)
+                        if arg.name == "not": # cannot leave negation here, recurse into new expression
+                            assert len(rec_newargs) == 1, "decompose_in_tree: expected a single expression as argument of negation but got {rec_newargs}"
+                            arg = recurse_negation(rec_newargs[0]) # negate the argument
+                        else:
+                            arg = copy.copy(arg)
+                            arg.update_args(rec_newargs)
                         if len(rec_toplevel) > 0:
                             toplevel.extend(rec_toplevel)
                     newargs.append(arg)

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -80,10 +80,10 @@ class TestTransfDecomp:
         ivs = [cp.intvar(1,9,name=n) for n in "xyz"]
 
         cons = [cp.AllDifferent(ivs) == 0]
-        assert set(map(str,decompose_in_tree(cons))) == {"not(and((x) != (y), (x) != (z), (y) != (z)))"}
+        assert set(map(str,decompose_in_tree(cons))) == {"or((x) == (y), (x) == (z), (y) == (z))"}
 
         cons = [0 == cp.AllDifferent(ivs)]
-        assert set(map(str,decompose_in_tree(cons))) == {"not(and((x) != (y), (x) != (z), (y) != (z)))"}
+        assert set(map(str,decompose_in_tree(cons))) == {"or((x) == (y), (x) == (z), (y) == (z))"}
 
         cons = [cp.AllDifferent(ivs) == cp.AllEqual(ivs[:-1])]
         assert set(map(str,decompose_in_tree(cons))) == {"(and((x) != (y), (x) != (z), (y) != (z))) == ((x) == (y))"}
@@ -210,6 +210,26 @@ class TestTransfDecomp:
         cons = cp.Count(x, 2) >= 1
         assert set(map(str, decompose_linear([cons]))) == \
                             {'(a == 2) + (b == 2) >= 1'}
+
+    def test_decompose_in_negation(self):
+
+        x,y,z = cp.intvar(0,10,shape=3, name=tuple("xyz"))
+        bv = cp.boolvar(name="bv")
+
+        cons = cp.AllDifferent([x,y,z])
+        assert set(map(str, decompose_in_tree([cons]))) == \
+                            {"(x) != (y)", "(x) != (z)", "(y) != (z)"}
+        assert set(map(str, decompose_in_tree([~cons]))) == \
+                            {"or((x) == (y), (x) == (z), (y) == (z))"}
+        assert set(map(str, decompose_in_tree([bv.implies(cons)]))) == \
+                            {"(bv) -> (and((x) != (y), (x) != (z), (y) != (z)))"}
+        assert set(map(str, decompose_in_tree([bv == (cons)]))) == \
+                            {"(bv) == (and((x) != (y), (x) != (z), (y) != (z)))"}
+        
+        # also when negation is nested
+        cons = bv == ~cp.AllDifferent([x,y,z])
+        assert set(map(str, decompose_in_tree([cons]))) == \
+                            {"(bv) == (or((x) == (y), (x) == (z), (y) == (z)))"}
 
     def test_issue_546(self):
         # https://github.com/CPMpy/cpmpy/issues/546


### PR DESCRIPTION
When refactoring the `decompose_in_tree` transformation in #929 we missed the special case where a global constraint occurs in a "not" expression.

In this PR, we again push down negation in the decomposition.