### PR TITLE
Improved GCC decomposition

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1998,7 +1998,7 @@ class GlobalCardinalityCount(GlobalConstraint):
         counts = [cp.Count(vars, v)  for v in vals]
         constraints = [cnt == o for cnt, o in zip(counts, occ)]
         if self.closed:
-            constraints.append(InDomain(v, vals) for v in vars)
+            constraints.extend([InDomain(v, vals) for v in vars])
             constraints.append(cp.sum(counts) == len(vars))
         else:
             constraints.append(cp.sum(counts) <= len(vars))

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1995,9 +1995,14 @@ class GlobalCardinalityCount(GlobalConstraint):
         Uses a conjunction of Count global function constraints.
         """
         vars, vals, occ = self.args
-        constraints = [cp.Count(vars, i) == v for i, v in zip(vals, occ)]
+        counts = [cp.Count(vars, v)  for v in vals]
+        constraints = [cnt == o for cnt, o in zip(counts, occ)]
         if self.closed:
-            constraints += [InDomain(v, vals) for v in vars]
+            constraints.append(InDomain(v, vals) for v in vars)
+            constraints.append(cp.sum(counts) == len(vars))
+        else:
+            constraints.append(cp.sum(counts) <= len(vars))
+            
         return constraints, []
 
     def value(self) -> Optional[bool]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1993,14 +1993,19 @@ class GlobalCardinalityCount(GlobalConstraint):
         """
         Decomposition of the GlobalCardinalityCount constraint.
         Uses a conjunction of Count global function constraints.
+        
+        Same as the one MiniZinc uses:
+        https://github.com/MiniZinc/libminizinc/blob/master/share/minizinc/std/fzn_global_cardinality.mzn
         """
         vars, vals, occ = self.args
-        counts = [cp.Count(vars, v)  for v in vals]
+        counts = [cp.Count(vars, v) for v in vals]
         constraints = [cnt == o for cnt, o in zip(counts, occ)]
         if self.closed:
             constraints.extend([InDomain(v, vals) for v in vars])
+            # redundant constraint
             constraints.append(cp.sum(counts) == len(vars))
         else:
+            # redundant constraint
             constraints.append(cp.sum(counts) <= len(vars))
             
         return constraints, []


### PR DESCRIPTION
Adds a redundant constraint on the sum of counts for GCC.

Should allow for faster detection of failure in a branch during solving