### PR TITLE
Bounds for pow and mod

### DIFF
--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -637,14 +637,22 @@ class Modulo(GlobalFunction):
         if lb2 == ub2 == 0:
             raise ZeroDivisionError("Domain of {} only contains 0".format(self.args[1]))
 
-        # the (abs of) the maximum value of the remainder is always one smaller than the absolute value of the divisor
-        lb = lb2 + (lb2 <= 0) - (lb2 >= 0)
-        ub = ub2 + (ub2 <= 0) - (ub2 >= 0)
-        if lb1 >= 0:  # result will be positive if first argument is positive
-            return 0, max(-lb, ub, 0)  # lb = 0
-        elif ub1 <= 0:  # result will be negative if first argument is negative
-            return min(-ub, lb, 0), 0  # ub = 0
-        return min(-ub, lb, 0), max(-lb, ub, 0)  # 0 should always be in the domain
+        # For small domains, compute exact bounds by enumeration.
+        if (ub1 - lb1 + 1) * (ub2 - lb2 + 1) <= 10 ** 6:
+            xs = np.arange(lb1, ub1 + 1)
+            ys = np.arange(lb2, ub2 + 1)
+            ys = ys[ys != 0]  # divisor is never 0 (partial function)
+            
+            rem = np.fmod(xs[:, None], ys[None, :]) # np.fmod implements truncated-division remainder
+            return int(rem.min()), int(rem.max())
+
+        # Otherwise fall back to an analytical over-approximation.
+        # The remainder has the same sign as the dividend and satisfies both
+        #   |remainder| <= |divisor| - 1   and   |remainder| <= |dividend|
+        max_rem = max(abs(lb2), abs(ub2)) - 1  # largest possible |remainder|
+        ub = min(ub1, max_rem) if ub1 > 0 else 0  # positive remainders need a positive dividend
+        lb = max(lb1, -max_rem) if lb1 < 0 else 0  # negative remainders need a negative dividend
+        return lb, ub
 
 
 class Power(GlobalFunction):

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -703,9 +703,13 @@ class Power(GlobalFunction):
             tuple[int, int]: A tuple of (lower bound, upper bound) for the power
         """
         base, exp = self.args
+        # exp is guaranteed to be a constant greater than 0
         lb_base, ub_base = get_bounds(base)
-
+    
         bounds = [lb_base ** exp, ub_base ** exp]
+        if lb_base < 0 < ub_base:
+            bounds.append(0)
+
         return min(bounds), max(bounds)
 
 

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -711,6 +711,9 @@ class Power(GlobalFunction):
             tuple[int, int]: A tuple of (lower bound, upper bound) for the power
         """
         base, exp = self.args
+        if exp == 0:
+            return 1, 1
+
         # exp is guaranteed to be a constant greater than 0
         lb_base, ub_base = get_bounds(base)
     

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1480,7 +1480,7 @@ class TestBounds:
         x = cp.intvar(-8, 5)
         op = cp.Power(x,3)
         lb, ub = op.get_bounds()
-        assert lb == -8 ** 3
+        assert lb == (-8) ** 3
         assert ub == 5 ** 3
 
         op = cp.Power(x, 4)
@@ -1491,13 +1491,18 @@ class TestBounds:
         x = cp.intvar(-5, 8)
         op = cp.Power(x,3)
         lb, ub = op.get_bounds()
-        assert lb == -5 ** 3
+        assert lb == (-5) ** 3
         assert ub == 8 ** 3
 
         op = cp.Power(x, 4)
         lb, ub = op.get_bounds()
         assert lb == 0
         assert ub == 8 ** 4
+
+        op = cp.Power(x,0)
+        lb, ub = op.get_bounds()
+        assert lb == 1
+        assert ub == 1
 
     
     def test_bounds_element(self):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1480,14 +1480,26 @@ class TestBounds:
         x = cp.intvar(-8, 5)
         op = cp.Power(x,3)
         lb, ub = op.get_bounds()
-        assert lb ==-8 ** 3
-        assert ub ==5 ** 3
+        assert lb == -8 ** 3
+        assert ub == 5 ** 3
 
         op = cp.Power(x, 4)
         lb, ub = op.get_bounds()
-        assert lb == 5 ** 4
+        assert lb == 0
+        assert ub == 8 ** 4
+        
+        x = cp.intvar(-5, 8)
+        op = cp.Power(x,3)
+        lb, ub = op.get_bounds()
+        assert lb == -5 ** 3
+        assert ub == 8 ** 3
+
+        op = cp.Power(x, 4)
+        lb, ub = op.get_bounds()
+        assert lb == 0
         assert ub == 8 ** 4
 
+    
     def test_bounds_element(self):
         x = cp.intvar(-8, 8)
         y = cp.intvar(-7, -1)


### PR DESCRIPTION
Fix bound implementation for `pow`, also includes more precise bound computation for Modulo when the domain is small.
Fixes #1011 