### PR TITLE
Dynamic dispatch `decompose_linear`

### DIFF
--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -638,7 +638,7 @@ def get_linear_decompositions():
     return dict(
         alldifferent=AllDifferent.decompose_linear,
         element=Element.decompose_linear,
-        table=Table.decompose_linear,
+        table=lambda expr: expr.decompose_linear(), # dispatch dynamically so Table subclasses with their own decompose_linear are respected 
         short_table=ShortTable.decompose,
         InDomain=InDomain.decompose_linear,
         regular=Regular.decompose_linear,

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -635,13 +635,14 @@ def get_linear_decompositions():
         returns:
             dict: a dictionary mapping expression names to a function, taking as argument the expression to decompose
     """
+    # dispatch dynamically so subclasses with their own decompose_linear are respected
     return dict(
-        alldifferent=AllDifferent.decompose_linear,
-        element=Element.decompose_linear,
-        table=lambda expr: expr.decompose_linear(), # dispatch dynamically so Table subclasses with their own decompose_linear are respected 
-        short_table=ShortTable.decompose,
-        InDomain=InDomain.decompose_linear,
-        regular=Regular.decompose_linear,
+        alldifferent=lambda expr: expr.decompose_linear(),
+        element=lambda expr: expr.decompose_linear(), 
+        table=lambda expr: expr.decompose_linear(), 
+        short_table=lambda expr: expr.decompose(),
+        InDomain=lambda expr: expr.decompose_linear(),
+        regular=lambda expr: expr.decompose_linear(),
     )
 
 def get_linear_positive_decompositions():
@@ -651,9 +652,10 @@ def get_linear_positive_decompositions():
         returns:
             dict: a dictionary mapping expression names to a function, taking as argument the expression to decompose
     """
+    # dispatch dynamically so subclasses with their own decompose_linear_positive are respected
     return dict(
-        regular=Regular.decompose_linear_positive,
-        circuit=Circuit.decompose_linear_positive,
+        regular=lambda expr: expr.decompose_linear_positive(),
+        circuit=lambda expr: expr.decompose_linear_positive(),
     )
 
 

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -761,3 +761,24 @@ class TestLinearizeReifiedVariablesThreshold:
         b, c = cp.intvar(1, 3, name="b"), cp.intvar(1, 3, name="c")
         out = linearize_reified_variables(self.cpm_cons + self.linearize([(b == 1) | (b == 2), b + c == 3]), min_values=2, csemap=self.csemap)
         assert str(out) == "[(BV[a == 1]) or (BV[a == 2]), (BV[b == 1]) or (BV[b == 2]), (b) + (c) == 3, sum([BV[a == 1], BV[a == 2], BV[a == 3]]) == 1, sum([BV[b == 1], BV[b == 2], BV[b == 3]]) == 1, sum([1, 0, -1, -2] * [b, BV[b == 1], BV[b == 2], BV[b == 3]]) == 1]", "The `a` var does occur"
+
+
+class TestLinearDecompositionDispatch:
+
+    def test_table_dispatches_to_subclass(self):
+        # The "table" entry in decompose_linear must dispatch on the instance, 
+        # so Table subclasses that override decompose_linear 
+        # (e.g. NonReifiedTable in the XCSP3 tooling) are used
+        from cpmpy.expressions.globalconstraints import Table
+        from cpmpy.transformations.linearize import get_linear_decompositions
+
+        sentinel = [cp.BoolVal(True)]
+        class SubTable(Table):
+            def decompose_linear(self, heuristic="domain"):
+                return sentinel, []
+
+        x = cp.intvar(0, 2, shape=2)
+        expr = SubTable(x, [[0, 1]])
+        decomposed, defining = get_linear_decompositions()["table"](expr)
+        assert decomposed is sentinel
+        assert defining == []


### PR DESCRIPTION
`decompose_linear` should use dynamic dispatch so that globals inheriting from other globals can still overwrite their linear decomposition.

Fix coming from 57349a829