### PR TITLE
Remove old deprecated code

### DIFF
--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -20,7 +20,6 @@ List of submodules
 # we only import methods/classes that are used for modelling
 # others need to be imported by the developer explicitely
 from .variables import boolvar, intvar, cpm_array
-from .variables import BoolVar, IntVar, cparray # Old, to be deprecated
 from .globalconstraints import (
     AllDifferent,
     AllDifferentExcept0,
@@ -77,10 +76,6 @@ __all__ = [
     "boolvar",
     "intvar",
     "cpm_array",
-# Variables (old, to be deprecated)
-    "BoolVar",
-    "IntVar",
-    "cparray",
 # Global functions
     "Minimum",
     "Maximum",

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -247,14 +247,6 @@ class Expression(object):
             return 0, 1  # default for boolean expressions
         raise NotImplementedError(f"`get_bounds` is not implemented for type {self}")
 
-    def deepcopy(self, memodict={}):
-        """ DEPRECATED: use copy.deepcopy() instead
-
-        Will be removed in stable version.
-        """
-        warnings.warn("Deprecated, use copy.deepcopy() instead, will be removed in stable version", DeprecationWarning)
-        return copy.deepcopy(self, memodict)
-
     def implies(self, other: BoolExprLike, simplify: bool = False) -> "Expression":
         """Implication constraint: ``self -> other``.
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -216,16 +216,6 @@ class GlobalConstraint(Expression):
 
 
 # Global Constraints (with Boolean return type)
-def alldifferent(args):
-    """
-    .. deprecated:: 0.9.0
-          Please use :class:`AllDifferent` instead.
-    """
-    warnings.warn("Deprecated, use AllDifferent(v1,v2,...,vn) instead, will be removed in "
-                  "stable version", DeprecationWarning)
-    return AllDifferent(*args) # unfold list as individual arguments
-
-
 class AllDifferent(GlobalConstraint):
     """
     Enforces that all arguments have a different (distinct) value
@@ -330,17 +320,6 @@ class AllDifferentExcept0(AllDifferentExceptN):
         """
         super().__init__(flatlist(args), 0)
 
-
-def allequal(args):
-    """
-    .. deprecated:: 0.9.0
-          Please use :class:`AllEqual` instead.
-    """
-    warnings.warn("Deprecated, use AllEqual(v1,v2,...,vn) instead, will be removed in stable version",
-                  DeprecationWarning)
-    return AllEqual(*args) # unfold list as individual arguments
-
-
 class AllEqual(GlobalConstraint):
     """
     Enforces that all arguments have the same value
@@ -415,17 +394,6 @@ class AllEqualExceptN(GlobalConstraint):
             return None
         vals = [v for v in vals if v not in frozenset(exclude_vals)]
         return len(set(vals)) <= 1
-
-
-def circuit(args):
-    """
-    .. deprecated:: 0.9.0
-          Please use :class:`Circuit` instead.
-    """
-    warnings.warn("Deprecated, use Circuit(v1,v2,...,vn) instead, will be removed in stable version",
-                  DeprecationWarning)
-    return Circuit(*args) # unfold list as individual arguments
-
 
 class Circuit(GlobalConstraint):
     """

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -137,8 +137,12 @@ class GlobalFunction(Expression):
 
     def decompose_comparison(self, cmp_op: str, cmp_rhs: Expression) -> tuple[list[Expression], list[Expression]]:
         """
-            DEPRECATED: returns a list of constraints representing the decomposed
-            comparison of the global function (and any auxiliary variables introduced).
+
+        .. deprecated:: 1.0.0
+            Please use :meth:`decompose` instead.
+
+        Returns a list of constraints representing the decomposed
+        comparison of the global function (and any auxiliary variables introduced).
 
         Arguments:
             cmp_op (str): Comparison operator
@@ -989,7 +993,8 @@ class NDElement(GlobalFunction):
 
 def element(arg_list):
     """
-    DEPRECATED: Use Element(arr,idx) instead of element([arr,idx]).
+    .. deprecated:: 1.0.0
+        Please use :meth:`Element(arr,idx)` instead of :meth:`element([arr,idx])`.
 
     Arguments:
         arg_list (list[Expression]): List containing array and index (2 elements)
@@ -997,7 +1002,7 @@ def element(arg_list):
     Returns:
         Element: An Element global function instance
     """
-    warnings.warn("Deprecated, use Element(arr,idx) instead, will be removed in stable version", DeprecationWarning)
+    warnings.warn("Deprecated, use Element(arr,idx) instead, will be removed", DeprecationWarning)
     assert (len(arg_list) == 2), "Element expression takes 2 arguments: Arr, Idx"
     return Element(arg_list[0], arg_list[1])
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -74,14 +74,6 @@ _VAR_ERR  = f"Variable names starting with {_IV_PREFIX} or {_BV_PREFIX} are rese
 _VAR_NAME_CHECK_STATE = threading.local()
 _VAR_NAME_CHECK_STATE.strict = True # default to strict mode
 
-def BoolVar(shape=1, name=None):
-    """
-    .. deprecated:: 0.9.0
-          Please use :func:`~cpmpy.expressions.variables.boolvar` instead.
-    """
-    warnings.warn("Deprecated, use boolvar() instead, will be removed in stable version", DeprecationWarning)
-    return boolvar(shape=shape, name=name)
-
 
 @overload
 def boolvar(shape: Literal[1] = 1,  # special case: a shape of =1 returns a single variable
@@ -158,15 +150,6 @@ def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
     r = NDVarArray(shape, dtype=object, buffer=data)
     r._has_subexpr = False # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
     return r
-
-
-def IntVar(lb, ub, shape=1, name=None):
-    """
-    .. deprecated:: 0.9.0
-          Please use :func:`~cpmpy.expressions.variables.intvar` instead.
-    """
-    warnings.warn("Deprecated, use intvar() instead, will be removed in stable version", DeprecationWarning)
-    return intvar(lb, ub, shape=shape, name=name)
 
 
 @overload
@@ -253,14 +236,6 @@ def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 
     r = NDVarArray(shape, dtype=object, buffer=data)
     r._has_subexpr = False # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
     return r
-
-def cparray(arr):
-    """
-    .. deprecated:: 0.9.0
-          Please use :func:`~cpmpy.expressions.variables.cpm_array` instead.
-    """
-    warnings.warn("Deprecated, use cpm_array() instead, will be removed in stable version", DeprecationWarning)
-    return cpm_array(arr)
 
 
 def cpm_array(arr: ListLike[ExprLike|Any]) -> NDVarArray:

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -302,12 +302,6 @@ class Model(object):
 
 
 
-    # keep for backwards compatibility
-    def deepcopy(self, memodict={}):
-        warnings.warn("Deprecated, use copy.deepcopy() instead, will be removed in stable version", DeprecationWarning)
-        return copy.deepcopy(self, memodict)
-
-
 def _update_variable_counters(model: Model):
     from cpmpy.transformations.get_variables import get_variables_model  # avoid circular import
     from cpmpy.expressions.variables import _BoolVarImpl, _IntVarImpl, _BV_PREFIX, _IV_PREFIX # avoid circular import

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -360,7 +360,7 @@ class CPM_gcs(SolverInterface):
             self.cpm_status.exitstatus = ExitStatus.UNKNOWN
 
         # clear user vars if no solution found
-        if self._solve_return(self.cpm_status, self.objective_value_) is False:
+        if self._solve_return(self.cpm_status) is False:
             for var in self.user_vars:
                 var._value = None
 

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -371,15 +371,13 @@ class SolverInterface(object):
 
     # shared helper functions
 
-    def _solve_return(self, cpm_status, objective_value=None):
+    def _solve_return(self, cpm_status):
         """
             Take a CPMpy Model and SolverStatus object and return
             the proper answer (True/False/objective_value)
 
             :param cpm_status: status extracted from the solver
             :type cpm_status: SolverStatus
-
-            :param objective_value: None or Int, as computed by solver [DEPRECATED]
 
             :return: Bool
                 - True      if a solution is found (not necessarily optimal, e.g. could be after timeout)

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -133,6 +133,11 @@ class SolverLookup():
 
     @classmethod
     def solvernames(cls):
+        """
+        .. deprecated:: 1.0.0
+            Please use :meth:`supported` instead.
+        """
+        warnings.warn("Deprecated, use supported() instead", DeprecationWarning)
         # The older (more indirectly named) way to get the list of names of *supported* solvers.
         # Will be deprecated at some point.
         return cls.supported()
@@ -244,19 +249,3 @@ class SolverLookup():
                 # For main solvers, show version if available
                 version = version if version else "Not found" if installed else "-"
                 print(f"{basename:<25} {'Yes' if installed else 'No':<10} {version:<15}")
-
-
-# using `builtin_solvers` is DEPRECATED, use `SolverLookup` object instead
-# Order matters! first is default, then tries second, etc...
-builtin_solvers = [CPM_ortools, CPM_gurobi, CPM_minizinc, CPM_pysat, CPM_exact, CPM_choco]
-def get_supported_solvers():
-    """
-        Returns a list of solvers supported on this machine.
-       
-        .. deprecated:: 0.9.4
-            Please use :class:`SolverLookup` object instead.
-
-        :return: a list of SolverInterface sub-classes :list[SolverInterface]:
-    """
-    warnings.warn("Deprecated, use Model.solvernames() instead, will be removed in stable version", DeprecationWarning)
-    return [sv for sv in builtin_solvers if sv.supported()]

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -42,6 +42,7 @@ class CustomDecomp(Protocol):
 def decompose_in_tree(lst_of_expr: list[Expression],
                       supported: Optional[AbstractSet[str]] = None,
                       supported_reified: Optional[AbstractSet[str]] = None,
+                      _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
                       decompose_custom: Optional[Dict[str, CustomDecomp]] = None,
                       decompose_custom_positive: Optional[Dict[str, CustomDecomp]] = None,
@@ -54,6 +55,8 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :param lst_of_expr: list of CPMpy expressions that may contain global constraints or global functions.
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
+    :param _toplevel: DEPRECATED
+    :param nested: DEPRECATED
     :param csemap: CSEMap object used to avoid decomposing the same global constraint twice
     :param decompose_custom: a dictionary mapping names of global constraints to their custom decompositions.
     :param decompose_custom_positive: a dictionary mapping names of global constraints to their custom decompositions, which are valid only in positive context.
@@ -70,6 +73,10 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :func:`cpmpy.transformations.reification.reify_rewrite`
     E.g. ``bv -> NumExpr <comp> Var/Const`` will then be rewritten as  ``[bv -> IV0 <comp> Var/Const, NumExpr == IV0]``.
     """
+    if _toplevel is not None:
+        warnings.warn("decompose_in_tree: argument '_toplevel' is deprecated and will be ignored, do not use/modify it", DeprecationWarning)
+    if nested:
+        warnings.warn("decompose_in_tree: argument 'nested' is deprecated and will be ignored, do not use/modify it", DeprecationWarning)
 
     if supported is None:
         supported = frozenset[str]()

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -42,7 +42,6 @@ class CustomDecomp(Protocol):
 def decompose_in_tree(lst_of_expr: list[Expression],
                       supported: Optional[AbstractSet[str]] = None,
                       supported_reified: Optional[AbstractSet[str]] = None,
-                      _toplevel=None, nested=False,
                       csemap: Optional[CSEMap] = None,
                       decompose_custom: Optional[Dict[str, CustomDecomp]] = None,
                       decompose_custom_positive: Optional[Dict[str, CustomDecomp]] = None,
@@ -55,8 +54,6 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :param lst_of_expr: list of CPMpy expressions that may contain global constraints or global functions.
     :param supported: a set of names of supported global constraints and global functions (will not be decomposed).
     :param supported_reified: a set of names of supported reified global constraints (those with Boolean return type only).
-    :param _toplevel: DEPRECATED
-    :param nested: DEPRECATED
     :param csemap: CSEMap object used to avoid decomposing the same global constraint twice
     :param decompose_custom: a dictionary mapping names of global constraints to their custom decompositions.
     :param decompose_custom_positive: a dictionary mapping names of global constraints to their custom decompositions, which are valid only in positive context.
@@ -73,8 +70,6 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :func:`cpmpy.transformations.reification.reify_rewrite`
     E.g. ``bv -> NumExpr <comp> Var/Const`` will then be rewritten as  ``[bv -> IV0 <comp> Var/Const, NumExpr == IV0]``.
     """
-    assert _toplevel is None, "decompose_in_tree: argument '_toplevel' is deprecated, do not use/modify it"
-    assert nested is False, "decompose_in_tree: argument 'nested' is deprecated, do not use/modify it"
 
     if supported is None:
         supported = frozenset[str]()

--- a/cpmpy/transformations/get_variables.py
+++ b/cpmpy/transformations/get_variables.py
@@ -25,9 +25,6 @@ def get_variables_model(model):
     return vars_ + [x for x in get_variables(model.objective_) if not x in seen]
 
 
-def vars_expr(expr):
-    warnings.warn("Deprecated, use get_variables() instead, will be removed in stable version", DeprecationWarning)
-    return get_variables(expr)
 def get_variables(expr, collect=None):
     """
         Get variables of an expression
@@ -93,12 +90,3 @@ def print_variables(expr_or_model):
     print("Variables:")
     for var in vars_:
         print(f"    {var}: {var.lb}..{var.ub}")
-
-
-# https://stackoverflow.com/questions/480214/how-do-you-remove-duplicates-from-a-list-whilst-preserving-order
-def _uniquify(seq):
-    warnings.warn("Deprecated, copy inline if used, will be removed in stable version", DeprecationWarning)
-    seen = set()
-    seen_add = seen.add
-    return [x for x in seq if not (x in seen or seen_add(x))]
-

--- a/cpmpy/transformations/negation.py
+++ b/cpmpy/transformations/negation.py
@@ -286,13 +286,3 @@ def recurse_negation(expr: Expression|bool|np.bool_) -> Expression:
     else:
         raise ValueError(f"Unsupported expression to negate: {expr}")
 
-
-def negated_normal(expr):
-    """
-    .. deprecated:: 0.9.16
-          Please use :func:`recurse_negation()` instead.
-    """
-    warnings.warn("Deprecated, use `recurse_negation()` instead which will negate and push down all negations in "
-                  "the expression (or use `push_down_negation` on the full expression tree); will be removed in "
-                  "stable version", DeprecationWarning)
-    return recurse_negation(expr)

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -13,8 +13,6 @@ from typing import Optional, AbstractSet, Any, Sequence
 
 
 def no_partial_functions(lst_of_expr: list[Expression],
-                        _toplevel: Optional[Any]=None, 
-                        _nbc: Optional[Any] = None, 
                         safen_toplevel: Optional[AbstractSet[str]] = None) -> list[Expression]:
     """
     A partial function is a function whose output is not defined for all possible inputs.
@@ -64,16 +62,11 @@ def no_partial_functions(lst_of_expr: list[Expression],
     
     Arguments:
         lst_of_expr (list[Expression]): list of CPMpy expressions
-        _toplevel (None): DEPRECATED
-        _nbc (None): DEPRECATED
         safen_toplevel (set[str]): list of expression types that need to be safened, even when toplevel. Used when
                                     a solver supports the global function natively (not decomposed) but does not accept
                                     unsafe values in its API (e.g., OR-Tools for `div`).
     """
-
-    assert _toplevel is None, "no_partial_functions:  argument '_toplevel' is deprecated, do not use/modify it"
-    assert _nbc is None, "no_partial_functions:  argument '_nbc' is deprecated, do not use/modify it"
-
+    
     if safen_toplevel is None:
         safen_toplevel = frozenset()
 

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -3,6 +3,7 @@
 """
 
 from copy import copy
+import warnings
 import numpy as np
 
 from ..expressions.variables import boolvar, intvar, NDVarArray, _BoolVarImpl, _NumVarImpl
@@ -13,6 +14,8 @@ from typing import Optional, AbstractSet, Any, Sequence
 
 
 def no_partial_functions(lst_of_expr: list[Expression],
+                        _toplevel: Optional[Any]=None, 
+                        _nbc: Optional[Any] = None, 
                         safen_toplevel: Optional[AbstractSet[str]] = None) -> list[Expression]:
     """
     A partial function is a function whose output is not defined for all possible inputs.
@@ -62,11 +65,18 @@ def no_partial_functions(lst_of_expr: list[Expression],
     
     Arguments:
         lst_of_expr (list[Expression]): list of CPMpy expressions
+        _toplevel (None): DEPRECATED
+        _nbc (None): DEPRECATED
         safen_toplevel (set[str]): list of expression types that need to be safened, even when toplevel. Used when
                                     a solver supports the global function natively (not decomposed) but does not accept
                                     unsafe values in its API (e.g., OR-Tools for `div`).
     """
-    
+
+    if _toplevel is not None:
+        warnings.warn("no_partial_functions: argument '_toplevel' is deprecated and will be ignored, do not use/modify it", DeprecationWarning)
+    if _nbc is not None:
+        warnings.warn("no_partial_functions: argument '_nbc' is deprecated and will be ignored, do not use/modify it", DeprecationWarning)
+
     if safen_toplevel is None:
         safen_toplevel = frozenset()
 


### PR DESCRIPTION
Removing old code that has been deprecated for a while. Some are still left in place due to
- being deprecated just now for the 1.0 release
- being deprecated for longer, but not correctly being labeled as such. Here we still need to give users time to make the switch.

Partially solves #1048. The removed code will be documented in the changelog of v1.0.0 and in the docs #1038 