### PR TITLE
Fix slow tests

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -486,6 +486,7 @@ class TestSolvers:
         assert not s.solve()
 
     @pytest.mark.requires_solver("z3")
+    @pytest.mark.skip(reason="test is extremely slow on z3 v5.0.0")
     def test_z3_optimize_inconsistent_model_values(self, solver):
         # Minimal Golomb-ruler-style problem: Z3 proves objective 20 but returns x9=500.
         # issue tracked in: https://github.com/CPMpy/cpmpy/issues/1036
@@ -1268,7 +1269,7 @@ def test_objective_numexprs(solver, constraint):
 
         # Maximization
         model.maximize(constraint)
-        res = model.solve(solver=solver)
+        res = model.solve(solver=solver, time_limit=3)
         if res is True: # we found a solution
             assert constraint.value() > lb # assume solver finds a feasible sol with value higher than lb
     


### PR DESCRIPTION
Skip the xfail test that #1049 and #1052 introduced for z3. It is extremely slow to run on z3 5.0.0.

Also add time limit for some other test that was taking a long time for some solvers.