### PR TITLE
Fix table subexpr check

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -145,7 +145,7 @@ import cpmpy as cp
 
 from ..exceptions import TypeError
 from .core import Expression, BoolVal, ExprLike, BoolExprLike, ListLike
-from .variables import cpm_array, intvar, boolvar, _BoolVarImpl, NDVarArray
+from .variables import cpm_array, intvar, boolvar, _BoolVarImpl, NDVarArray, _NumVarImpl
 from .utils import all_pairs, is_bool, STAR, get_bounds, argvals, is_any_list, flatlist, is_num, is_boolexpr, implies, argval
 
 if TYPE_CHECKING:
@@ -591,7 +591,7 @@ class Table(GlobalConstraint):
         else:
             has_subexpr = False
             for x in array:  # C-style python
-                if x.has_subexpr():
+                if isinstance(x, Expression) and not isinstance(x, (_NumVarImpl, BoolVal)):
                     has_subexpr = True
                     break
 
@@ -744,7 +744,7 @@ class ShortTable(GlobalConstraint):
         else:
             has_subexpr = False
             for x in array:  # C-style python
-                if x.has_subexpr():
+                if isinstance(x, Expression) and not isinstance(x, (_NumVarImpl, BoolVal)):
                     has_subexpr = True
                     break
 
@@ -826,7 +826,7 @@ class NegativeTable(GlobalConstraint):
         else:
             has_subexpr = False
             for x in array:  # C-style python
-                if x.has_subexpr():
+                if isinstance(x, Expression) and not isinstance(x, (_NumVarImpl, BoolVal)):
                     has_subexpr = True
                     break
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -431,6 +431,12 @@ class TestGlobal:
         model = cp.Model(constraints[0].decompose())
         assert not model.solve()
 
+    def test_table_with_subexpr(self):
+        iv = cp.intvar(0, 10, shape=3)
+        c = cp.Table(iv+iv, [[10, 8, 2], [5, 9, 2]])
+        assert cp.Model(c).solve()
+        assert cp.Model(c.decompose()).solve()
+
     def test_table_value(self):
         """Test Table.value() with known assignments (and unassigned -> None)."""
         iv = cp.intvar(0, 10, shape=3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1907,18 +1907,6 @@ class TestTypeChecks:
                 print("Solver not supported: ", name)
                 continue
 
-
-    def test_table(self):
-        iv = cp.intvar(-8,8,3)
-
-        #assert cp.Model(cp.Table([iv[0], [iv[1], iv[2]]], [ (5, 2, 2)])).solve() # not flatlist, should work
-        # used to work, not allowed anymore
-        pytest.raises(AttributeError, cp.Table, [iv[0], [iv[1], iv[2]]], [ (5, 2, 2)])
-
-        pytest.raises(AttributeError, cp.Table, [iv[0], iv[1], iv[2], 5], [(5, 2, 2)])
-        pytest.raises(AttributeError, cp.Table, [iv[0], iv[1], iv[2], [5]], [(5, 2, 2)])
-        pytest.raises(AttributeError, cp.Table, [iv[0], iv[1], iv[2], ['a']], [(5, 2, 2)])
-
     # def test_issue627(self): -> not allowed anymore; index must be an Expression
     #     for s, cls in cp.SolverLookup.base_solvers():
     #         if cls.supported():


### PR DESCRIPTION
There was an error introduced by #895 on checking whether the arguments of a table-like constraint contain a subexpression, it checked whether the arg HAS a subexpression, but it should really check if the arg IS a subexpression.

Added a test and fixed constructors, uncovered after merging master into #1015 