### PR TITLE
Fix normalized boolexpr with const int rhs

### DIFF
--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -336,7 +336,7 @@ def get_or_make_var(expr, csemap=None):
     """Return ``(flat_arg, aux_constraints)`` with ``flat_arg`` a var or numeric constant.
 
     Already-flat ``expr`` is returned as ``(expr, [])``. Otherwise flatten ``expr`` and,
-    if needed, introduce ``V`` with ``flattened_expr == V`` added to ``aux_constraints``.
+    if needed, introduce ``BV`` with ``flattened_expr == BV`` added to ``aux_constraints``.
     """
 
     if __is_flat_var(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -333,20 +333,10 @@ def __is_flat_var_or_list(arg):
            is_star(arg)
 
 def get_or_make_var(expr, csemap=None):
-    """
-        Return ``(flat_arg, aux_constraints)``.
+    """Return ``(flat_arg, aux_constraints)`` with ``flat_arg`` a var or numeric constant.
 
-        ``flat_arg`` is a variable or numeric constant suitable as a flat normal-form argument.
-        ``aux_constraints`` is a (possibly empty) list of constraints produced while flattening.
-
-        If ``expr`` is already flat (``__is_flat_var(expr)``), return ``(expr, [])``.
-
-        Otherwise flatten ``expr`` recursively. When a fresh variable ``V`` is introduced to
-        stand in for the flattened expression, append ``flattened_expr == V`` to
-        ``aux_constraints`` (along with any constraints already produced by flattening).
-
-        Example: for boolean global ``gc = alldifferent([IV0, IV1])``, a typical result is
-        ``(BV0, [alldifferent(IV0, IV1) == BV0])``.
+    Already-flat ``expr`` is returned as ``(expr, [])``. Otherwise flatten ``expr`` and,
+    if needed, introduce ``V`` with ``flattened_expr == V`` added to ``aux_constraints``.
     """
 
     if __is_flat_var(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -94,11 +94,11 @@ import builtins
 import cpmpy as cp
 
 from .cse import CSEMap
-from .normalize import toplevel_list, simplify_boolean, simplify_bool_num_comparison
-from ..expressions.core import Expression, Comparison, Operator, BoolVal
+from .normalize import toplevel_list, simplify_boolean
+from ..expressions.core import Expression, Comparison, Operator
 from ..expressions.core import _wsum_should, _wsum_make
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl
-from ..expressions.utils import is_num, is_any_list, is_int, is_star, is_true_cst, is_false_cst
+from ..expressions.utils import is_num, is_any_list, is_int, is_star
 from .negation import recurse_negation
 
 
@@ -333,10 +333,10 @@ def __is_flat_var_or_list(arg):
            is_star(arg)
 
 def get_or_make_var(expr, csemap=None):
-    """Return ``(flat_arg, aux_constraints)`` with ``flat_arg`` a var or numeric constant.
-
-    Already-flat ``expr`` is returned as ``(expr, [])``. Otherwise flatten ``expr`` and,
-    if needed, introduce ``BV`` with ``flattened_expr == BV`` added to ``aux_constraints``.
+    """
+        Must return a variable, and list of flat normal constraints
+        Determines whether this is a Boolean or Integer variable and returns
+        the equivalent of: (var, normalize(expr) == var)
     """
 
     if __is_flat_var(expr):
@@ -450,7 +450,7 @@ def normalized_boolexpr(expr, csemap=None):
         if (expr.name != '!=') and (not expr.has_subexpr()):
             return (expr, [])  # shortcut
         else:
-            # LHS can be boolexpr, RHS must become flat (var or constant)
+            # LHS can be boolexpr, RHS has to be variable
 
             lexpr, rexpr = expr.args
             exprname = expr.name
@@ -460,28 +460,22 @@ def normalized_boolexpr(expr, csemap=None):
                 not __is_flat_var(rexpr) and __is_flat_var(lexpr):
                 lexpr, rexpr = rexpr, lexpr
 
-            # bool vs numeric constant: fold before reification (same table as simplify_boolean)
-            if lexpr.is_bool() and is_num(rexpr):
-                simplified = simplify_bool_num_comparison(exprname, lexpr, rexpr, num_context=False)
-                if simplified is not None:
-                    if is_true_cst(simplified) or is_false_cst(simplified):
-                        return (BoolVal(is_true_cst(simplified)), [])
-                    if isinstance(simplified, int):
-                        return (BoolVal(bool(simplified)), [])
-                    flat, cons = normalized_boolexpr(simplified, csemap=csemap)
-                    return (flat, cons)
-
-            # ensure rhs is flat (var or numeric constant); may still be a literal
+            # ensure rhs is var
             (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
 
             # LHS: check if Boolexpr == smth:
             if (exprname == '==' or exprname == '!=') and lexpr.is_bool():
                 # this is a reified constraint, so lhs must be var too to be in normal form
                 (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                if expr.name == '!=' and isinstance(rvar, _BoolVarImpl):
-                    # != not needed, negate RHS variable
-                    rvar = ~rvar  # rvar is var, so safe to just negate
-                    exprname = '=='
+                if expr.name == '!=':
+                    if isinstance(rvar, _BoolVarImpl):
+                        # != not needed, negate RHS variable
+                        rvar = ~rvar  # rvar is var, so safe to just negate
+                        exprname = '=='
+                    elif is_num(rvar) and rvar in (0, 1):
+                        # reified boolexpr != 0/1  ->  boolexpr == 1/0
+                        rvar = 1 - rvar
+                        exprname = '=='
             else:
                 # other cases: LHS is numexpr
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -334,9 +334,10 @@ def __is_flat_var_or_list(arg):
 
 def get_or_make_var(expr, csemap=None):
     """
-        Must return a variable, and list of flat normal constraints
-        Determines whether this is a Boolean or Integer variable and returns
-        the equivalent of: (var, normalize(expr) == var)
+        Return a flat argument (variable or numeric constant) and auxiliary constraints.
+
+        For non-flat expressions, flattens and introduces an equality to a fresh variable
+        (see docstring: equivalent of ``(var, normalize(expr) == var)``).
     """
 
     if __is_flat_var(expr):
@@ -450,7 +451,7 @@ def normalized_boolexpr(expr, csemap=None):
         if (expr.name != '!=') and (not expr.has_subexpr()):
             return (expr, [])  # shortcut
         else:
-            # LHS can be boolexpr, RHS has to be variable
+            # LHS can be boolexpr, RHS must become flat (var or constant)
 
             lexpr, rexpr = expr.args
             exprname = expr.name
@@ -460,19 +461,19 @@ def normalized_boolexpr(expr, csemap=None):
                 not __is_flat_var(rexpr) and __is_flat_var(lexpr):
                 lexpr, rexpr = rexpr, lexpr
 
-            # ensure rhs is var
-            (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
-
-            # bool vs numeric constant: same truth table as simplify_boolean
-            if lexpr.is_bool() and is_num(rvar):
-                simplified = simplify_bool_num_comparison(exprname, lexpr, rvar, num_context=False)
+            # bool vs numeric constant: fold before reification (same table as simplify_boolean)
+            if lexpr.is_bool() and is_num(rexpr):
+                simplified = simplify_bool_num_comparison(exprname, lexpr, rexpr, num_context=False)
                 if simplified is not None:
                     if is_true_cst(simplified) or is_false_cst(simplified):
-                        return (BoolVal(is_true_cst(simplified)), rcons)
+                        return (BoolVal(is_true_cst(simplified)), [])
                     if isinstance(simplified, int):
-                        return (BoolVal(bool(simplified)), rcons)
+                        return (BoolVal(bool(simplified)), [])
                     flat, cons = normalized_boolexpr(simplified, csemap=csemap)
-                    return (flat, cons + rcons)
+                    return (flat, cons)
+
+            # ensure rhs is flat (var or numeric constant); may still be a literal
+            (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
 
             # LHS: check if Boolexpr == smth:
             if (exprname == '==' or exprname == '!=') and lexpr.is_bool():

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -94,11 +94,11 @@ import builtins
 import cpmpy as cp
 
 from .cse import CSEMap
-from .normalize import toplevel_list, simplify_boolean
-from ..expressions.core import Expression, Comparison, Operator
+from .normalize import toplevel_list, simplify_boolean, simplify_bool_num_comparison
+from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.core import _wsum_should, _wsum_make
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl
-from ..expressions.utils import is_num, is_any_list, is_int, is_star
+from ..expressions.utils import is_num, is_any_list, is_int, is_star, is_true_cst, is_false_cst
 from .negation import recurse_negation
 
 
@@ -463,19 +463,25 @@ def normalized_boolexpr(expr, csemap=None):
             # ensure rhs is var
             (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
 
+            # bool vs numeric constant: same truth table as simplify_boolean
+            if lexpr.is_bool() and is_num(rvar):
+                simplified = simplify_bool_num_comparison(exprname, lexpr, rvar, num_context=False)
+                if simplified is not None:
+                    if is_true_cst(simplified) or is_false_cst(simplified):
+                        return (BoolVal(is_true_cst(simplified)), rcons)
+                    if isinstance(simplified, int):
+                        return (BoolVal(bool(simplified)), rcons)
+                    flat, cons = normalized_boolexpr(simplified, csemap=csemap)
+                    return (flat, cons + rcons)
+
             # LHS: check if Boolexpr == smth:
             if (exprname == '==' or exprname == '!=') and lexpr.is_bool():
                 # this is a reified constraint, so lhs must be var too to be in normal form
                 (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                if expr.name == '!=':
-                    if isinstance(rvar, _BoolVarImpl):
-                        # != not needed, negate RHS variable
-                        rvar = ~rvar  # rvar is var, so safe to just negate
-                        exprname = '=='
-                    elif is_num(rvar) and rvar in (0, 1):
-                        # reified boolexpr != 0/1  ->  boolexpr == 1/0
-                        rvar = 1 - rvar
-                        exprname = '=='
+                if expr.name == '!=' and isinstance(rvar, _BoolVarImpl):
+                    # != not needed, negate RHS variable
+                    rvar = ~rvar  # rvar is var, so safe to just negate
+                    exprname = '=='
             else:
                 # other cases: LHS is numexpr
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -336,8 +336,9 @@ def get_or_make_var(expr, csemap=None):
     """
         Return a flat argument (variable or numeric constant) and auxiliary constraints.
 
-        For non-flat expressions, flattens and introduces an equality to a fresh variable
-        (see docstring: equivalent of ``(var, normalize(expr) == var)``).
+        If ``expr`` is already flat (variable or numeric literal), returns it with no aux constraints.
+        Otherwise flattens ``expr`` and adds a reification constraint linking it to a fresh variable
+        (e.g. ``(alldifferent(...)) == BV``), then returns ``(BV, [that constraint, ...])``.
     """
 
     if __is_flat_var(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -334,11 +334,19 @@ def __is_flat_var_or_list(arg):
 
 def get_or_make_var(expr, csemap=None):
     """
-        Return a flat argument (variable or numeric constant) and auxiliary constraints.
+        Return ``(flat_arg, aux_constraints)``.
 
-        If ``expr`` is already flat (variable or numeric literal), returns it with no aux constraints.
-        Otherwise flattens ``expr`` and adds a reification constraint linking it to a fresh variable
-        (e.g. ``(alldifferent(...)) == BV``), then returns ``(BV, [that constraint, ...])``.
+        ``flat_arg`` is a variable or numeric constant suitable as a flat normal-form argument.
+        ``aux_constraints`` is a (possibly empty) list of constraints produced while flattening.
+
+        If ``expr`` is already flat (``__is_flat_var(expr)``), return ``(expr, [])``.
+
+        Otherwise flatten ``expr`` recursively. When a fresh variable ``V`` is introduced to
+        stand in for the flattened expression, append ``flattened_expr == V`` to
+        ``aux_constraints`` (along with any constraints already produced by flattening).
+
+        Example: for boolean global ``gc = alldifferent([IV0, IV1])``, a typical result is
+        ``(BV0, [alldifferent(IV0, IV1) == BV0])``.
     """
 
     if __is_flat_var(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -467,10 +467,15 @@ def normalized_boolexpr(expr, csemap=None):
             if (exprname == '==' or exprname == '!=') and lexpr.is_bool():
                 # this is a reified constraint, so lhs must be var too to be in normal form
                 (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                if expr.name == '!=' and rvar.is_bool():
-                    # != not needed, negate RHS variable
-                    rvar = ~rvar  # rvar is var, so safe to just negate
-                    exprname = '=='
+                if expr.name == '!=':
+                    if isinstance(rvar, _BoolVarImpl):
+                        # != not needed, negate RHS variable
+                        rvar = ~rvar  # rvar is var, so safe to just negate
+                        exprname = '=='
+                    elif is_num(rvar) and rvar in (0, 1):
+                        # reified boolexpr != 0/1  ->  boolexpr == 1/0
+                        rvar = 1 - rvar
+                        exprname = '=='
             else:
                 # other cases: LHS is numexpr
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -16,46 +16,6 @@ from ..expressions.globalconstraints import GlobalConstraint
 from .negation import recurse_negation
 
 
-def simplify_bool_num_comparison(name: str, lhs: Expression, rhs, num_context: bool = False) -> Expression | int | None:
-    """
-    Simplify ``lhs name rhs`` when ``lhs`` is boolean and ``rhs`` is numeric.
-
-    Uses the same truth table as :func:`simplify_boolean` (see table in
-    :func:`_simplify_boolean_expr`). Returns ``None`` when the pattern does not apply.
-    """
-    if not (isinstance(lhs, Expression) and lhs.is_bool() and is_num(rhs)):
-        return None
-    if isinstance(rhs, BoolVal):
-        rhs = int(rhs.value())
-    if rhs < 0:
-        return BoolVal(name in {"!=", ">", ">="})
-    if rhs == 0:
-        if name == "!=" or name == ">":
-            return lhs
-        if name == "==" or name == "<=":
-            return recurse_negation(lhs)
-        if name == "<":
-            return 0 if num_context else BoolVal(False)
-        if name == ">=":
-            return 1 if num_context else BoolVal(True)
-    if 0 < rhs < 1:
-        raise ValueError(
-            f"Comparison {lhs} {name} {rhs} is not supported, rhs is a floating point value: {rhs} (type: {type(rhs)})"
-        )
-    if rhs == 1:
-        if name == "==" or name == ">=":
-            return lhs
-        if name == "!=" or name == "<":
-            return recurse_negation(lhs)
-        if name == ">":
-            return 0 if num_context else BoolVal(False)
-        if name == "<=":
-            return 1 if num_context else BoolVal(True)
-    if rhs > 1:
-        return BoolVal(name in {"!=", "<", "<="})
-    return None
-
-
 def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True) -> list[Expression]:
     """
     Unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with :func:`~cpmpy.expressions.core.Expression.is_bool()` true.
@@ -280,9 +240,34 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
         >= |  T  T   x  F
         <= |  F  ~x  T  T
         """
-        simplified = simplify_bool_num_comparison(name, lhs, rhs, num_context=num_context)
-        if simplified is not None:
-            return True, simplified
+        if isinstance(lhs, Expression) and lhs.is_bool() and is_num(rhs):
+            # direct simplification of boolean comparisons
+            if isinstance(rhs, BoolVal):
+                rhs = int(rhs.value())
+            if rhs < 0:
+                return True, BoolVal(name in  {"!=", ">", ">="}) # all other operators evaluate to False
+            elif rhs == 0:
+                if name == "!=" or name == ">":
+                    return True, lhs
+                if name == "==" or name == "<=":
+                    return True, recurse_negation(lhs)
+                if name == "<":
+                    return True, (0 if num_context else BoolVal(False))
+                if name == ">=":
+                    return True, (1 if num_context else BoolVal(True))
+            elif 0 < rhs < 1:
+                raise ValueError(f"Comparison {lhs} {name} {rhs} is not supported, rhs is a floating point value: {rhs} (type: {type(rhs)})")
+            elif rhs == 1:
+                if name == "==" or name == ">=":
+                    return True, lhs
+                if name == "!=" or name == "<":
+                    return True, recurse_negation(lhs)
+                if name == ">":
+                    return True, (0 if num_context else BoolVal(False))
+                if name == "<=":
+                    return True, (1 if num_context else BoolVal(True))
+            elif rhs > 1:
+                return True, BoolVal(name in {"!=", "<", "<="}) # all other operators evaluate to False
 
         # normalize comparison orientation to keep expression on lhs
         if is_num(lhs) and isinstance(rhs, Expression):

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -16,7 +16,7 @@ from ..expressions.globalconstraints import GlobalConstraint
 from .negation import recurse_negation
 
 
-def simplify_bool_num_comparison(name: str, lhs: Expression, rhs, *, num_context: bool = False) -> Expression | int | None:
+def simplify_bool_num_comparison(name: str, lhs: Expression, rhs, num_context: bool = False) -> Expression | int | None:
     """
     Simplify ``lhs name rhs`` when ``lhs`` is boolean and ``rhs`` is numeric.
 

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -16,6 +16,46 @@ from ..expressions.globalconstraints import GlobalConstraint
 from .negation import recurse_negation
 
 
+def simplify_bool_num_comparison(name: str, lhs: Expression, rhs, *, num_context: bool = False) -> Expression | int | None:
+    """
+    Simplify ``lhs name rhs`` when ``lhs`` is boolean and ``rhs`` is numeric.
+
+    Uses the same truth table as :func:`simplify_boolean` (see table in
+    :func:`_simplify_boolean_expr`). Returns ``None`` when the pattern does not apply.
+    """
+    if not (isinstance(lhs, Expression) and lhs.is_bool() and is_num(rhs)):
+        return None
+    if isinstance(rhs, BoolVal):
+        rhs = int(rhs.value())
+    if rhs < 0:
+        return BoolVal(name in {"!=", ">", ">="})
+    if rhs == 0:
+        if name == "!=" or name == ">":
+            return lhs
+        if name == "==" or name == "<=":
+            return recurse_negation(lhs)
+        if name == "<":
+            return 0 if num_context else BoolVal(False)
+        if name == ">=":
+            return 1 if num_context else BoolVal(True)
+    if 0 < rhs < 1:
+        raise ValueError(
+            f"Comparison {lhs} {name} {rhs} is not supported, rhs is a floating point value: {rhs} (type: {type(rhs)})"
+        )
+    if rhs == 1:
+        if name == "==" or name == ">=":
+            return lhs
+        if name == "!=" or name == "<":
+            return recurse_negation(lhs)
+        if name == ">":
+            return 0 if num_context else BoolVal(False)
+        if name == "<=":
+            return 1 if num_context else BoolVal(True)
+    if rhs > 1:
+        return BoolVal(name in {"!=", "<", "<="})
+    return None
+
+
 def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True) -> list[Expression]:
     """
     Unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with :func:`~cpmpy.expressions.core.Expression.is_bool()` true.
@@ -240,34 +280,9 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
         >= |  T  T   x  F
         <= |  F  ~x  T  T
         """
-        if isinstance(lhs, Expression) and lhs.is_bool() and is_num(rhs):
-            # direct simplification of boolean comparisons
-            if isinstance(rhs, BoolVal):
-                rhs = int(rhs.value())
-            if rhs < 0:
-                return True, BoolVal(name in  {"!=", ">", ">="}) # all other operators evaluate to False
-            elif rhs == 0:
-                if name == "!=" or name == ">":
-                    return True, lhs
-                if name == "==" or name == "<=":
-                    return True, recurse_negation(lhs)
-                if name == "<":
-                    return True, (0 if num_context else BoolVal(False))
-                if name == ">=":
-                    return True, (1 if num_context else BoolVal(True))
-            elif 0 < rhs < 1:
-                raise ValueError(f"Comparison {lhs} {name} {rhs} is not supported, rhs is a floating point value: {rhs} (type: {type(rhs)})")
-            elif rhs == 1:
-                if name == "==" or name == ">=":
-                    return True, lhs
-                if name == "!=" or name == "<":
-                    return True, recurse_negation(lhs)
-                if name == ">":
-                    return True, (0 if num_context else BoolVal(False))
-                if name == "<=":
-                    return True, (1 if num_context else BoolVal(True))
-            elif rhs > 1:
-                return True, BoolVal(name in {"!=", "<", "<="}) # all other operators evaluate to False
+        simplified = simplify_bool_num_comparison(name, lhs, rhs, num_context=num_context)
+        if simplified is not None:
+            return True, simplified
 
         # normalize comparison orientation to keep expression on lhs
         if is_num(lhs) and isinstance(rhs, Expression):

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -324,7 +324,7 @@ class TestFlattenExpr:
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
         # reified global != 1 (z3 fuzz): rhs is int literal, not a BoolVar
         gc = cp.AllDifferentExceptN([a, b, c], [0])
-        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (BV14), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13), (BV13 == 0) == (BV14)])"
+        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (BV14), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13), (BV13 == 0) == (BV14)])" # ideally there is no BV14 and we just have (~BV0) or (~BV13) instead
         #simplify output
         assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])"
 

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -324,6 +324,8 @@ class TestFlattenExpr:
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
         # reified global != 1 (z3 fuzz): rhs is int literal, not a BoolVar
         gc = cp.AllDifferentExceptN([a, b, c], [0])
-        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (BV14), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13), (BV13 == 0) == (BV14)])"
+        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (~BV13), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13)])"
+        assert str(normalized_boolexpr(gc != 7)) == "(boolval(True), [])"
+        assert str(normalized_boolexpr(gc == 7)) == "(boolval(False), [])"
         #simplify output
         assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])"

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -324,9 +324,7 @@ class TestFlattenExpr:
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
         # reified global != 1 (z3 fuzz): rhs is int literal, not a BoolVar
         gc = cp.AllDifferentExceptN([a, b, c], [0])
-        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (~BV13), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13)])"
-        assert str(normalized_boolexpr(gc != 7)) == "(boolval(True), [])"
-        assert str(normalized_boolexpr(gc == 7)) == "(boolval(False), [])"
+        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (BV14), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13), (BV13 == 0) == (BV14)])"
         #simplify output
         assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])"
 

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -322,5 +322,8 @@ class TestFlattenExpr:
 
         # != in boolexpr, bug #170
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
+        # reified global != 1 (z3 fuzz): rhs is int literal, not a BoolVar
+        gc = cp.AllDifferentExceptN([a, b, c], [0])
+        assert str(normalized_boolexpr(x.implies(gc != 1))) == "((~BV0) or (BV14), [(alldifferent_except_n([IV0, IV1, IV2],[0])) == (BV13), (BV13 == 0) == (BV14)])"
         #simplify output
         assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])"


### PR DESCRIPTION
For cases where we had a global expression in reified constant in a disequality with a constant there was a bug because the current code expected the rhs to be a var. In the code comments the assumption is that after get_or_make_var the rhs is always a var, but this is not necessarily true, a constant stays a constant. I believe the get_or_make_var behaviour is correct so I patched the code in flatten_constraint to handle such cases with a constant.