### PR TITLE
Microoptimization: slots for _NumVarImpl

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -320,6 +320,8 @@ class _NumVarImpl(Expression):
     including bounds checking and value management. It should not be instantiated
     directly, but rather through the helper functions :func:`~cpmpy.expressions.variables.intvar` and :func:`~cpmpy.expressions.variables.boolvar`.
     """
+    __slots__ = ('lb', 'ub', 'name', '_value')
+
     def __init__(self, lb: int, ub: int, name: str):
         assert (is_num(lb) and is_num(ub))
         assert (lb <= ub)
@@ -432,6 +434,8 @@ class NegBoolView(_BoolVarImpl):
 
         Do not create this object directly, use the `~` operator instead: `~bv`
     """
+    __slots__ = ('_bv',)
+
     def __init__(self, bv: _BoolVarImpl):
         #assert(isinstance(bv, _BoolVarImpl))
         self._bv = bv


### PR DESCRIPTION
I recently learned about using `__slots__` in python objects
https://stackoverflow.com/questions/472000/usage-of-slots

The main advantage is that your objects take less memory, which may be very useful for models with loads of variables/constraints (e.g., files we read in from DIMACS?)

I've implemented it for _NumVarImpl, no real time gains, but memory footprint for a variable now goes from ±450B to ±80B which is nice : )

The real gains are probably when typing Operator and Comparison, or some of the globals (e.g., Multiplication).