### PR TITLE
Document Numpy compatibility

### DIFF
--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -547,8 +547,7 @@ class NDVarArray(np.ndarray):
                     raise NotImplementedError("CPMpy does not support vectorized indexing into multi-dimensional arrays. If you really need this, please report on github.")
                 if any(isinstance(i, Expression) and i.is_bool() for i in index_arr.flat):
                     raise TypeError("Boolean decision variables cannot be used as a mask (result length would depend on their values). Use integer decision variables as indices instead.")
-                # typing: reshape returns NDVarArray
-                return cpm_array([self[i] for i in index_arr.flat]).reshape(index_arr.shape)  # type: ignore
+                return cpm_array([self[i] for i in index_arr.flat]).reshape(index_arr.shape)
 
         return super().__getitem__(index)
 

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -539,6 +539,17 @@ class NDVarArray(np.ndarray):
                 return cp.Element(arr, new_indices[0])
             return cp.NDElement(arr, new_indices)
 
+        # vectorized indexing: arr[idx_array] -> [arr[idx0], arr[idx1], ...] (shape of index)
+        if isinstance(index, (list, np.ndarray)):
+            index_arr = np.asarray(index)
+            if any(isinstance(i, Expression) for i in index_arr.flat):
+                if self.ndim != 1:
+                    raise NotImplementedError("CPMpy does not support vectorized indexing into multi-dimensional arrays. If you really need this, please report on github.")
+                if any(isinstance(i, Expression) and i.is_bool() for i in index_arr.flat):
+                    raise TypeError("Boolean decision variables cannot be used as a mask (result length would depend on their values). Use integer decision variables as indices instead.")
+                # typing: reshape returns NDVarArray
+                return cpm_array([self[i] for i in index_arr.flat]).reshape(index_arr.shape)  # type: ignore
+
         return super().__getitem__(index)
 
     """

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -397,9 +397,21 @@ print(f"arr: {arr.value()}, idx: {idx.value()}, val: {arr[idx].value()}")
 # example output -- arr: [2 1 3 4], idx: 0, val: 2
 ```
 
-The `arr[idx]` works because `arr` is a CPMpy `NDVarArray()` and we overloaded the `__getitem__()` Python function. It even supports multi-dimensional access, e.g. `arr[idx1,idx2]`.
+The `arr[idx]` works because `arr` is a CPMpy `NDVarArray()` and we overloaded the `__getitem__()` Python function. It even supports multi-dimensional access, e.g. `arr[idx1,idx2]`. Indexing with an array of integer decision variables is also supported (vectorized): `arr[idx_array]` creates an array of `Element` expressions, one per index.
 
-This does not work on NumPy arrays though, as they don't know CPMpy. So you have to **wrap the array** in our `cpm_array()` or call `Element()` directly:
+```python
+import cpmpy as cp
+
+arr = cp.intvar(1, 10, shape=5)
+idx = cp.intvar(0, 4, shape=3)
+
+m = cp.Model(
+    cp.AllDifferent(idx),
+    arr[idx] == [1, 2, 3]  # equivalent to: [arr[idx[0]] == 1, arr[idx[1]] == 2, arr[idx[2]] == 3]
+)
+```
+
+This does not work on NumPy arrays though, as they don't know CPMpy. So you have to **wrap the array** using `cp.cpm_array()`
 
 ```python
 import numpy as np

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -278,8 +278,42 @@ m = cp.Model(
 )
 ```
 
-Note that because of our overloading of `+,-,*,//` some numpy functions like `np.sum(some_array)` will also create a CPMpy expression when used on CPMpy decision variables. However, this is not guaranteed, and other functions like `np.max(some_array)` will not. To **avoid surprises**, you should hence always take care to call the CPMpy functions `cp.sum()`, `cp.max()` etc. We did overload `some_cpm_array.sum()` and `.min()`/`.max()` (including the axis= argument), so these are safe to use.
+### NumPy operations
 
+CPMpy's arrays of decision variables are subclasses of `numpy.ndarray`, so many NumPy operations work on them. The rule of thumb is that an operation is supported when its **result shape is known at modeling time**. Element-wise operators (`+,-,*,//,%`, comparisons, `&|^~`), aggregations (`sum/min/max/...`), reshaping (`reshape`, transpose, slicing, ...) and dot products like `np.dot(x,w)` all fall in this category:
+
+```python
+import cpmpy as cp
+import numpy as np
+
+x = cp.intvar(0, 10, shape=3)
+w = np.array([1, 2, 3])
+M = cp.intvar(0, 10, shape=(2, 3))
+
+x + w          # element-wise
+M + w          # broadcasts w over the rows of M
+M.sum(axis=0)  # vector of column sums
+M.T            # transpose
+np.dot(x, w)   # dot-product
+```
+
+Binary operators follow NumPy broadcasting: the other operand is broadcast to the shape of the CPMpy array. So `M + w` with `M.shape==(2,3)` and `w.shape==(3,)` works, while incompatible shapes raise a `ValueError`. One limitation compared to plain NumPy is that the result always keeps the shape of the CPMpy array — e.g. a `(3,1)` array plus a length-3 vector does not expand to `(3,3)`.
+
+What does **not** work are operations whose result depends on the (still unknown) values of the decision variables. In particular, you cannot use Boolean decision variables as a mask, because the length of the result would depend on how many are `True`:
+
+```python
+import cpmpy as cp
+import numpy as np
+
+b = cp.boolvar(shape=10)
+# np.arange(10)[b]  # IndexError
+```
+
+Because of our overloading of `+,-,*,//` some NumPy functions like `np.sum(x)` will also create a CPMpy expression. This is not guaranteed for all NumPy functions though — `np.equal(x, y)` for example returns a plain Boolean array, not constraints. To **avoid surprises**, prefer the Python operators and the CPMpy functions `cp.sum()`, `cp.max()` etc. We did overload `x.sum()`, `.min()`, `.max()`, `.any()` and `.all()` (including the `axis=` argument), so these are safe to use.
+
+Also note that `np.concatenate` / `stack` / `hstack` / `vstack` return a plain `ndarray`, so wrap the result with `cp.cpm_array(...)` before doing further CPMpy operations on it.
+
+If you encounter a NumPy operation that you think should work, but doesn't, please reach out to us on GitHub! We are keen to improve NumPy compatibility.
 
 ### Global constraints
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -285,6 +285,57 @@ class TestNDVarArrayBroadcast:
         with pytest.raises(ValueError, match="broadcast"):
             x * np.array([1, 2])
 
+
+class TestNDVarArrayVectorizedIndex:
+
+    def test_index_with_ivar_array(self):
+        arr = intvar(0, 10, shape=5, name="arr")
+        idx = intvar(0, 4, shape=3, name="idx")
+        expr = arr[idx]
+        assert isinstance(expr, NDVarArray)
+        assert expr.shape == (3,)
+        for i in range(3):
+            assert isinstance(expr[i], cp.Element)
+            assert expr[i].args[1] is idx[i]
+
+    def test_index_with_ivar_list(self):
+        arr = intvar(0, 10, shape=5, name="arr")
+        i0, i1 = intvar(0, 4, name="i0"), intvar(0, 4, name="i1")
+        expr = arr[[i0, i1]]
+        assert isinstance(expr, NDVarArray)
+        assert expr.shape == (2,)
+        assert expr[0].args[1] is i0 and expr[1].args[1] is i1
+
+    def test_index_preserves_shape(self):
+        arr = intvar(0, 10, shape=5, name="arr")
+        idx = intvar(0, 4, shape=(2, 2), name="idx")
+        expr = arr[idx]
+        assert expr.shape == (2, 2)
+        assert all(isinstance(e, cp.Element) for e in expr.flat)
+
+    def test_index_mixed_const_and_ivar(self):
+        arr = intvar(0, 10, shape=5, name="arr")
+        i = intvar(0, 4, name="i")
+        expr = arr[[0, i, 2]]
+        assert expr.shape == (3,)
+        assert expr[0] is arr[0]
+        assert isinstance(expr[1], cp.Element)
+        assert expr[2] is arr[2]
+
+    def test_bool_mask_raises(self):
+        arr = intvar(0, 10, shape=5, name="arr")
+        b = cp.boolvar(shape=5, name="b")
+        with pytest.raises(TypeError, match="mask"):
+            arr[b]
+
+    def test_vectorized_index_solves(self):
+        arr = cpm_array([10, 20, 30, 40])
+        idx = intvar(0, 3, shape=2, name="idx")
+        m = cp.Model(arr[idx] == [20, 40], idx[0] != idx[1])
+        assert m.solve()
+        assert sorted(idx.value().tolist()) == [1, 3]
+
+
 class TestArrayExpressions:
 
     def test_scalar_expr_with_ndarray(self):


### PR DESCRIPTION
More elaborate explanation on which numpy operations are supported by our NDVarArrays and which are not.
Did not make an exhaustive list, but more general guidelines on what works and what doesn't

Also implements `arr[[idx0,idx1,idx2]]` which previously would raise an error. It now returns a NDVarArray of Element constraints

Closes #791