### PR TITLE
xfail test for z3 bug

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -485,6 +485,32 @@ class TestSolvers:
         s = cp.SolverLookup.get("z3", m)
         assert not s.solve()
 
+    @pytest.mark.requires_solver("z3")
+    @pytest.mark.xfail(
+        reason="Z3 returns incorrect variable values after optimize; see https://github.com/CPMpy/cpmpy/issues/1036",
+        strict=True,
+    )
+    def test_z3_optimize_inconsistent_model_values(self, solver):
+        # Minimal Golomb-ruler-style problem: Z3 proves objective 20 but returns x9=500.
+        # issue tracked in: https://github.com/CPMpy/cpmpy/issues/1036
+        n = 10
+        U = 500
+        x = cp.intvar(0, U, shape=n)
+        ds = [x[j] - x[i] for i in range(n) for j in range(i + 1, n)]
+        m = cp.Model([
+            x[0] == 0,
+            cp.IncreasingStrict(x),
+            cp.AllDifferent(ds),
+        ])
+        m.minimize(x[n - 1])
+
+        s = cp.SolverLookup.get("z3:opt", m)
+        assert s.solve()
+        assert s.status().exitstatus == ExitStatus.OPTIMAL
+        obj_bound = s.z3_solver.lower(s.obj_handle)
+        assert s.z3_solver.lower(s.obj_handle) == s.z3_solver.upper(s.obj_handle)
+        assert x[n - 1].value() == obj_bound
+
     def test_pow(self):
         iv1 = cp.intvar(2,9)
         for i in [0,1,2]:


### PR DESCRIPTION
Adds an xfail test for #1036, notifying us when a new version of Z3 gets released with the fix. The fix is already in the upstream codebase, just waiting for a `z3-solver` release on PyPi.