### PR TITLE
Trivial decompose

### DIFF
--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -268,7 +268,11 @@ def _decompose_in_tree_args(args: list[Any]|tuple[Any, ...],
                     if len(rec_toplevel) > 0:
                         toplevel.extend(rec_toplevel)
 
-                if len(exprs) == 1:
+                if len(exprs) == 0:
+                    # empty decomposition (e.g. alldifferent over 0/1 elements)
+                    # is a trivially-true conjunction
+                    arg = BoolVal(True)
+                elif len(exprs) == 1:
                     arg = exprs[0]
                 else:
                     # replace arg by conjunction of decompose

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -313,3 +313,20 @@ class TestTransfDecomp:
         if "exact" in cp.SolverLookup.solvernames():  # otherwise, not supported
             model = cp.Model(cons)
             model.solve(solver="exact")
+
+
+    # edge cases find by fuzztesting
+    def test_decompose_empty_nested_alldifferent(self):
+        # Fuzz-test regression: a single-variable AllDifferent is vacuously true,
+        # but pairwise decompose() returns no constraints. When such a global is
+        # nested inside another expression (here: or), decompose_in_tree used to
+        # wrap the empty list in Operator("and", []) and crash.
+        x = cp.intvar(0, 10, name="x")
+        cons = [cp.any([cp.AllDifferent(x), cp.AllDifferent(x)])]
+
+        decomposed = decompose_in_tree(cons)
+        assert str(decomposed) == "[(boolval(True)) or (boolval(True))]"
+
+        # ortools: native top-level alldifferent, but empty supported_reified,
+        # so nested instances still go through generic decompose_in_tree
+        assert cp.Model(cons).solve(solver="ortools")

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -317,16 +317,11 @@ class TestTransfDecomp:
 
     # edge cases find by fuzztesting
     def test_decompose_empty_nested_alldifferent(self):
-        # Fuzz-test regression: a single-variable AllDifferent is vacuously true,
-        # but pairwise decompose() returns no constraints. When such a global is
-        # nested inside another expression (here: or), decompose_in_tree used to
-        # wrap the empty list in Operator("and", []) and crash.
+        # Fuzz-test regression: a single-variable AllDifferent is trivially true.
         x = cp.intvar(0, 10, name="x")
         cons = [cp.any([cp.AllDifferent(x), cp.AllDifferent(x)])]
 
         decomposed = decompose_in_tree(cons)
         assert str(decomposed) == "[(boolval(True)) or (boolval(True))]"
 
-        # ortools: native top-level alldifferent, but empty supported_reified,
-        # so nested instances still go through generic decompose_in_tree
         assert cp.Model(cons).solve(solver="ortools")


### PR DESCRIPTION
In some edgecases a global constraints would decompose into 0 constraints (e.g. AllDifferent with 0/1 elements). These 0 constraints would then be conjoined, which would lead to a crash. This fixes that.