### PR TITLE
Fix 'Expr OP NDArr' by doing 'NDArr ROP Expr'

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -289,6 +289,8 @@ class Expression(object):
 
     # Comparisons
     def __eq__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__eq__(self)
         # BoolExpr == 1|true|0|false, common case, simply BoolExpr
         if self.is_bool() and is_num(other):
             if other is True or other == 1:
@@ -298,23 +300,35 @@ class Expression(object):
         return Comparison("==", self, other)
 
     def __ne__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__ne__(self)
         return Comparison("!=", self, other)
 
     def __lt__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__gt__(self)
         return Comparison("<", self, other)
 
     def __le__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__ge__(self)
         return Comparison("<=", self, other)
 
     def __gt__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__lt__(self)
         return Comparison(">", self, other)
 
     def __ge__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__le__(self)
         return Comparison(">=", self, other)
 
     # Boolean Operators
     # Implements bitwise operations & | ^ and ~ (and, or, xor, not)
     def __and__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__rand__(self)
         # some simple constant removal
         if is_true_cst(other):
             return self
@@ -325,6 +339,8 @@ class Expression(object):
         return Operator("and", [self, other])
 
     def __rand__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__and__(self)
         # some simple constant removal
         if is_true_cst(other):
             return self
@@ -335,6 +351,8 @@ class Expression(object):
         return Operator("and", [other, self])
 
     def __or__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__ror__(self)
         # some simple constant removal
         if is_false_cst(other):
             return self
@@ -345,6 +363,8 @@ class Expression(object):
         return Operator("or", [self, other])
 
     def __ror__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__or__(self)
         # some simple constant removal
         if is_false_cst(other):
             return self
@@ -355,6 +375,8 @@ class Expression(object):
         return Operator("or", [other, self])
 
     def __xor__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__rxor__(self)
         # some simple constant removal
         if is_true_cst(other):
             return ~self
@@ -363,6 +385,8 @@ class Expression(object):
         return cp.Xor([self, other])
 
     def __rxor__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__xor__(self)
         # some simple constant removal
         if is_true_cst(other):
             return ~self
@@ -373,23 +397,31 @@ class Expression(object):
     # Mathematical Operators, including 'r'everse if it exists
     # Addition
     def __add__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__radd__(self)
         if is_num(other) and other == 0:
             return self
         return Operator("sum", [self, other])
 
     def __radd__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__add__(self)
         if is_num(other) and other == 0:
             return self
         return Operator("sum", [other, self])
 
     # subtraction
     def __sub__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__rsub__(self)
         # if is_num(other) and other == 0:
         #     return self
         # return Operator("sub", [self, other])
         return self.__add__(-other)
 
     def __rsub__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__sub__(self)
         # if is_num(other) and other == 0:
         #     return -self
         # return Operator("sub", [other, self])
@@ -397,11 +429,15 @@ class Expression(object):
     
     # multiplication: use GlobalFunction Multiplication so it can be decomposed (e.g. to linear)
     def __mul__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__rmul__(self)
         if is_num(other) and other == 1:
             return self
         return cp.Multiplication(self, other)
 
     def __rmul__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__mul__(self)
         if is_num(other) and other == 1:
             return self
         return cp.Multiplication(other, self)
@@ -419,17 +455,25 @@ class Expression(object):
         return self.__rfloordiv__(other)
 
     def __floordiv__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__rfloordiv__(self)
         if is_num(other) and other == 1:
             return self
         return cp.Division(self, other)
 
     def __rfloordiv__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__floordiv__(self)
         return cp.Division(other, self)
 
     def __mod__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__rmod__(self)
         return cp.Modulo(self, other)
 
     def __rmod__(self, other):
+        if isinstance(other, cp.expressions.variables.NDVarArray):
+            return other.__mod__(self)
         return cp.Modulo(other, self)
 
     def __pow__(self, other: Any, modulo: Optional[int] = None):

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -308,28 +308,28 @@ class Expression(object):
             return other.__ne__(self)
         return Comparison("!=", self, other)
 
-    def __lt__(self, other: ExprLike | np.ndarray):
+    def __lt__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__gt__(self)
         return Comparison("<", self, other)
 
-    def __le__(self, other: ExprLike | np.ndarray):
+    def __le__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__ge__(self)
         return Comparison("<=", self, other)
 
-    def __gt__(self, other: ExprLike | np.ndarray):
+    def __gt__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__lt__(self)
         return Comparison(">", self, other)
 
-    def __ge__(self, other: ExprLike | np.ndarray):
+    def __ge__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -338,7 +338,7 @@ class Expression(object):
 
     # Boolean Operators
     # Implements bitwise operations & | ^ and ~ (and, or, xor, not)
-    def __and__(self, other: BoolExprLike | np.ndarray):
+    def __and__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -352,7 +352,7 @@ class Expression(object):
                             f"E.g. always write (x==2)&(y<5).")
         return Operator("and", [self, other])
 
-    def __rand__(self, other: BoolExprLike | np.ndarray):
+    def __rand__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -366,7 +366,7 @@ class Expression(object):
                             f"did you forget to put brackets? E.g. always write (x==2)&(y<5).")
         return Operator("and", [other, self])
 
-    def __or__(self, other: BoolExprLike | np.ndarray):
+    def __or__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -380,7 +380,7 @@ class Expression(object):
                             f"did you forget to put brackets? E.g. always write (x==2)|(y<5).")
         return Operator("or", [self, other])
 
-    def __ror__(self, other: BoolExprLike | np.ndarray):
+    def __ror__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -394,7 +394,7 @@ class Expression(object):
                             f"did you forget to put brackets? E.g. always write (x==2)|(y<5).")
         return Operator("or", [other, self])
 
-    def __xor__(self, other: BoolExprLike | np.ndarray):
+    def __xor__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -406,7 +406,7 @@ class Expression(object):
             return self
         return cp.Xor([self, other])
 
-    def __rxor__(self, other: BoolExprLike | np.ndarray):
+    def __rxor__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -420,7 +420,7 @@ class Expression(object):
 
     # Mathematical Operators, including 'r'everse if it exists
     # Addition
-    def __add__(self, other: ExprLike | np.ndarray):
+    def __add__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -429,7 +429,7 @@ class Expression(object):
             return self
         return Operator("sum", [self, other])
 
-    def __radd__(self, other: ExprLike | np.ndarray):
+    def __radd__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -439,7 +439,7 @@ class Expression(object):
         return Operator("sum", [other, self])
 
     # subtraction
-    def __sub__(self, other: ExprLike | np.ndarray):
+    def __sub__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -451,7 +451,7 @@ class Expression(object):
         # return Operator("sub", [self, other])
         return self.__add__(-other)
 
-    def __rsub__(self, other: ExprLike | np.ndarray):
+    def __rsub__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -462,7 +462,7 @@ class Expression(object):
         return (-self).__radd__(other)
     
     # multiplication: use GlobalFunction Multiplication so it can be decomposed (e.g. to linear)
-    def __mul__(self, other: ExprLike | np.ndarray):
+    def __mul__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -471,7 +471,7 @@ class Expression(object):
             return self
         return cp.Multiplication(self, other)
 
-    def __rmul__(self, other: ExprLike | np.ndarray):
+    def __rmul__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -492,7 +492,7 @@ class Expression(object):
         warnings.warn("We only support floordivision, use // instead of /", SyntaxWarning)
         return self.__rfloordiv__(other)
 
-    def __floordiv__(self, other: ExprLike | np.ndarray):
+    def __floordiv__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -501,21 +501,21 @@ class Expression(object):
             return self
         return cp.Division(self, other)
 
-    def __rfloordiv__(self, other: ExprLike | np.ndarray):
+    def __rfloordiv__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__floordiv__(self)
         return cp.Division(other, self)
 
-    def __mod__(self, other: ExprLike | np.ndarray):
+    def __mod__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__rmod__(self)
         return cp.Modulo(self, other)
 
-    def __rmod__(self, other: ExprLike | np.ndarray):
+    def __rmod__(self, other):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -289,7 +289,9 @@ class Expression(object):
 
     # Comparisons
     def __eq__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__eq__(self)
         # BoolExpr == 1|true|0|false, common case, simply BoolExpr
         if self.is_bool() and is_num(other):
@@ -300,34 +302,46 @@ class Expression(object):
         return Comparison("==", self, other)
 
     def __ne__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__ne__(self)
         return Comparison("!=", self, other)
 
     def __lt__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__gt__(self)
         return Comparison("<", self, other)
 
     def __le__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__ge__(self)
         return Comparison("<=", self, other)
 
     def __gt__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__lt__(self)
         return Comparison(">", self, other)
 
     def __ge__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__le__(self)
         return Comparison(">=", self, other)
 
     # Boolean Operators
     # Implements bitwise operations & | ^ and ~ (and, or, xor, not)
     def __and__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__rand__(self)
         # some simple constant removal
         if is_true_cst(other):
@@ -339,7 +353,9 @@ class Expression(object):
         return Operator("and", [self, other])
 
     def __rand__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__and__(self)
         # some simple constant removal
         if is_true_cst(other):
@@ -351,7 +367,9 @@ class Expression(object):
         return Operator("and", [other, self])
 
     def __or__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__ror__(self)
         # some simple constant removal
         if is_false_cst(other):
@@ -363,7 +381,9 @@ class Expression(object):
         return Operator("or", [self, other])
 
     def __ror__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__or__(self)
         # some simple constant removal
         if is_false_cst(other):
@@ -375,7 +395,9 @@ class Expression(object):
         return Operator("or", [other, self])
 
     def __xor__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__rxor__(self)
         # some simple constant removal
         if is_true_cst(other):
@@ -385,7 +407,9 @@ class Expression(object):
         return cp.Xor([self, other])
 
     def __rxor__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__xor__(self)
         # some simple constant removal
         if is_true_cst(other):
@@ -397,14 +421,18 @@ class Expression(object):
     # Mathematical Operators, including 'r'everse if it exists
     # Addition
     def __add__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__radd__(self)
         if is_num(other) and other == 0:
             return self
         return Operator("sum", [self, other])
 
     def __radd__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__add__(self)
         if is_num(other) and other == 0:
             return self
@@ -412,7 +440,9 @@ class Expression(object):
 
     # subtraction
     def __sub__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__rsub__(self)
         # if is_num(other) and other == 0:
         #     return self
@@ -420,7 +450,9 @@ class Expression(object):
         return self.__add__(-other)
 
     def __rsub__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__sub__(self)
         # if is_num(other) and other == 0:
         #     return -self
@@ -429,14 +461,18 @@ class Expression(object):
     
     # multiplication: use GlobalFunction Multiplication so it can be decomposed (e.g. to linear)
     def __mul__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__rmul__(self)
         if is_num(other) and other == 1:
             return self
         return cp.Multiplication(self, other)
 
     def __rmul__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__mul__(self)
         if is_num(other) and other == 1:
             return self
@@ -455,24 +491,32 @@ class Expression(object):
         return self.__rfloordiv__(other)
 
     def __floordiv__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__rfloordiv__(self)
         if is_num(other) and other == 1:
             return self
         return cp.Division(self, other)
 
     def __rfloordiv__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__floordiv__(self)
         return cp.Division(other, self)
 
     def __mod__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__rmod__(self)
         return cp.Modulo(self, other)
 
     def __rmod__(self, other):
-        if isinstance(other, cp.expressions.variables.NDVarArray):
+        if isinstance(other, np.ndarray):
+            if not isinstance(other, cp.expressions.variables.NDVarArray):
+                other = cp.cpm_array(other)
             return other.__mod__(self)
         return cp.Modulo(other, self)
 

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -308,28 +308,28 @@ class Expression(object):
             return other.__ne__(self)
         return Comparison("!=", self, other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__gt__(self)
         return Comparison("<", self, other)
 
-    def __le__(self, other):
+    def __le__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__ge__(self)
         return Comparison("<=", self, other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__lt__(self)
         return Comparison(">", self, other)
 
-    def __ge__(self, other):
+    def __ge__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -338,7 +338,7 @@ class Expression(object):
 
     # Boolean Operators
     # Implements bitwise operations & | ^ and ~ (and, or, xor, not)
-    def __and__(self, other):
+    def __and__(self, other: BoolExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -352,7 +352,7 @@ class Expression(object):
                             f"E.g. always write (x==2)&(y<5).")
         return Operator("and", [self, other])
 
-    def __rand__(self, other):
+    def __rand__(self, other: BoolExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -366,7 +366,7 @@ class Expression(object):
                             f"did you forget to put brackets? E.g. always write (x==2)&(y<5).")
         return Operator("and", [other, self])
 
-    def __or__(self, other):
+    def __or__(self, other: BoolExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -380,7 +380,7 @@ class Expression(object):
                             f"did you forget to put brackets? E.g. always write (x==2)|(y<5).")
         return Operator("or", [self, other])
 
-    def __ror__(self, other):
+    def __ror__(self, other: BoolExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -394,7 +394,7 @@ class Expression(object):
                             f"did you forget to put brackets? E.g. always write (x==2)|(y<5).")
         return Operator("or", [other, self])
 
-    def __xor__(self, other):
+    def __xor__(self, other: BoolExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -406,7 +406,7 @@ class Expression(object):
             return self
         return cp.Xor([self, other])
 
-    def __rxor__(self, other):
+    def __rxor__(self, other: BoolExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -420,7 +420,7 @@ class Expression(object):
 
     # Mathematical Operators, including 'r'everse if it exists
     # Addition
-    def __add__(self, other):
+    def __add__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -429,7 +429,7 @@ class Expression(object):
             return self
         return Operator("sum", [self, other])
 
-    def __radd__(self, other):
+    def __radd__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -439,17 +439,19 @@ class Expression(object):
         return Operator("sum", [other, self])
 
     # subtraction
-    def __sub__(self, other):
+    def __sub__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__rsub__(self)
+        if isinstance(other, np.bool_):
+            other = int(other)  # unary - on np.bool_ is not allowed by numpy
         # if is_num(other) and other == 0:
         #     return self
         # return Operator("sub", [self, other])
         return self.__add__(-other)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -460,7 +462,7 @@ class Expression(object):
         return (-self).__radd__(other)
     
     # multiplication: use GlobalFunction Multiplication so it can be decomposed (e.g. to linear)
-    def __mul__(self, other):
+    def __mul__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -469,7 +471,7 @@ class Expression(object):
             return self
         return cp.Multiplication(self, other)
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -490,7 +492,7 @@ class Expression(object):
         warnings.warn("We only support floordivision, use // instead of /", SyntaxWarning)
         return self.__rfloordiv__(other)
 
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
@@ -499,21 +501,21 @@ class Expression(object):
             return self
         return cp.Division(self, other)
 
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__floordiv__(self)
         return cp.Division(other, self)
 
-    def __mod__(self, other):
+    def __mod__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)
             return other.__rmod__(self)
         return cp.Modulo(self, other)
 
-    def __rmod__(self, other):
+    def __rmod__(self, other: ExprLike | np.ndarray):
         if isinstance(other, np.ndarray):
             if not isinstance(other, cp.expressions.variables.NDVarArray):
                 other = cp.cpm_array(other)

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -485,7 +485,7 @@ def canonical_comparison(lst_of_expr: ListLike[Expression]) -> list[Expression]:
                 
                 # 2) add collected variables to lhs
                 if isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and (lhs.name == "sum" or lhs.name == "wsum")):
-                    lhs = lhs + lhs2
+                    lhs = Operator("sum", [lhs, lhs2])
                 else:
                     raise ValueError(f"unexpected expression on lhs of expression, should be sum, wsum or intvar but got {lhs}")
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -266,6 +266,15 @@ class TestMul:
         assert yx.shape == (3,)
         assert all(a is y or b is y for a, b in (e.args for e in yx))
 
+    def test_scalar_expr_with_numpy_array(self):
+        e = sum(cp.boolvar(3))
+        y = np.array([1, 2, 3])
+        ey, ye = e * y, y * e
+        assert isinstance(ey, NDVarArray)
+        assert ey.shape == ye.shape == (3,)
+        for a, b in zip(ey, ye):
+            assert str(a) == str(b)
+
     def test_nullarg_mul(self):
         x = intvar(0,5,shape=3, name="x")
         a = np.array([0,1,1], dtype=bool)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -243,6 +243,18 @@ class TestMul:
         assert expr.is_lhs_num is False
         assert expr.args[0] is x and expr.args[1] is y
 
+    def test_nullarg_mul(self):
+        x = intvar(0,5,shape=3, name="x")
+        a = np.array([0,1,1], dtype=bool)
+
+        prod = x * a
+
+        assert isinstance(prod, NDVarArray)
+        for expr in prod:
+            assert isinstance(expr, Expression) or expr == 0
+
+class TestArrayExpressions:
+
     def test_scalar_expr_with_ndarray(self):
         x = intvar(0, 5, shape=3, name=tuple("abc"))
         y = intvar(0, 5, name="y")
@@ -274,18 +286,6 @@ class TestMul:
         assert ey.shape == ye.shape == (3,)
         for a, b in zip(ey, ye):
             assert str(a) == str(b)
-
-    def test_nullarg_mul(self):
-        x = intvar(0,5,shape=3, name="x")
-        a = np.array([0,1,1], dtype=bool)
-
-        prod = x * a
-
-        assert isinstance(prod, NDVarArray)
-        for expr in prod:
-            assert isinstance(expr, Expression) or expr == 0
-
-class TestArrayExpressions:
 
     def test_sum(self):
         x = intvar(0,5,shape=10, name="x")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -243,6 +243,29 @@ class TestMul:
         assert expr.is_lhs_num is False
         assert expr.args[0] is x and expr.args[1] is y
 
+    def test_scalar_expr_with_ndarray(self):
+        x = intvar(0, 5, shape=3, name=tuple("abc"))
+        y = intvar(0, 5, name="y")
+        xy, yx = x * y, y * x
+        assert isinstance(xy, NDVarArray) and isinstance(yx, NDVarArray)
+        for i in range(3):
+            assert set(xy[i].args) == set(yx[i].args)
+            assert set((x + y)[i].args) == set((y + x)[i].args)
+        assert str(x == y) == str(y == x)
+
+    def test_scalar_expr_left_of_ndarray_mul(self):
+        # y * x must broadcast element-wise, not wrap the whole array in one Multiplication
+        from cpmpy.expressions.globalfunctions import Multiplication
+
+        x = intvar(0, 10, shape=3, name=tuple("abc"))
+        y = intvar(0, 10, name="y")
+        assert isinstance(x * y, NDVarArray)
+        yx = y * x
+        assert isinstance(yx, NDVarArray)
+        assert not isinstance(yx, Multiplication)
+        assert yx.shape == (3,)
+        assert all(a is y or b is y for a, b in (e.args for e in yx))
+
     def test_nullarg_mul(self):
         x = intvar(0,5,shape=3, name="x")
         a = np.array([0,1,1], dtype=bool)


### PR DESCRIPTION
Fix 'Expr OP NDArr' by doing 'NDArr ROP Expr'

Fixes:
```
>>> x * y
NDVarArray([(a) * (y), (b) * (y), (c) * (y)], dtype=object)
>>> y * x
(y) * ([a b c])
```
from #1034

Curiously its actually a typing gap... that you can also get an
ndarray as second argument.

So with this now fixed, we might as well just go ahead and type all
these operators...?
