### PR TITLE
Flatten wsum remove inplace edits

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -544,7 +544,9 @@ def normalized_numexpr(expr, csemap=None):
 
         # wsum needs special handling because expr.args is a tuple of which only 2nd one has exprs
         if expr.name == 'wsum':
-            weights, sub_exprs  = expr.args
+            weights, sub_exprs = expr.args
+            weights = list(weights)
+            sub_exprs = list(sub_exprs)
             # while here, avoid creation of auxiliary variables for compatible operators -/sum/wsum
             i = 0
             while(i < len(sub_exprs)): # can dynamically change

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -324,3 +324,14 @@ class TestFlattenExpr:
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
         #simplify output
         assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])"
+
+        # wsum negation shares the vars list; flatten must not corrupt paired coefficients
+        vars_list = [a, Operator('sum', [x, y]), 1]
+        pos_wsum = Operator('wsum', ([1, -2, -1], vars_list))
+        neg_wsum = Operator('wsum', ([-1, 2, 1], vars_list))
+        impl = (pos_wsum < 0).implies(neg_wsum == c)
+        flat = flatten_constraint([impl])
+        for con in flat:
+            if isinstance(con, Operator) and con.name == 'wsum':
+                w, v = con.args
+                assert len(w) == len(v), (w, v)


### PR DESCRIPTION
The flattening of wsum was making in-place update to the original wsum argument expressions, which we promise our transformations will never do (always copy). Causes bugs when other expressions re-used wsum's arguments.