### PR TITLE
Decompose, `Regular` and `MDD` bugs from fuzztesting

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -962,7 +962,7 @@ class Regular(GlobalConstraint):
         # define the rest of the automaton using transition table
         cons.extend(Table([state_vars[i - 1], arr[i], state_vars[i]], transitions) for i in range(1, len(arr)))
         # last state must be accepting
-        value = [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])]
+        value : list[Expression] = [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])]
         if complete:
             # constraint is satisfied iff last state is accepting
             return value, cons

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -958,12 +958,15 @@ class Regular(GlobalConstraint):
         state_vars = intvar(0, len(self.nodes)-1, shape=len(arr))
         id_start = self.node_map[start]
         # optimization: we know the entry node of the automaton, results in smaller table
-        defining: list[Expression] = [Table([arr[0], state_vars[0]], [[v, e] for s, v, e in transitions if s == id_start])]
+        cons: list[Expression] = [Table([arr[0], state_vars[0]], [[v, e] for s, v, e in transitions if s == id_start])]
         # define the rest of the automaton using transition table
-        defining.extend(Table([state_vars[i - 1], arr[i], state_vars[i]], transitions) for i in range(1, len(arr)))
+        cons.extend(Table([state_vars[i - 1], arr[i], state_vars[i]], transitions) for i in range(1, len(arr)))
 
-        # constraint is satisfied iff last state is accepting
-        return [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])], defining
+        if complete:
+            # constraint is satisfied iff last state is accepting
+            return [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])], cons
+        else:
+            return cons, []
 
     def decompose_linear_positive(self) -> tuple[list[Expression], list[Expression]]:
         return self.decompose_linear(complete=False)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1224,6 +1224,8 @@ class MDD(GlobalConstraint):
 
         if necessary_levels:
             first_needed = min(necessary_levels)
+            # We iterate over all levels starting from the first level that needs a dummy node.
+            # This is done because invalid edges must be introduced layer by layer, so that the complete MDD admits a solution to the flow problem for all variable assignments.
             for level in range(first_needed + 1, n):
                 dummy = dummy_nodes[level - 1]
                 levels[dummy] = level

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -138,7 +138,7 @@
 import copy
 import warnings
 from collections import defaultdict
-from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING, reveal_type
+from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
 import numpy as np
 
 import cpmpy as cp

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -138,7 +138,7 @@
 import copy
 import warnings
 from collections import defaultdict
-from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING
+from typing import cast, Literal, Optional, Iterable, Any, TYPE_CHECKING, reveal_type
 import numpy as np
 
 import cpmpy as cp
@@ -1137,7 +1137,7 @@ class MDD(GlobalConstraint):
         for id1, v, id2 in transitions:
             self.mapping[id1][v] = id2
 
-        self.levels = {self.root_node: 0}
+        self.levels : dict[int | str, int] = {self.root_node: 0}
         current_nodes = [self.root_node]
         for level in range(len(array)):
             new_nodes = []
@@ -1188,7 +1188,8 @@ class MDD(GlobalConstraint):
                     self.mapping.pop(node, None)
                     self.levels.pop(node, None)
 
-    def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]], dict[int|str, int]]:
+    def _get_complete_mdd(self, mapping : dict[int, dict[int, int]], levels: dict[int, int], sink_node: int
+                          ) -> tuple[dict[int, dict[int, int]], set[tuple[int, int]], dict[int, int]]:
         """
         Auxiliary function that extends the MDD with invalid edges, which are directed to level-specific dummy nodes.
         Any path reaching a dummy node is directed to the sink node level by level, for all subsequent variable assignments.
@@ -1199,42 +1200,40 @@ class MDD(GlobalConstraint):
             (source node, transition value) that are added to the MDD.
         """
         arr = self.args[0]
-        invalid_edges = set()
-        extended_mapping = copy.deepcopy(self.mapping)
+        invalid_edges : set[tuple[int, int]] = set()
+        extended_mapping : dict[int , dict[int, int]] = copy.deepcopy(mapping)
 
         n = len(arr)
-        levels = self.levels.copy()
+        levels = levels.copy()
 
-        all_nodes = set(levels.keys())
+        next_id = len(levels) + 1
 
-        dummy_nodes : list[str|int] = []
-        i = 0
-        while len(dummy_nodes) < n - 1:
-            dummy_nodes += [name] if (name := f"__dummy_{i}__") not in all_nodes else []
-            i += 1
-        dummy_nodes.append(self.sink_node)
+        dummy_nodes: list[int] = [next_id + i for i in range(n - 1)]
+        dummy_nodes.append(sink_node)
 
         for i, dummy in enumerate(dummy_nodes):
             levels[dummy] = i + 1
 
+        necessary_levels = []
         for id1 in list(extended_mapping.keys()):
             level = levels[id1]
             domain = range(arr[level].lb, arr[level].ub + 1)
-
             for v in domain:
                 if v not in extended_mapping[id1]:
                     extended_mapping[id1][v] = dummy_nodes[level]
+                    if level not in necessary_levels:
+                        necessary_levels.append(level)
                     invalid_edges.add((id1, v))
 
-        for level in range(1, n):
-            dummy = dummy_nodes[level-1]
-            next_dummy = dummy_nodes[level]
-
-            domain = range(arr[level-1].lb, arr[level-1].ub + 1)
-
-            for v in domain:
-                extended_mapping[dummy][v] = next_dummy
-                invalid_edges.add((dummy, v))
+        if necessary_levels:
+            first_needed = min(necessary_levels)
+            for level in range(first_needed + 1, n):
+                dummy = dummy_nodes[level - 1]
+                next_dummy = dummy_nodes[level]
+                domain = range(arr[level].lb, arr[level].ub + 1)
+                for v in domain:
+                    extended_mapping[dummy][v] = next_dummy
+                    invalid_edges.add((dummy, v))
 
         return extended_mapping, invalid_edges, levels
 
@@ -1259,22 +1258,41 @@ class MDD(GlobalConstraint):
         if self.reduce:
             self._reduce()
 
+        node_map: dict[int | str, int] = {node: idx for idx, node in enumerate(self.levels)}
+        mapping: dict[int, dict[int, int]] = defaultdict(dict)
+
+        for src, edges in self.mapping.items():
+            for val, dst in edges.items():
+                mapping[node_map[src]][val] = node_map[dst]
+
+        levels: dict[int, int] = {
+            node_map[node]: lvl for node, lvl in self.levels.items()
+        }
+        sink_node : int = node_map[self.sink_node]
+
+        reveal_type(levels)
+
         if complete:
-        # MDD is extended with invalid edges, which are directed to the sink node
-            mapping, invalid_edges_set, levels = self._get_complete_mdd()
+            complete_mapping, invalid_edges_set, complete_levels = self._get_complete_mdd(
+                mapping, levels, sink_node
+            )
+
+            reveal_type(levels)
+            reveal_type(complete_levels)
+
+            levels = complete_levels
             invalid_edges = frozenset(invalid_edges_set)
+
         else:
-            mapping = self.mapping
-            levels = self.levels
             invalid_edges = frozenset()
 
         # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
         # The default is an empty list, representing no ingoing / outgoing flow.
-        flow_in: dict[int | str, list[Expression]] = defaultdict(list)
-        flow_out: dict[int | str, list[Expression]] = defaultdict(list)
-
+        flow_in: dict[int, list[Expression]] = defaultdict(list)
+        flow_out: dict[int, list[Expression]] = defaultdict(list)
+        reveal_type(levels)
         # Used to link edge variables to direct encoding variables in a later step
-        edge_vars = defaultdict(list)
+        edge_vars : dict[tuple[int, int], list[Expression]] = defaultdict(list)
         invalid_edge_vars = []
 
         # Determine flow in and flow out for each node, and make a boolvar for each edge

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1189,7 +1189,7 @@ class MDD(GlobalConstraint):
                     self.levels.pop(node, None)
 
     def _get_complete_mdd(self, mapping : dict[int, dict[int, int]], levels: dict[int, int], sink_node: int
-                          ) -> tuple[dict[int, dict[int, int]], set[tuple[int, int]], dict[int, int]]:
+                          ) -> tuple[dict[int, dict[int, int]], dict[int, int], set[tuple[int, int]]]:
         """
         Auxiliary function that extends the MDD with invalid edges, which are directed to level-specific dummy nodes.
         Any path reaching a dummy node is directed to the sink node level by level, for all subsequent variable assignments.
@@ -1211,9 +1211,6 @@ class MDD(GlobalConstraint):
         dummy_nodes: list[int] = [next_id + i for i in range(n - 1)]
         dummy_nodes.append(sink_node)
 
-        for i, dummy in enumerate(dummy_nodes):
-            levels[dummy] = i + 1
-
         necessary_levels = []
         for id1 in list(extended_mapping.keys()):
             level = levels[id1]
@@ -1229,13 +1226,14 @@ class MDD(GlobalConstraint):
             first_needed = min(necessary_levels)
             for level in range(first_needed + 1, n):
                 dummy = dummy_nodes[level - 1]
+                levels[dummy] = level
                 next_dummy = dummy_nodes[level]
                 domain = range(arr[level].lb, arr[level].ub + 1)
                 for v in domain:
                     extended_mapping[dummy][v] = next_dummy
                     invalid_edges.add((dummy, v))
 
-        return extended_mapping, invalid_edges, levels
+        return extended_mapping, levels, invalid_edges
 
     def decompose_positive(self) -> tuple[list[Expression], list[Expression]]:
         return self.decompose(complete=False)
@@ -1261,25 +1259,17 @@ class MDD(GlobalConstraint):
         node_map: dict[int | str, int] = {node: idx for idx, node in enumerate(self.levels)}
         mapping: dict[int, dict[int, int]] = defaultdict(dict)
 
-        for src, edges in self.mapping.items():
-            for val, dst in edges.items():
+        for src, src_edges in self.mapping.items():
+            for val, dst in src_edges.items():
                 mapping[node_map[src]][val] = node_map[dst]
 
-        levels: dict[int, int] = {
-            node_map[node]: lvl for node, lvl in self.levels.items()
-        }
+        levels: dict[int, int] = {node_map[node]: lvl for node, lvl in self.levels.items()}
         sink_node : int = node_map[self.sink_node]
 
-        reveal_type(levels)
-
         if complete:
-            complete_mapping, invalid_edges_set, complete_levels = self._get_complete_mdd(
-                mapping, levels, sink_node
-            )
+            complete_mapping, complete_levels, invalid_edges_set = self._get_complete_mdd(mapping, levels, sink_node)
 
-            reveal_type(levels)
-            reveal_type(complete_levels)
-
+            mapping = complete_mapping
             levels = complete_levels
             invalid_edges = frozenset(invalid_edges_set)
 
@@ -1290,7 +1280,6 @@ class MDD(GlobalConstraint):
         # The default is an empty list, representing no ingoing / outgoing flow.
         flow_in: dict[int, list[Expression]] = defaultdict(list)
         flow_out: dict[int, list[Expression]] = defaultdict(list)
-        reveal_type(levels)
         # Used to link edge variables to direct encoding variables in a later step
         edge_vars : dict[tuple[int, int], list[Expression]] = defaultdict(list)
         invalid_edge_vars = []

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -961,12 +961,13 @@ class Regular(GlobalConstraint):
         cons: list[Expression] = [Table([arr[0], state_vars[0]], [[v, e] for s, v, e in transitions if s == id_start])]
         # define the rest of the automaton using transition table
         cons.extend(Table([state_vars[i - 1], arr[i], state_vars[i]], transitions) for i in range(1, len(arr)))
-
+        # last state must be accepting
+        value = [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])]
         if complete:
             # constraint is satisfied iff last state is accepting
-            return [InDomain(state_vars[-1], [self.node_map[e] for e in accepting])], cons
+            return value, cons
         else:
-            return cons, []
+            return value + cons, []
 
     def decompose_linear_positive(self) -> tuple[list[Expression], list[Expression]]:
         return self.decompose_linear(complete=False)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1151,7 +1151,6 @@ class MDD(GlobalConstraint):
         sink_nodes = [node for node, level in self.levels.items() if level == len(array)]
         assert len(sink_nodes) == 1
         self.sink_node = sink_nodes[0]
-
         # store whether the MDD should be reduced during decomposition
         self.reduce = reduce
 
@@ -1189,28 +1188,55 @@ class MDD(GlobalConstraint):
                     self.mapping.pop(node, None)
                     self.levels.pop(node, None)
 
-
-
-    def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
+    def _get_complete_mdd(self) -> tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]], dict[int|str, int]]:
         """
-        Auxiliary function that extends the MDD with invalid edges, which are directed to the sink node.
+        Auxiliary function that extends the MDD with invalid edges, which are directed to level-specific dummy nodes.
+        Any path reaching a dummy node is directed to the sink node level by level, for all subsequent variable assignments.
 
         Returns:
             tuple[dict[int | str, dict[int, int | str]], set[tuple[int | str, int]]]:
-            A tuple containing the extended mapping of the MDD and a set of invalid edges (source node, transition value) that are added to the MDD.
+            A tuple containing the extended mapping of the MDD and a set of invalid edges
+            (source node, transition value) that are added to the MDD.
         """
         arr = self.args[0]
         invalid_edges = set()
         extended_mapping = copy.deepcopy(self.mapping)
-        for id1 in self.mapping.keys():
-            level = self.levels[id1]
+
+        n = len(arr)
+        levels = self.levels.copy()
+
+        all_nodes = set(levels.keys())
+
+        dummy_nodes : list[str|int] = []
+        i = 0
+        while len(dummy_nodes) < n - 1:
+            dummy_nodes += [name] if (name := f"__dummy_{i}__") not in all_nodes else []
+            i += 1
+        dummy_nodes.append(self.sink_node)
+
+        for i, dummy in enumerate(dummy_nodes):
+            levels[dummy] = i + 1
+
+        for id1 in list(extended_mapping.keys()):
+            level = levels[id1]
             domain = range(arr[level].lb, arr[level].ub + 1)
+
             for v in domain:
-                if v not in self.mapping[id1]:
-                    extended_mapping[id1][v] = self.sink_node
+                if v not in extended_mapping[id1]:
+                    extended_mapping[id1][v] = dummy_nodes[level]
                     invalid_edges.add((id1, v))
 
-        return extended_mapping, invalid_edges
+        for level in range(1, n):
+            dummy = dummy_nodes[level-1]
+            next_dummy = dummy_nodes[level]
+
+            domain = range(arr[level-1].lb, arr[level-1].ub + 1)
+
+            for v in domain:
+                extended_mapping[dummy][v] = next_dummy
+                invalid_edges.add((dummy, v))
+
+        return extended_mapping, invalid_edges, levels
 
     def decompose_positive(self) -> tuple[list[Expression], list[Expression]]:
         return self.decompose(complete=False)
@@ -1235,10 +1261,11 @@ class MDD(GlobalConstraint):
 
         if complete:
         # MDD is extended with invalid edges, which are directed to the sink node
-            mapping, invalid_edges_set = self._get_complete_mdd()
+            mapping, invalid_edges_set, levels = self._get_complete_mdd()
             invalid_edges = frozenset(invalid_edges_set)
         else:
             mapping = self.mapping
+            levels = self.levels
             invalid_edges = frozenset()
 
         # Ingoing and outgoing flow for each node (key: node ID, value: list of edge variables)
@@ -1254,7 +1281,7 @@ class MDD(GlobalConstraint):
         for id1, edges in mapping.items():
             for value, id2 in edges.items():
                 edge_var = cp.boolvar()
-                level = self.levels[id1]
+                level = levels[id1]
                 flow_out[id1].append(edge_var)
                 flow_in[id2].append(edge_var)
                 edge_vars[(level, value)].append(edge_var)
@@ -1262,32 +1289,37 @@ class MDD(GlobalConstraint):
                 if (id1, value) in invalid_edges:
                     invalid_edge_vars.append(edge_var)
 
-        defining = []
-        constraining = []
+        cons = []
+        value_cons = []
 
         # Enforce flow constraints: flow in = flow out, at most one activated in/out edge
-        for node, level in self.levels.items():
+        for node, level in levels.items():
             incoming = flow_in[node]
             outgoing = flow_out[node]
 
             if level == 0:
-                constraining.append(cp.sum(outgoing) == 1) # root
+                value_cons.append(cp.sum(outgoing) == 1) # root
             elif level == len(arr):
-                defining.append(cp.sum(incoming) == 1) # sink
+                cons.append(cp.sum(incoming) == 1) # sink
             else:
-                defining.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
-                defining.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
-                defining.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
+                cons.append(cp.sum(incoming) == cp.sum(outgoing)) #enforce flow for internal nodes
+                cons.append(cp.sum(incoming) <= 1) # redundant constraint: at most one incoming edge
+                cons.append(cp.sum(outgoing) <= 1) # redundant constraint: at most one outgoing edge
 
         # Enforce that when arr[i] == v, exactly one of the edges at level i with label v is true, otherwise none can be true
         for (level, value), vars_ in edge_vars.items():
-            defining.append(cp.sum(vars_) == (arr[level] == value))
+            cons.append(cp.sum(vars_) == (arr[level] == value))
 
-        constraining.append(cp.sum(invalid_edge_vars) == 0)
+        value_cons.append(cp.sum(invalid_edge_vars) == 0)
 
-        # When the MDD is extended to a complete MDD by means of invalid edges, there is always a solution to the flow problem.
-        # The only constraining constraints are therefore that the root flow is equal to 1, and that no invalid edge has any flow.
-        return constraining, defining
+        if complete:
+            # When the MDD is extended to a complete MDD by means of invalid edges, there is always a solution to the flow problem.
+            # The only value constraints are therefore that the root flow is equal to 1, and that no invalid edge has any flow.
+            return value_cons, cons
+        else:
+            # The MDD is not complete (i.e. does not admit a solution to the flow problem for all variable assignments).
+            # Therefore, all constraints must be considered value constraints, as they can all be violated by some variable assignment.
+            return value_cons + cons, []
 
 
     def value(self) -> Optional[bool]:

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -90,8 +90,11 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             if csemap is not None:
                 decomp = csemap.get_decomposition(expr)
                 if decomp is not None:
-                    assert decomp.name == "and", "decompose_in_tree: expected a conjunction but got {decomp}"
-                    newlist.extend(decomp.args)
+                    assert isinstance(decomp, Expression)
+                    if decomp.name == "and":
+                        newlist.extend(decomp.args)
+                    else:
+                        newlist.append(decomp)
                     continue
 
             # First see if a custom decomposition is provided for positive context, then for any context, otherwise use the default

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -251,6 +251,7 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     decomp = csemap.get_decomposition(arg)
                     if decomp is not None:
                         newargs.append(decomp)
+                        changed = True
                         continue
                 arg_orig = arg
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -21,6 +21,7 @@ This allows to post the decomposed expression tree to the solver if it supports 
 
 import copy
 from typing import AbstractSet, Optional, Dict, Any, Callable, Protocol, cast, overload
+import warnings
 import numpy as np
 
 
@@ -110,8 +111,14 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                 todolist.extend(toplevel_exprs)
             if len(exprs) > 0:
                 todolist.extend(exprs)
-                if csemap is not None:
-                    csemap.save_decomposition(expr, Operator("and", exprs))
+                # don't save toplevel decompositions to the csemap, 
+                # we currently don't have a way of distinguishing positive and negative in the csemap ... TODO
+                # if csemap is not None:
+                #     if len(exprs) == 1: # dont wrap in conjunction
+                #         csemap.save_decomposition(expr, exprs[0])
+                #     else:
+                #         csemap.save_decomposition(expr, Operator("and", exprs))
+        
         elif isinstance(expr, (bool, np.bool_)):
             # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
             changed = True

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -670,6 +670,22 @@ class TestGlobal:
         assert num_true + num_false == 2**3
         assert len(true_sols & false_sols) == 0# no solutions can be in both
 
+    def test_regular_positive_reif(self):
+        b = cp.boolvar()
+        x = cp.intvar(0, 1, shape=2)
+
+        # 3-state automaton that accepts only the string [0, 0].
+        reg = cp.Regular(x, transitions=[('a', 0, 'b'), ('b', 0, 'c')], start='a', accepting=['c'])
+
+        m = cp.Model([x[0] == 1, b.implies(reg)])
+
+        # x[0] = 1 has no transition from 'a' -> automaton rejects -> reg is False.
+        # b is False, so "b -> reg" MUST be satisfiable.
+        sat = m.solve()
+
+        assert sat, "BUG: half-reified Regular is unsound for rejected strings"
+
+
     def test_mdd(self):
         x = cp.intvar(0, 3, shape=3)
 
@@ -693,6 +709,30 @@ class TestGlobal:
         assert sols_redu == set(solutions)
 
         assert num_orig == num_redu
+
+    def test_mdd_variable_reuse(self):
+        x = cp.intvar(0, 3, shape=3, name="x")
+        # MDD accepting exactly [1,1,1]
+        mdd = cp.MDD(x, transitions=[('A', 1, 'B'),
+                                  ('B', 1, 'C'),
+                                  ('C', 1, 'D'), ])
+
+        # x=[0,0,0] is NOT a path in the MDD => MDD(x) is False => ~MDD(x) must be True.
+        m_neg = cp.Model([x[0] == 0, x[1] == 0, x[2] == 0, ~mdd])
+        assert m_neg.solve()
+
+        # Full reification: b == MDD(x), force b False with the rejected assignment.
+        b = cp.boolvar(name="b")
+        m_reif = cp.Model([x[0] == 0, x[1] == 0, x[2] == 0, b == mdd, ~b])
+        assert m_reif.solve()
+
+        # Sanity: a genuinely accepted assignment still works positively.
+        m_toplevel = cp.Model([x[0] == 1, x[1] == 1, x[2] == 1, mdd])
+        assert m_toplevel.solve()
+
+        # Sanity: a non-accepted assignment still works when the mdd is positively reified, with no other constraints on b.
+        m_pos = cp.Model([x[0] == 0, x[1] == 0, x[2] == 0, b.implies(mdd)])
+        assert m_pos.solve()
 
 
     def test_minimum(self):
@@ -1735,20 +1775,7 @@ class TestTypeChecks:
 
         assert total == len(all_sols) + len(not_all_sols)
 
-    def test_regular_positive_reif(self):
-        b = cp.boolvar()
-        x = cp.intvar(0, 1, shape=2)
 
-        # 3-state automaton that accepts only the string [0, 0].
-        reg = cp.Regular(x, transitions=[('a', 0, 'b'), ('b', 0, 'c')], start='a', accepting=['c'])
-
-        m = cp.Model([x[0] == 1, b.implies(reg)])
-
-        # x[0] = 1 has no transition from 'a' -> automaton rejects -> reg is False.
-        # b is False, so "b -> reg" MUST be satisfiable.
-        sat = m.solve()
-
-        assert sat, "BUG: half-reified Regular is unsound for rejected strings"
 
 
     def test_increasing(self):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1735,6 +1735,12 @@ class TestTypeChecks:
 
         assert total == len(all_sols) + len(not_all_sols)
 
+    # Addressed in PR #1039, still failing
+    def test_all_equal_exceptn_nested_boolexpr_with_negated_reuse(self):
+        a, b = cp.boolvar(2, name=("a", "b"))
+        constr = cp.AllEqualExceptN([a, b, False, a | b], 4)
+        assert cp.Model([constr, (~constr) | constr]).solve(solver="ortools")
+
 
     def test_increasing(self):
         x = cp.intvar(-8, 8)
@@ -1757,6 +1763,23 @@ class TestTypeChecks:
         assert not cp.Model([cp.Decreasing(x,y,b)]).solve()
         z = cp.intvar(2,5)
         assert cp.Model([cp.Decreasing(z,b)]).solve()
+
+    # PR #1039, now fixed
+    def test_decreasing_nested_boolexpr_with_negated_reuse(self):
+        ivv63, ivv64 = cp.intvar(-8, 8, shape=2)
+        iv0 = cp.intvar(-8, 8, name="x")
+        derived = (iv0 - 10 * ivv64 - 8) // 10
+
+        constr = cp.Decreasing(ivv63, ivv64)
+        derived_constr = cp.Decreasing(ivv63, derived)
+
+        model = cp.Model([
+            constr,
+            constr.implies(constr),
+            derived_constr,
+            derived_constr.implies(derived_constr),
+        ])
+        assert model.solve(solver="ortools")
 
     def test_increasing_strict(self):
         x = cp.intvar(-8, 8)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1684,7 +1684,7 @@ class TestTypeChecks:
         assert cp.Model([cp.AllEqual(a,b,False, a | b)]).solve()
         assert not cp.Model([cp.AllEqual(x,y,b)]).solve()
 
-    def test_all_equal_exceptn(self):
+    '''def test_all_equal_exceptn(self):
         x = cp.intvar(-8, 8)
         y = cp.intvar(-7, -1)
         b = cp.boolvar()
@@ -1699,7 +1699,7 @@ class TestTypeChecks:
         # test with list of n
         iv = cp.intvar(0, 4, shape=7)
         assert not cp.Model([cp.AllEqualExceptN([iv], [7,8]), iv[0] != iv[1]]).solve()
-        assert cp.Model([cp.AllEqualExceptN([iv], [4, 1]), iv[0] != iv[1]]).solve()
+        assert cp.Model([cp.AllEqualExceptN([iv], [4, 1]), iv[0] != iv[1]]).solve()'''
 
     def test_not_all_equal_exceptn(self):
         x = cp.intvar(lb=0, ub=3, shape=3)
@@ -1740,6 +1740,22 @@ class TestTypeChecks:
         a, b = cp.boolvar(2, name=("a", "b"))
         constr = cp.AllEqualExceptN([a, b, False, a | b], 4)
         assert cp.Model([constr, (~constr) | constr]).solve(solver="ortools")
+
+
+    def test_regular_positive_reif(self):
+        b = cp.boolvar()
+        x = cp.intvar(0, 1, shape=2)
+
+        # 3-state automaton that accepts only the string [0, 0].
+        reg = cp.Regular(x, transitions=[('a', 0, 'b'), ('b', 0, 'c')], start='a', accepting=['c'])
+
+        m = cp.Model([x[0] == 1, b.implies(reg)])
+
+        # x[0] = 1 has no transition from 'a' -> automaton rejects -> reg is False.
+        # b is False, so "b -> reg" MUST be satisfiable.
+        sat = m.solve()
+
+        assert sat, "BUG: half-reified Regular is unsound for rejected strings"
 
 
     def test_increasing(self):

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1735,13 +1735,6 @@ class TestTypeChecks:
 
         assert total == len(all_sols) + len(not_all_sols)
 
-    # Addressed in PR #1039, still failing
-    '''def test_all_equal_exceptn_nested_boolexpr_with_negated_reuse(self):
-        a, b = cp.boolvar(2, name=("a", "b"))
-        constr = cp.AllEqualExceptN([a, b, False, a | b], 4)
-        assert cp.Model([constr, (~constr) | constr]).solve(solver="ortools")'''
-
-
     def test_regular_positive_reif(self):
         b = cp.boolvar()
         x = cp.intvar(0, 1, shape=2)
@@ -1779,23 +1772,6 @@ class TestTypeChecks:
         assert not cp.Model([cp.Decreasing(x,y,b)]).solve()
         z = cp.intvar(2,5)
         assert cp.Model([cp.Decreasing(z,b)]).solve()
-
-    # PR #1039, now fixed
-    def test_decreasing_nested_boolexpr_with_negated_reuse(self):
-        ivv63, ivv64 = cp.intvar(-8, 8, shape=2)
-        iv0 = cp.intvar(-8, 8, name="x")
-        derived = (iv0 - 10 * ivv64 - 8) // 10
-
-        constr = cp.Decreasing(ivv63, ivv64)
-        derived_constr = cp.Decreasing(ivv63, derived)
-
-        model = cp.Model([
-            constr,
-            constr.implies(constr),
-            derived_constr,
-            derived_constr.implies(derived_constr),
-        ])
-        assert model.solve(solver="ortools")
 
     def test_increasing_strict(self):
         x = cp.intvar(-8, 8)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1684,7 +1684,7 @@ class TestTypeChecks:
         assert cp.Model([cp.AllEqual(a,b,False, a | b)]).solve()
         assert not cp.Model([cp.AllEqual(x,y,b)]).solve()
 
-    '''def test_all_equal_exceptn(self):
+    def test_all_equal_exceptn(self):
         x = cp.intvar(-8, 8)
         y = cp.intvar(-7, -1)
         b = cp.boolvar()
@@ -1699,7 +1699,7 @@ class TestTypeChecks:
         # test with list of n
         iv = cp.intvar(0, 4, shape=7)
         assert not cp.Model([cp.AllEqualExceptN([iv], [7,8]), iv[0] != iv[1]]).solve()
-        assert cp.Model([cp.AllEqualExceptN([iv], [4, 1]), iv[0] != iv[1]]).solve()'''
+        assert cp.Model([cp.AllEqualExceptN([iv], [4, 1]), iv[0] != iv[1]]).solve()
 
     def test_not_all_equal_exceptn(self):
         x = cp.intvar(lb=0, ub=3, shape=3)
@@ -1736,10 +1736,10 @@ class TestTypeChecks:
         assert total == len(all_sols) + len(not_all_sols)
 
     # Addressed in PR #1039, still failing
-    def test_all_equal_exceptn_nested_boolexpr_with_negated_reuse(self):
+    '''def test_all_equal_exceptn_nested_boolexpr_with_negated_reuse(self):
         a, b = cp.boolvar(2, name=("a", "b"))
         constr = cp.AllEqualExceptN([a, b, False, a | b], 4)
-        assert cp.Model([constr, (~constr) | constr]).solve(solver="ortools")
+        assert cp.Model([constr, (~constr) | constr]).solve(solver="ortools")'''
 
 
     def test_regular_positive_reif(self):

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -2,6 +2,7 @@ import cpmpy as cp
 from cpmpy.expressions.globalconstraints import GlobalConstraint
 from cpmpy.expressions.globalfunctions import GlobalFunction
 from cpmpy.expressions.utils import flatlist
+from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.decompose_global import decompose_in_tree
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl  # to reset counters
 from cpmpy.transformations.linearize import decompose_linear
@@ -313,3 +314,66 @@ class TestTransfDecomp:
         if "exact" in cp.SolverLookup.solvernames():  # otherwise, not supported
             model = cp.Model(cons)
             model.solve(solver="exact")
+
+
+    # edge cases find by fuzztesting
+    def test_repeated_nested_global(self):
+        a,b = cp.intvar(0,10, shape=2, name=tuple("ab"))
+        cons = cp.AllDifferent(a,b)
+
+        constraints = [cons, ~cons | cons]
+        decomposed = decompose_in_tree(constraints)
+        assert set(map(str, decomposed)) == {
+            "(a) != (b)", # decomposition of the first constraint
+            "((a) == (b)) or ((a) != (b))", # decomposition of the second constraint
+        }
+    
+    def test_all_equal_exceptn_nested_boolexpr_with_negated_reuse(self):
+        a, b = cp.boolvar(2, name=("a", "b"))
+        constr = cp.AllEqualExceptN([a, b, False, a | b], 4)
+        assert cp.Model([constr, (~constr) | constr]).solve(solver="ortools")
+
+    def test_single_expr_in_decomp_reused(self):
+
+        class MyCustomGlobal(GlobalConstraint):
+            def __init__(self, arr):
+                super().__init__("mycustomglobal", tuple(flatlist(arr)))
+
+            def decompose(self):
+                return [cp.sum(self.args) == 1], []
+
+        x = cp.intvar(0, 10, shape=3, name="x")
+        cons = MyCustomGlobal(x)
+
+        decomposed = decompose_in_tree([cons, ~cons | cons], csemap=CSEMap())
+        assert set(map(str, decomposed)) == {
+            "sum(x[0], x[1], x[2]) == 1",
+            "(sum(x[0], x[1], x[2]) != 1) or (sum(x[0], x[1], x[2]) == 1)",
+        }
+
+        decomposed = decompose_in_tree([~cons | cons, cons], csemap=CSEMap())
+        assert set(map(str, decomposed)) == {
+            "sum(x[0], x[1], x[2]) == 1",
+            "(sum(x[0], x[1], x[2]) != 1) or (sum(x[0], x[1], x[2]) == 1)",
+        }
+    
+    def test_global_custom_toplevel_repeated(self):
+
+        class MyCustomGlobal(GlobalConstraint):
+            def __init__(self, arr):
+                super().__init__("mycustomglobal", tuple(flatlist(arr)))
+
+            def decompose(self):
+                return [cp.sum(self.args) == 1], []
+            
+            def decompose_positive(self):
+                return [cp.sum(self.args) == 5], [] # something else to distinguish output
+
+        x = cp.intvar(0, 10, shape=3, name="x")
+        cons = MyCustomGlobal(x)
+
+        decomposed = decompose_in_tree([cons, ~cons], csemap=CSEMap())
+        assert set(map(str, decomposed)) == {
+            "sum(x[0], x[1], x[2]) == 5", # positive decompose
+            "sum(x[0], x[1], x[2]) != 1", # negative decompose (don't use positive-only one)
+        }


### PR DESCRIPTION
Fuzztesting revealed the following bug: in decompose_in_tree it is possible for an expression resulting from decomposition to not be a conjunction. Therefore the original assertion was invalid and the if-statement had to be rewritten.