### PR TITLE
Runtime solver version warnings

### DIFF
--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -51,8 +51,6 @@
 from typing import Optional
 import warnings
 
-from packaging.version import Version
-
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
 from ..expressions.core import Expression, Comparison, Operator, NestedBoolExprLike
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
@@ -85,18 +83,17 @@ class CPM_template(SolverInterface):
     # [GUIDELINE] list all global constraints supported in reified context (or half-reified if transformed)
     #           (e.g., 'alldifferent' if your solver supports `b -> AllDifferent(X)`)
     supported_reified_global_constraints = frozenset()
+    # [GUIDELINE] version constraints are read from your extras_require key in ``setup.py``,
+    #           derived from the class name (``CPM_template`` -> ``"template"``);
+    #           only set ``dependency_extra`` if your extras key differs from that
 
     @staticmethod
     def supported():
         # try to import the package
         try:
             import TEMPLATEpy as gp
-            # optionally enforce a specific version
-            tpl_version = CPM_template.version()
-            if Version(tpl_version) < Version("2.1.0"):
-                warnings.warn(f"CPMpy uses features only available from TEMPLATEpy version 0.2.1, "
-                              f"but you have version {tpl_version}.")
-                return False
+            # warns if installed packages do not match the version constraints of this solver's extra in ``setup.py``
+            CPM_template._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError: # if solver's Python package is not installed
             return False

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -45,9 +45,6 @@ import time
 from typing import Optional
 
 import numpy as np
-from packaging.version import Version
-
-import warnings
 
 from ..transformations.normalize import toplevel_list
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
@@ -98,19 +95,13 @@ class CPM_choco(SolverInterface):
         try:
             # check if pychoco is installed
             import pychoco as chc
-            chc_version = CPM_choco.version()
-            # check it's the correct version
-            # CPMPy uses features only available from 0.2.1
-            if Version(chc_version) < Version("0.2.1"):
-                warnings.warn(f"CPMpy uses features only available from Pychoco version 0.2.1, "
-                              f"but you have version {chc_version}.")
-                return False
+            CPM_choco._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False
         except Exception as e:
             raise e
-        
+
     @staticmethod
     def version() -> Optional[str]:
         """

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -101,6 +101,7 @@ class CPM_cplex(SolverInterface):
             return False
         try:
             import cplex
+            CPM_cplex._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError as e:
             return False

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -97,6 +97,7 @@ class CPM_cpo(SolverInterface):
         # try to import the package
         try:
             import docplex.cp as docp
+            CPM_cpo._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -51,8 +51,6 @@ import time
 import warnings
 from typing import Optional, List, Iterable
 
-from packaging.version import Version
-
 from cpmpy.transformations.negation import push_down_negation, push_down_negation_objective
 
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus, Callback
@@ -95,17 +93,13 @@ class CPM_exact(SolverInterface):
         try:
             # check if exact is installed
             import exact
-            xct_version = CPM_exact.version()
-            if Version(xct_version) < Version("2.1.0"):
-                warnings.warn(f"CPMpy requires Exact version >=2.1.0 is required but you have version "
-                              f"{xct_version}, beware exact>=2.1.0 requires Python 3.10 or higher.")
-                return False
+            CPM_exact._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError: # exact is not installed
             return False
         except Exception as e:
             raise e
-        
+
     @staticmethod
     def version() -> Optional[str]:
         """

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -50,10 +50,7 @@
 
         CPM_gcs
 """
-import warnings
 from typing import Optional, Callable, Iterable, Any
-
-from packaging.version import Version
 
 from cpmpy.transformations.comparison import only_numexpr_equality
 from cpmpy.transformations.reification import reify_rewrite, only_bv_reifies
@@ -103,11 +100,7 @@ class CPM_gcs(SolverInterface):
         # try to import the package
         try:
             import gcspy
-            gcs_version = CPM_gcs.version()
-            if Version(gcs_version) < Version("0.1.8"):
-                warnings.warn(f"CPMpy requires GCS version >=0.1.8 but you have version "
-                              f"{gcs_version}, beware exact>=2.1.0 requires Python 3.10 or higher.")
-                return False
+            CPM_gcs._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -96,6 +96,7 @@ class CPM_gurobi(SolverInterface):
     def installed():
         try:
             import gurobipy as gp
+            CPM_gurobi._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -86,6 +86,7 @@ class CPM_highs(SolverInterface):
         # try to import the package
         try:
             import highspy  # noqa: F401
+            CPM_highs._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -117,6 +117,7 @@ class CPM_minizinc(SolverInterface):
         try:
             #  check if MiniZinc Python is installed
             import minizinc
+            CPM_minizinc._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -95,6 +95,7 @@ class CPM_ortools(SolverInterface):
         # try to import the package
         try:
             import ortools
+            CPM_ortools._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -83,7 +83,7 @@ class CPM_pindakaas(SolverInterface):
     def supported():
         try:
             import pindakaas
-
+            CPM_pindakaas._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -37,12 +37,10 @@
     Module details
     ==============
 """
-import warnings
+import time
 from typing import Optional, List, Iterable
-from os.path import join
 
 import numpy as np
-from packaging.version import Version
 
 from cpmpy.exceptions import NotSupportedError
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
@@ -59,8 +57,6 @@ from ..transformations.comparison import only_numexpr_equality
 from ..transformations.negation import push_down_negation
 from ..transformations.reification import reify_rewrite, only_bv_reifies, only_implies
 from ..transformations.safening import no_partial_functions, safen_objective
-
-import time
 
 
 class CPM_pumpkin(SolverInterface):
@@ -81,11 +77,7 @@ class CPM_pumpkin(SolverInterface):
         # try to import the package
         try:
             import pumpkin_solver as psp
-            pum_version = CPM_pumpkin.version()
-            if Version(pum_version) < Version("0.3.0"):
-                warnings.warn(f"CPMpy uses features only available from Pumpkin version >=0.3.0 "
-                              f"but you have version {pum_version}")
-                return False
+            CPM_pumpkin._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -120,6 +120,7 @@ class CPM_pysat(SolverInterface):
                 except (ModuleNotFoundError, NameError):  # pysat returns the wrong error type (latter i/o former)
                     CPM_pysat._pb = None  # not installed, avoid reimporting
 
+            CPM_pysat._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -82,6 +82,7 @@ class CPM_pysdd(SolverInterface):
         # try to import the package
         try:
             from pysdd.sdd import SddManager
+            CPM_pysdd._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -79,6 +79,7 @@ class CPM_scip(SolverInterface):
         # try to import the package
         try:
             import pyscipopt
+            CPM_scip._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -23,6 +23,7 @@ from typing import Any, Optional, List, Callable, TypeAlias, Iterable
 import warnings
 import time
 from enum import Enum
+from functools import lru_cache
 
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, ListLike, ExprLike, NestedBoolExprLike
@@ -35,6 +36,25 @@ from ..transformations.normalize import toplevel_list
 
 Callback: TypeAlias = Expression | ListLike[Expression] | Callable[[], None] # type alias to as display argument in solve and solveAll
 
+
+@lru_cache(maxsize=1)
+def _cpmpy_requirements() -> tuple:
+    """
+    The requirements (incl. extras) declared by the installed ``cpmpy``
+    distribution, as parsed :class:`packaging.requirements.Requirement` objects.
+
+    Empty when running from an uninstalled source tree.
+    """
+    from importlib.metadata import PackageNotFoundError, requires
+    from packaging.requirements import Requirement
+
+    try:
+        reqs = requires("cpmpy") or []
+    except PackageNotFoundError:
+        return ()
+    return tuple(Requirement(r) for r in reqs)
+
+
 class SolverInterface(object):
     """
         Abstract class for defining solver interfaces. All classes implementing
@@ -43,6 +63,10 @@ class SolverInterface(object):
 
     supported_global_constraints: frozenset[str] = frozenset()  # global constraints supported by the solver (e.g., AllDifferent...)
     supported_reified_global_constraints: frozenset[str] = frozenset()  # global constraints supported in reified context
+    # Key in ``setup.py``'s ``extras_require``, used to warn about incompatible
+    # installed package versions. Defaults to the class name without its
+    # ``CPM_`` prefix (e.g. ``CPM_z3`` -> ``"z3"``); only set to override that.
+    dependency_extra: Optional[str] = None
 
     # REQUIRED functions:
     @staticmethod
@@ -55,7 +79,38 @@ class SolverInterface(object):
                 [bool]: Solver support by current system setup.
         """
         return False
-    
+
+    @classmethod
+    def _warn_outdated_dependencies(cls) -> None:
+        """
+        Warn if installed solver packages do not satisfy the version constraints
+        declared for this solver's ``extras_require`` entry in ``setup.py``
+        (read back from the installed distribution metadata).
+
+        Does not block use: older/newer optional solver deps can still be tried
+        at the user's own risk. Prefer calling this from ``supported()`` /
+        ``installed()`` after a successful import.
+        """
+        extra = cls.dependency_extra or cls.__name__.removeprefix("CPM_").lower()
+
+        from importlib.metadata import PackageNotFoundError, version
+
+        for req in _cpmpy_requirements():
+            if req.marker is None or not req.marker.evaluate({"extra": extra}):
+                continue
+            if not req.specifier:
+                continue
+            try:
+                installed = version(req.name)
+            except PackageNotFoundError:
+                continue
+            if not req.specifier.contains(installed, prereleases=True):
+                warnings.warn(
+                    f"CPMpy's '{extra}' extra expects '{req.name}{req.specifier}', "
+                    f"but you have {req.name}=={installed}. You may encounter issues. "
+                    f"Consider: pip install -U 'cpmpy[{extra}]'"
+                )
+
     @classmethod
     def version(cls) -> Optional[str]:
         """

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -87,6 +87,7 @@ class CPM_z3(SolverInterface):
         # try to import the package
         try:
             import z3
+            CPM_z3._warn_outdated_dependencies()
             return True
         except ModuleNotFoundError:
             return False

--- a/docs/adding_solver.md
+++ b/docs/adding_solver.md
@@ -7,7 +7,7 @@ To add your solver to CPMpy, you should copy [cpmpy/solvers/TEMPLATE.py](https:/
 Implementing the template consists of the following parts:
 
   * `version()` where you return the installed version of the solver's Python API, if its installed.
-  * `supported()` where you check whether the solver is ready to use. Never include the solver python package at the top-level of the file, CPMpy has to work even if a user did not install your solver package. If needed, split this into helper checks such as `installed()`, `license_ok()`, `executable_installed()`, or version checks.
+  * `supported()` where you check whether the solver is ready to use. Never include the solver python package at the top-level of the file, CPMpy has to work even if a user did not install your solver package. If needed, split this into helper checks such as `installed()`, `license_ok()`, or `executable_installed()`. For package version constraints, call ``cls._warn_outdated_dependencies()`` after a successful import; it checks the constraints of your extras key in ``setup.py`` (derived from the class name, ``CPM_mysolver`` -> ``"mysolver"``). That warns when the installed version is outside the declared range, without making ``supported()`` return ``False``, so users can still try an older optional solver dependency at their own risk.
   * `__init__()` and `native_model()` where you initialize and return the underlying solver object.
   * `solver_var()` where you create new solver variables and map them to CPMpy decision variables.
   * `solve()` where you call the solver, get the status and runtime, and reverse-map the variable values after solving.
@@ -24,7 +24,7 @@ Now, to get your solver known and easy to use, you also have to register it in a
   * ``docs/api/solvers/`` needs a `.rst` file for your solver, to appear in CPMpy's [API documentation](./api/solvers.rst) (copy one of the other solvers' file and make the necessary changes)
   * ``cpmpy/solvers/__init__.py`` in the *"List of classes"*, the imports and the all, so its easy to import from cpmpy.solvers
   * ``mypy.ini`` if your solver is not typed, you should set ignore_missing_imports for it here
-  * ``setup.py`` you can add a group to ease install; our policy is to only forbid existing solver versions that we know are incompatible
+  * ``setup.py``: add your package version constraints under your solver extras key (single source of truth, used by both install and the runtime version warnings); our policy is to warn about incompatible versions rather than hard-forbid them at runtime
   * ``.github/workflows/python-test.yml`` if the solver is free to use, then this will make the GitHub CI run the test-suite on every commit (highly recommended)
   * ``tests/test_solvers.py`` its not really required, but you can add one explicit test for your solver here, it will always run if the solver is installed
   * if you want your solver to be named in different places in the docs, check ``docs/solvers.md`` and ``docs/installation_instructions.rst`` for solvers mentioned there


### PR DESCRIPTION
Closes #1053 

Implements runtime solver version checks (with warnings if failed) of the optional solver deps. Added to each solver's `supported()`. Version definitions are taken from `setup.py`