### PR TITLE
Add incremental flag for faster one-shot Exact and SCIP solves

### DIFF
--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -187,11 +187,20 @@ class Model(object):
         if kwargs and solver is None:
             raise NotSupportedError("Specify the solver when using kwargs, since they are solver-specific!")
 
+        if isinstance(solver, str):
+            name = solver.split(":", 1)[0]
+        elif isinstance(solver, type) and issubclass(solver, SolverInterface):
+            name = solver.__name__.removeprefix("CPM_").lower()
+        else:
+            name = None
+
+        init_kwargs = {"incremental": False} if name in ("exact", "scip") else {}
+
         if isinstance(solver, SolverInterface):
             # for advanced use, call its constructor with this model
-            s = solver(self)
+            s = solver(self, **init_kwargs)
         else:
-            s = SolverLookup.get(solver, self)
+            s = SolverLookup.get(solver, self, **init_kwargs)
 
         # call solver
         ret = s.solve(time_limit=time_limit, **kwargs)

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -116,7 +116,7 @@ class CPM_exact(SolverInterface):
             return None
 
 
-    def __init__(self, cpm_model=None, subsolver=None, **kwargs):
+    def __init__(self, cpm_model=None, subsolver=None, incremental=True, **kwargs):
         """
         Constructor of the native solver object
 
@@ -126,6 +126,8 @@ class CPM_exact(SolverInterface):
         Arguments:
             cpm_model: Model(), a CPMpy Model() (optional)
             subsolver: None
+            incremental: if True (default), use toOptimum in solve() so the solver state
+                can be reused (e.g. change objective). If False, use runFull (faster one-shot).
 
         Exact takes options at initialization instead of solving.
         The Exact solver parameters are defined by https://gitlab.com/nonfiction-software/exact/-/blob/main/src/Options.hpp
@@ -138,6 +140,7 @@ class CPM_exact(SolverInterface):
         assert subsolver is None, "Exact does not allow subsolvers."
 
         from exact import Exact as xct
+        self.incremental = incremental
         # initialise the native solver object
         options = list(kwargs.items()) # options is a list of string-pairs, e.g. [("verbosity","1")]
         options = [(opt[0], str(opt[1])) for opt in options] # Ensure values are also strings
@@ -227,7 +230,11 @@ class CPM_exact(SolverInterface):
             
         # call the solver, with parameters
         start = time.time()
-        my_status, obj_val = self.xct_solver.toOptimum(timeout=timeout)
+        obj_val = None
+        if self.incremental:
+            my_status, obj_val = self.xct_solver.toOptimum(timeout=timeout)
+        else:
+            my_status = self.xct_solver.runFull(optimize=self.has_objective(), timeout=timeout)
         end = time.time()
 
         # new status, translate runtime
@@ -264,11 +271,15 @@ class CPM_exact(SolverInterface):
         # True/False depending on self.cpm_status
         ret = self._solve_return(self.cpm_status)
         self._fillVars(has_solution=ret)
-        if self.has_objective():
-            if self.objective_is_min_:
-                self.objective_value_ = obj_val
-            else: # maximize, so actually negative value
-                self.objective_value_ = -obj_val
+        if self.has_objective() and ret:
+            if self.incremental:
+                assert obj_val is not None
+                if self.objective_is_min_:
+                    self.objective_value_ = obj_val
+                else: # maximize, so actually negative value
+                    self.objective_value_ = -obj_val
+            else:
+                self.objective_value_ = self.objective_.value()
         
         return ret
 

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -87,13 +87,14 @@ class CPM_scip(SolverInterface):
         except PackageNotFoundError:
             return None
 
-    def __init__(self, cpm_model=None, subsolver=None):
+    def __init__(self, cpm_model=None, subsolver=None, incremental=True):
         if not self.supported():
             raise ModuleNotFoundError(
                 "CPM_scip: Install SCIPOptSuite and the python package 'pyscipopt' to use this solver interface.")
         assert subsolver is None, "SCIP does not support subsolvers"
         import pyscipopt as scip
 
+        self.incremental = incremental
         self.scip_model = scip.Model()
         self.scip_model.setParam("display/verblevel", 0)  # remove solver logs from output
         self.objective_value_ = None
@@ -183,7 +184,8 @@ class CPM_scip(SolverInterface):
         # transformed space, and just leave the original model. All solutions are kept, 
         # and the user can now change the model as they will. The downside is that potentially 
         # useful information for speeding up the next optimisation call is thrown out.
-        self.scip_model.freeTransform()
+        if self.incremental:
+            self.scip_model.freeTransform()
 
         return has_sol
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -570,6 +570,36 @@ class TestSolvers:
         with open(proof_file+".proof", "r") as f:
             assert f.readline()[:-1] == "pseudo-Boolean proof version 1.1"# check header of proof-file
 
+    @pytest.mark.skipif(not CPM_exact.supported(), reason="Exact not installed")
+    def test_exact_incremental_solve(self):
+        iv = cp.intvar(0, 10, shape=2)
+        m = cp.Model(iv >= 1, iv <= 5)
+        m.maximize(sum(iv))
+
+        assert m.solve(solver="exact")
+        obj_model = m.objective_value()
+        status_model = m.status().exitstatus
+
+        s = cp.SolverLookup.get("exact", m, incremental=True)
+        assert s.solve()
+        assert s.objective_value() == obj_model
+        assert s.status().exitstatus == status_model
+
+    @pytest.mark.skipif(not CPM_scip.supported(), reason="SCIP not installed")
+    def test_scip_incremental_solve(self):
+        iv = cp.intvar(0, 10, shape=2)
+        m = cp.Model(iv >= 1, iv <= 5)
+        m.maximize(sum(iv))
+
+        assert m.solve(solver="scip")
+        obj_model = m.objective_value()
+        status_model = m.status().exitstatus
+
+        s = cp.SolverLookup.get("scip", m, incremental=True)
+        assert s.solve()
+        assert s.objective_value() == obj_model
+        assert s.status().exitstatus == status_model
+
     @pytest.mark.skipif(not CPM_choco.supported(),
                         reason="pychoco not installed")
     def test_choco(self):


### PR DESCRIPTION
Closes #968.

For one-shot solves via `Model.solve()`, Exact and SCIP were doing extra work meant for reusing the solver object. Exact always went through `toOptimum()`; SCIP always called `freeTransform()` after `optimize()`. Both are useful when you keep the solver and solve again, but `Model.solve()` throws the solver away anyway.

This adds an `incremental` flag on both interfaces (default `True`). `Model.solve()` passes `incremental=False` for exact and scip. Exact then uses `runFull`; SCIP skips `freeTransform()`.

Left `Model.solveAll()` alone — SCIP's generic enumeration calls `solve()` in a loop and adds nogoods, so it still needs the incremental path.

Added a couple of tests that check `Model.solve()` gives the same result as `SolverLookup.get(..., incremental=True)`.