### PR TITLE
Remove xfailing test for Z3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r", encoding="utf8") as readme_file:
 
 solver_dependencies = {
     "ortools": ["ortools>=9.3.10497,!=9.9.*,!=9.10.*,!=9.11.*"], # exclusion due to bug #191
-    "z3": ["z3-solver>=4.8.15.0"],
+    "z3": ["z3-solver>=5.0.0"],
     "choco": ["pychoco>=0.2.1,<0.3.0"],  # 0.3.0 breaks CPMpy tests
     "exact": ["exact>=2.1.0"], # older versions (<2.2.1) are bugged on py3.13
     "minizinc": ["minizinc>=0.7.0"],

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -486,13 +486,10 @@ class TestSolvers:
         assert not s.solve()
 
     @pytest.mark.requires_solver("z3")
-    @pytest.mark.xfail(
-        reason="Z3 returns incorrect variable values after optimize; see https://github.com/CPMpy/cpmpy/issues/1036",
-        strict=True,
-    )
     def test_z3_optimize_inconsistent_model_values(self, solver):
         # Minimal Golomb-ruler-style problem: Z3 proves objective 20 but returns x9=500.
         # issue tracked in: https://github.com/CPMpy/cpmpy/issues/1036
+        # resolved in z3 version 5.0.0
         n = 10
         U = 500
         x = cp.intvar(0, U, shape=n)


### PR DESCRIPTION
Z3 had a new release, about 5h after I merged #1049 ...
So this PR removes the xfail from the test.

Not sure if we should add the min version in the supported check of the z3 interface, its not that we really rely on features in the new z3 version, its just that the result might be wrong due to internal bugs...