### PR TITLE
Remove mul from supported for CPLEX

### DIFF
--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -467,7 +467,8 @@ class CPM_cplex(SolverInterface):
                         self.cplex_model.add_constraint(self.cplex_model.max(self.solver_vars(lhs.args)) == cplexrhs)
                     elif lhs.name == 'abs':
                         self.cplex_model.add_constraint(self.cplex_model.abs(self.solver_var(lhs.args[0])) == cplexrhs)
-                    elif lhs.name == 'mul':
+                    elif lhs.name == 'mul': 
+                        raise ValueError("CPLEX only supports convex multiplication constraints, should be decomposed and linearized already. Please report on github.")
                         cplexlhs = self._make_numexpr(lhs)
                         self.cplex_model.add_constraint(cplexlhs == cplexrhs)
                     else:

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -86,7 +86,7 @@ class CPM_cplex(SolverInterface):
     Documentation of the solver's own Python API:
     https://ibmdecisionoptimization.github.io/docplex-doc/mp/docplex.mp.model.html
     """
-    supported_global_constraints = frozenset({"min", "max", "abs", "mul"})
+    supported_global_constraints = frozenset({"min", "max", "abs"})
 
     @staticmethod
     def supported():
@@ -234,6 +234,8 @@ class CPM_cplex(SolverInterface):
             else: # CSP
                 self.cpm_status.exitstatus = ExitStatus.FEASIBLE
         elif cplex_status == "JobFailed":
+            self.cpm_status.exitstatus = ExitStatus.ERROR
+        elif cplex_status == "Non-convex QCP":
             self.cpm_status.exitstatus = ExitStatus.ERROR
         elif "aborted" in cplex_status:
             self.cpm_status.exitstatus = ExitStatus.NOT_RUN
@@ -467,6 +469,9 @@ class CPM_cplex(SolverInterface):
                         self.cplex_model.add_constraint(self.cplex_model.max(self.solver_vars(lhs.args)) == cplexrhs)
                     elif lhs.name == 'abs':
                         self.cplex_model.add_constraint(self.cplex_model.abs(self.solver_var(lhs.args[0])) == cplexrhs)
+                    elif lhs.name == 'mul':
+                        cplexlhs = self._make_numexpr(lhs)
+                        self.cplex_model.add_constraint(cplexlhs == cplexrhs)
                     else:
                         raise NotImplementedError(
                         "Not a known supported cplex comparison '{}' {}".format(lhs.name, con))

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -235,8 +235,6 @@ class CPM_cplex(SolverInterface):
                 self.cpm_status.exitstatus = ExitStatus.FEASIBLE
         elif cplex_status == "JobFailed":
             self.cpm_status.exitstatus = ExitStatus.ERROR
-        elif cplex_status == "Non-convex QCP":
-            self.cpm_status.exitstatus = ExitStatus.ERROR
         elif "aborted" in cplex_status:
             self.cpm_status.exitstatus = ExitStatus.NOT_RUN
         else:  # another? This can happen when error during solve.

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -661,8 +661,13 @@ class TestGlobal:
         true_model = cp.Model(cp.Regular(x, transitions, start, ends))
         false_model = cp.Model(~cp.Regular(x, transitions, start, ends))
 
-        num_true = true_model.solveAll(solver=solver, display=lambda : true_sols.add(tuple(argvals(x))))
-        num_false = false_model.solveAll(solver=solver, display=lambda : false_sols.add(tuple(argvals(x))))
+        if solver in ("gurobi", "cplex"):
+            kwargs = dict(solution_limit=10) # all assignments = 8
+        else:
+            kwargs = dict()
+
+        num_true = true_model.solveAll(solver=solver, display=lambda : true_sols.add(tuple(argvals(x))), **kwargs)
+        num_false = false_model.solveAll(solver=solver, display=lambda : false_sols.add(tuple(argvals(x))), **kwargs)
 
         assert num_true == len(solutions)
         assert true_sols == set(solutions)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -727,6 +727,12 @@ class TestSolvers:
         s = cp.SolverLookup.get("cplex", m)
         assert s.solve()
 
+        x, y = cp.intvar(0, 10, shape=2)
+        m = cp.Model(x * y == 1)
+        s = cp.SolverLookup.get("cplex", m)
+        assert s.solve()
+        assert x.value() * y.value() == 1
+
 
     @pytest.mark.skipif(not CPM_cplex.supported(),
                         reason="cplex not installed")


### PR DESCRIPTION
Multiplication was not supported for CPLEX so it needs to be decomposed, fixes #764 (which I think was temporarily fixed, but broken again when mul became a global).