### PR TITLE
Save lhs and rhs of reification to csemap

### DIFF
--- a/cpmpy/expressions/python_builtins.py
+++ b/cpmpy/expressions/python_builtins.py
@@ -174,6 +174,8 @@ def sum(iterable, **kwargs):
             return builtins.sum(iterable, **kwargs)  # does not contain expressions
 
     assert len(kwargs)==0, "sum over expressions does not support keyword arguments"
+    if len(iterable) == 1:
+        return iterable[0]
     return Operator("sum", iterable)
 
 

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -37,6 +37,18 @@ class CSEMap:
             
         return self.flat_map.get(expr, default)
 
+    def put(self, expr: Expression, var: _IntVarImpl) -> None:
+        """
+        Put the given expression and variable into the flat_map.
+        """
+        if expr.is_bool():
+            normal_expr, negate = self._canonicalize_boolexpr(expr)
+            if negate:
+                var = ~var
+            self.flat_map[normal_expr] = var
+        else:
+            self.flat_map[expr] = var
+
     def save_decomposition(self, expr: Expression, newexpr: Expression):
         """Save the decomposition of the given global constraint or global function."""
         self.decomp_map[expr] = newexpr

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -40,13 +40,21 @@ class CSEMap:
     def put(self, expr: Expression, var: _IntVarImpl) -> None:
         """
         Put the given expression and variable into the flat_map.
+        Only use this method if you want to save expr == var to the flat_map.
+        Use get_or_make_var instead to make a new variable for an expression.
+        Raises a ValueError if the expression is already in the flat_map.
         """
         if expr.is_bool():
+            assert var.is_bool(), f"{expr} is of type Boolean, but {var} is of type {type(var)}. Please report on github."
             normal_expr, negate = self._canonicalize_boolexpr(expr)
             if negate:
                 var = ~var
+            if normal_expr in self.flat_map:
+                raise ValueError(f"Expression {normal_expr} is already in the flat_map. Please report on github.")
             self.flat_map[normal_expr] = var
         else:
+            if expr in self.flat_map:
+                raise ValueError(f"Expression {expr} is already in the flat_map. Please report on github.")
             self.flat_map[expr] = var
 
     def save_decomposition(self, expr: Expression, newexpr: Expression):

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -37,6 +37,18 @@ class CSEMap:
             
         return self.flat_map.get(expr, default)
 
+    def put(self, expr: Expression, var: _IntVarImpl) -> None:
+        """
+        Normalize the expression and put the given expression and variable into the flat_map.
+        """
+        if expr.is_bool():
+            expr, negate = self._canonicalize_boolexpr(expr)
+            if negate:
+                var = ~var
+            self.flat_map[expr] = var
+        else:
+            self.flat_map[expr] = var
+
     def save_decomposition(self, expr: Expression, newexpr: Expression):
         """Save the decomposition of the given global constraint or global function."""
         self.decomp_map[expr] = newexpr

--- a/cpmpy/transformations/cse.py
+++ b/cpmpy/transformations/cse.py
@@ -37,18 +37,6 @@ class CSEMap:
             
         return self.flat_map.get(expr, default)
 
-    def put(self, expr: Expression, var: _IntVarImpl) -> None:
-        """
-        Normalize the expression and put the given expression and variable into the flat_map.
-        """
-        if expr.is_bool():
-            expr, negate = self._canonicalize_boolexpr(expr)
-            if negate:
-                var = ~var
-            self.flat_map[expr] = var
-        else:
-            self.flat_map[expr] = var
-
     def save_decomposition(self, expr: Expression, newexpr: Expression):
         """Save the decomposition of the given global constraint or global function."""
         self.decomp_map[expr] = newexpr

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -259,15 +259,17 @@ def flatten_constraint(expr, csemap=None):
             # Reification (double implication): Boolexpr == Var
             # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
             if exprname == '==' and lexpr.is_bool():
+                lhs = None
                 if rvar.is_bool():
                     if csemap is not None:
-                        lexpr_norm, negate = csemap._canonicalize_boolexpr(lexpr) # canonicalize the lexpr
-                        if negate:
-                            csemap.flat_map[lexpr_norm] = ~rvar # save this reificsation in the csemap
+                        other_expr = csemap.get(lexpr)
+                        if other_expr is not None:
+                            lhs = other_expr # already have a constraint lexpr == bvar, use bvar instead
+                            lcons = []
                         else:
-                            csemap.flat_map[lexpr_norm] = rvar # save this reificsation in the csemap
-                    # this is a reification
-                    (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
+                            csemap.put(lexpr, rvar)
+                    if lhs is None:
+                        (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
                 else:
                     # integer comparison
                     (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -261,11 +261,7 @@ def flatten_constraint(expr, csemap=None):
             if exprname == '==' and lexpr.is_bool():
                 if rvar.is_bool():
                     if csemap is not None:
-                        lexpr_norm, negate = csemap._canonicalize_boolexpr(lexpr) # canonicalize the lexpr
-                        if negate:
-                            csemap.flat_map[lexpr_norm] = ~rvar # save this reificsation in the csemap
-                        else:
-                            csemap.flat_map[lexpr_norm] = rvar # save this reificsation in the csemap
+                        csemap.put(lexpr, rvar)
                     # this is a reification
                     (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
                 else:

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -260,7 +260,7 @@ def flatten_constraint(expr, csemap=None):
             # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
             if exprname == '==' and lexpr.is_bool():
                 if rvar.is_bool():
-                    if csemap is not None:
+                    if csemap is not None and csemap.get(lexpr) is None:
                         csemap.put(lexpr, rvar)
                     # this is a reification
                     (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -260,6 +260,8 @@ def flatten_constraint(expr, csemap=None):
             # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
             if exprname == '==' and lexpr.is_bool():
                 if rvar.is_bool():
+                    if csemap is not None:
+                        csemap.flat_map[lexpr] = rvar # save this reification in the csemap
                     # this is a reification
                     (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
                 else:

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -261,7 +261,8 @@ def flatten_constraint(expr, csemap=None):
             if exprname == '==' and lexpr.is_bool():
                 if rvar.is_bool():
                     if csemap is not None:
-                        csemap.flat_map[lexpr] = rvar # save this reification in the csemap
+                        lexpr_norm, _ = csemap._canonicalize_boolexpr(lexpr) # canonicalize the lexpr
+                        csemap.flat_map[lexpr_norm] = rvar # save this reificsation in the csemap
                     # this is a reification
                     (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
                 else:

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -259,17 +259,15 @@ def flatten_constraint(expr, csemap=None):
             # Reification (double implication): Boolexpr == Var
             # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
             if exprname == '==' and lexpr.is_bool():
-                lhs = None
                 if rvar.is_bool():
                     if csemap is not None:
-                        other_expr = csemap.get(lexpr)
-                        if other_expr is not None:
-                            lhs = other_expr # already have a constraint lexpr == bvar, use bvar instead
-                            lcons = []
+                        lexpr_norm, negate = csemap._canonicalize_boolexpr(lexpr) # canonicalize the lexpr
+                        if negate:
+                            csemap.flat_map[lexpr_norm] = ~rvar # save this reificsation in the csemap
                         else:
-                            csemap.put(lexpr, rvar)
-                    if lhs is None:
-                        (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
+                            csemap.flat_map[lexpr_norm] = rvar # save this reificsation in the csemap
+                    # this is a reification
+                    (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
                 else:
                     # integer comparison
                     (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -261,8 +261,11 @@ def flatten_constraint(expr, csemap=None):
             if exprname == '==' and lexpr.is_bool():
                 if rvar.is_bool():
                     if csemap is not None:
-                        lexpr_norm, _ = csemap._canonicalize_boolexpr(lexpr) # canonicalize the lexpr
-                        csemap.flat_map[lexpr_norm] = rvar # save this reificsation in the csemap
+                        lexpr_norm, negate = csemap._canonicalize_boolexpr(lexpr) # canonicalize the lexpr
+                        if negate:
+                            csemap.flat_map[lexpr_norm] = ~rvar # save this reificsation in the csemap
+                        else:
+                            csemap.flat_map[lexpr_norm] = rvar # save this reificsation in the csemap
                     # this is a reification
                     (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
                 else:

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -135,7 +135,6 @@ class TestCSE:
         b = cp.boolvar(name="b")
 
         flat_cons = flatten_constraint((x > 5) == b, csemap=self.csemap)
-        print(flat_cons)
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(x > 5) == (b)"

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -135,12 +135,41 @@ class TestCSE:
         b = cp.boolvar(name="b")
 
         flat_cons = flatten_constraint((x > 5) == b, csemap=self.csemap)
+        print(flat_cons)
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(x > 5) == (b)"
-        assert len(self.csemap) == 0
 
+    def test_flat_reification_in_csemap(self):
 
+        x = cp.intvar(0,10,name="x")
+        b = cp.boolvar(name="b")
+
+        flat_cons = flatten_constraint((x == 5) == b, csemap=self.csemap)
+
+        assert len(flat_cons) == 1
+        assert str(flat_cons[0]) == "(x == 5) == (b)"
+        assert len(self.csemap) == 1
+        assert {str(expr): str(var) for expr, var in self.csemap.flat_map.items()} == {
+            "x == 5": "b",
+        }
+
+    def test_reification_of_exprs_in_csemap(self):
+
+        x = cp.intvar(0,10,name="x")
+        y = cp.intvar(0,10,name="y")
+        b = cp.boolvar(name="b")
+
+        flat_cons = flatten_constraint((x == 5) == (y == 10), csemap=self.csemap)
+
+        assert len(flat_cons) == 2
+        assert str(flat_cons[0]) == "(x == 5) == (BV0)"
+        assert str(flat_cons[1]) == "(y == 10) == (BV0)"
+        assert len(self.csemap) == 2
+        assert {str(expr): str(var) for expr, var in self.csemap.flat_map.items()} == {
+            "x == 5": "BV0",
+            "y == 10": "BV0",
+        }
 
     def test_decompose(self):
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -154,6 +154,19 @@ class TestCSE:
             "x == 5": "b",
         }
 
+    def test_flat_reification_negation_in_csemap(self):
+
+        x = cp.intvar(0,10,name="x")
+        b = cp.boolvar(name="b")
+
+        flat_cons = flatten_constraint((x != 5) == b, csemap=self.csemap)
+
+        assert len(flat_cons) == 1
+        assert str(flat_cons[0]) == "(x != 5) == (b)"
+        assert len(self.csemap) == 1
+        assert {str(expr): str(var) for expr, var in self.csemap.flat_map.items()} == {
+            "x == 5": "~b",
+        }
     def test_reification_of_exprs_in_csemap(self):
 
         x = cp.intvar(0,10,name="x")


### PR DESCRIPTION
Improvement to cse in flattening:

If we encounter a constraint `lexpr == rexpr`, flatten will make a new variable `BV0` for `rexpr` and add a constraint: `rexpr == BV0`, and save `rexpr : BV0` to the csemap.

In this PR, I extend this to also add `lexpr : BV0` to the csemap. 
This allows to re-use the already introduced variable `BV0` again if we encounter `lexpr` as a subexpression.
Also increases the likelihood of an intvar being encoded with a direct encoding using `linearize_reified_varvals`, as the csemap can now contain more cases of `var == val : BV`. (e.g., if the user wrote `(x == 3) == b` -- see tests)
 
Also includes a small change to builtins.sum, returning `expr` when calling `cp.sum([expr])`; this improves the linearization for MDD, as we avoid the cases where we call `sum(edge_vars) == (var == val)` where `edge_vars` has a length of 1.