### PR TITLE
Hermax MaxSAT modeling library

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -19,6 +19,7 @@ jobs:
               sudo snap install minizinc --classic
           - solver: pindakaas
           - solver: pumpkin
+          - solver: hermax
           - solver: scip
           - solver: highs
     uses: ./.github/workflows/test-solver.yml

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ CPMpy can translate to a wide variety of constraint solving paradigms, including
 * **GO Solvers**: Hexaly (license required)
 * **SMT Solvers**: Z3
 * **PB Solvers**: Exact
+* **MaxSAT Solvers**: RC2 (via PySAT), Hermax + solvers
 * **SAT Encoders and Solvers**: PySAT+solvers, Pindakaas
 * **Decision Diagrams**: PySDD
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CPMpy can translate to a wide variety of constraint solving paradigms, including
 * **GO Solvers**: Hexaly (license required)
 * **SMT Solvers**: Z3
 * **PB Solvers**: Exact
-* **MaxSAT Solvers**: RC2 (via PySAT), Hermax + solvers
+* **MaxSAT Solvers**: RC2 (via PySAT), Hermax+solvers
 * **SAT Encoders and Solvers**: PySAT+solvers, Pindakaas
 * **Decision Diagrams**: PySDD
 

--- a/cpmpy/solvers/__init__.py
+++ b/cpmpy/solvers/__init__.py
@@ -43,6 +43,7 @@ List of solver submodules
     cplex
     hexaly
     rc2
+    hermax
     scip
     highs
 
@@ -80,6 +81,7 @@ from .pumpkin import CPM_pumpkin
 from .cplex import CPM_cplex
 from .hexaly import CPM_hexaly
 from .rc2 import CPM_rc2
+from .hermax import CPM_hermax
 from .scip import CPM_scip
 from .highs import CPM_highs
 
@@ -90,6 +92,7 @@ __all__ = [
     "CPM_exact",
     "CPM_gcs",
     "CPM_gurobi",
+    "CPM_hermax",
     "CPM_hexaly",
     "CPM_highs",
     "CPM_minizinc",

--- a/cpmpy/solvers/hermax.py
+++ b/cpmpy/solvers/hermax.py
@@ -314,17 +314,6 @@ class CPM_hermax(SolverInterface):
         self.her_model &= (~hm_bv).implies(hm_iv == 0)
         return iv
 
-    @staticmethod
-    def _bool_sum(expr):
-        """True if ``expr`` is a sum/wsum over boolean decision variables."""
-        if not isinstance(expr, Operator):
-            return False
-        if expr.name == "sum":
-            return any(isinstance(a, _BoolVarImpl) for a in expr.args)
-        if expr.name == "wsum":
-            return any(isinstance(a, _BoolVarImpl) for a in expr.args[1])
-        return False
-
     def _make_numexpr(self, cpm_expr):
         """
             Turns a numeric CPMpy 'flat' expression into a solver-specific
@@ -348,16 +337,14 @@ class CPM_hermax(SolverInterface):
 
         if isinstance(cpm_expr, Operator):
             if cpm_expr.name == "sum":
-                return sum(self.solver_vars(cpm_expr.args))
+                return sum(self._make_numexpr(a) for a in cpm_expr.args)
             if cpm_expr.name == "wsum":
                 weights, vars_ = cpm_expr.args
-                her_vars = self.solver_vars(cpm_expr.args[1])
-                return sum(w * v for w, v in zip(weights, her_vars))
+                return sum(w * self._make_numexpr(v) for w, v in zip(weights, vars_))
             if cpm_expr.name == "sub":
-                a, b = cpm_expr.args
-                return self.solver_var(a) - self.solver_var(b)
+                return self._make_numexpr(cpm_expr.args[0]) - self._make_numexpr(cpm_expr.args[1])
             if cpm_expr.name == "-":
-                return (-1) * self.solver_var(cpm_expr.args[0])
+                return (-1) * self._make_numexpr(cpm_expr.args[0])
             if cpm_expr.name == "mul":
                 a, b = cpm_expr.args
                 if is_num(a):
@@ -524,13 +511,6 @@ class CPM_hermax(SolverInterface):
                 if lhs.name == "max":
                     return self.her_model.max(self.solver_vars(lhs.args)) == self.solver_var(rhs)
                 raise NotImplementedError(f"Hermax: unsupported global function {lhs}")
-
-            if cpm_con.name in ("<", ">", ">=") and (self._bool_sum(lhs) or self._bool_sum(rhs)):
-                raise ValueError(
-                    "Hermax: strict comparison (<, >, >=) of a sum of boolean variables against an "
-                    "integer is not supported due to a Hermax encoding bug; use <= or == instead. "
-                    "Issue at https://github.com/josalhor/hermax/issues/3"
-                )
 
             hm_lhs = self._make_numexpr(lhs)
             hm_rhs = self._make_numexpr(rhs)

--- a/cpmpy/solvers/hermax.py
+++ b/cpmpy/solvers/hermax.py
@@ -37,7 +37,10 @@
         CPM_hermax
 """
 import time
+import warnings
 from typing import Optional
+
+from packaging.version import Version
 
 from cpmpy.expressions.globalfunctions import GlobalFunction
 
@@ -45,12 +48,12 @@ from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal, NestedBoolExprLike
 from ..expressions.globalconstraints import GlobalConstraint
-from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, intvar
+from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl
 from ..expressions.utils import is_num, is_int, is_boolexpr
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions, safen_objective
-from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
+from ..transformations.flatten_model import flatten_constraint, flatten_objective
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.reification import reify_rewrite, only_bv_reifies, only_implies
@@ -60,7 +63,6 @@ from ..transformations.linearize import (
     linearize_reified_variables,
 )
 
-
 class CPM_hermax(SolverInterface):
     """
     Interface to Hermax's modeling API (``hermax.model.Model``).
@@ -68,6 +70,7 @@ class CPM_hermax(SolverInterface):
     Creates the following attributes (see parent constructor for more):
 
     - ``her_model``: the underlying ``hermax.model.Model`` object
+    - ``her_solver``: optional Hermax IPAMIR solver class selected via ``subsolver``
 
     Documentation of the solver's own Python API:
     https://hermax.readthedocs.io/
@@ -83,9 +86,26 @@ class CPM_hermax(SolverInterface):
     def supported():
         try:
             import hermax  # noqa: F401
+            her_version = CPM_hermax.version()
+            if her_version is None or Version(her_version) < Version("1.2.3"):
+                warnings.warn(f"CPMpy requires Hermax version >=1.2.3 "
+                              f"but you have version {her_version}")
+                return False
             return True
         except ModuleNotFoundError:
             return False
+
+    @staticmethod
+    def solvernames(**kwargs):
+        """
+            Returns solvers supported by Hermax on your system
+        """
+        if CPM_hermax.supported():
+            import hermax.non_incremental as her_ni
+            return list(her_ni.__all__)
+        else:
+            warnings.warn("Hermax is not installed or not supported on this system.")
+            return []
 
     @staticmethod
     def version() -> Optional[str]:
@@ -104,23 +124,42 @@ class CPM_hermax(SolverInterface):
 
         Arguments:
             cpm_model: Model(), a CPMpy Model() (optional)
-            subsolver: None, not used
+            subsolver (str, name of the hermax solver, e.g. EvalMaxSAT):  see .solvernames() to get the list of available solver(names)
         """
         if not self.supported():
+            her_version = CPM_hermax.version()
+            if her_version is not None and Version(her_version) < Version("1.2.3"):
+                raise ImportError(
+                    f"CPM_hermax: CPMpy requires Hermax version >=1.2.3 "
+                    f"but you have version {her_version}"
+                )
             raise ModuleNotFoundError("CPM_hermax: Install the python package 'hermax' to use this solver interface.")
 
         from hermax.model import Model
+        import hermax.non_incremental as her_ni
 
-        assert subsolver is None, "Hermax does not support subsolvers yet"
+        # determine subsolver
+        if subsolver is None or subsolver == "hermax":
+            # default: hermax's built-in SAT/MaxSAT backends
+            her_solver = None
+            name = "hermax"
+        else:
+            if subsolver.startswith("hermax:"):
+                subsolver = subsolver[7:]  # strip 'hermax:'
+            if subsolver not in self.solvernames():
+                raise ValueError(f"Unknown Hermax subsolver '{subsolver}', choose from {self.solvernames()}")
+            her_solver = getattr(her_ni, subsolver)
+            name = "hermax:" + subsolver
 
+        # initialise the native solver object
         self.her_model = Model()
+        self.her_solver = her_solver
         self._objective = None
         self._objective_posted = False
         self._assumption_map = {}  # dimacs lit -> CPMpy assumption expr
-        self._last_core = None
-        self._bool_intmap = {}  # boolvar name -> channeled {0,1} intvar
 
-        super().__init__(name="hermax", cpm_model=cpm_model)
+        # initialise everything else and post the constraints/objective
+        super().__init__(name=name, cpm_model=cpm_model)
 
     @property
     def native_model(self):
@@ -134,25 +173,33 @@ class CPM_hermax(SolverInterface):
         Call the Hermax solver
 
         Arguments:
-            time_limit (float, optional): maximum solve time in seconds.
-                Negative values raise ``ValueError``. When supported by the
-                underlying PySAT/backend solver, search is interrupted after
-                the limit.
-            assumptions: iterable of Boolean variables (or their negation) assumed true
-            **kwargs: forwarded to ``hermax.model.Model.solve`` (e.g. ``sat_solver_name``,
-                ``maxsat_backend``, ``incremental``, ``solver``)
+            time_limit (float, optional): not supported yet (raises ``NotSupportedError``)
+            assumptions:                  iterable (e.g. list, set, tuple) of CPMpy Boolean variables (or their negation) that are assumed to be true.
+                                          For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
+                                          get_core() returns a small subset of assumption variables that are unsat together.
+            **kwargs:                     any keyword argument, sets parameters of solver object
 
-        Returns:
-            whether a solution was found
+        Arguments that correspond to solver parameters:
+
+        - ``sat_solver_name``
+        - ``maxsat_backend``
+        - ``incremental``
+
+        The MaxSAT subsolver itself is selected at construction time
+        (e.g. ``cp.SolverLookup.get("hermax:EvalMaxSAT")``), not via ``solve()``.
+
+        See https://hermax.readthedocs.io/ for the full list.
         """
-        if time_limit is not None and time_limit < 0:
-            raise ValueError(f"Time limit cannot be negative, but got {time_limit}")
+        if "solver" in kwargs:
+            raise ValueError("Hermax subsolver must be selected at construction (e.g. cp.SolverLookup.get('hermax:EvalMaxSAT')), not via solve(solver=...).")
+
+        if time_limit is not None:
+            raise NotSupportedError("Hermax: time_limit is not supported yet (no reliable interrupt/anytime API on the default MaxSAT path)")
 
         self.solver_vars(list(self.user_vars))
 
         hm_assumptions = None
         self._assumption_map = {}
-        self._last_core = None
         if assumptions is not None:
             assumptions = list(assumptions)
             hm_assumptions = []
@@ -164,77 +211,29 @@ class CPM_hermax(SolverInterface):
                 self._assumption_map[dimacs] = a
 
         start = time.time()
-        timer = None
-        if time_limit is not None and time_limit > 0:
-            from threading import Timer
-
-            def _interrupt():
-                sat = getattr(self.her_model._inc_state, "sat_solver", None)
-                if sat is not None and hasattr(sat, "interrupt"):
-                    try:
-                        sat.interrupt()
-                    except Exception:
-                        pass
-                ip = getattr(self.her_model._inc_state, "ip_solver", None)
-                if ip is not None and hasattr(ip, "interrupt"):
-                    try:
-                        ip.interrupt()
-                    except Exception:
-                        pass
-
-            timer = Timer(time_limit, _interrupt)
-            timer.daemon = True
-            timer.start()
-
-        try:
-            result = self.her_model.solve(assumptions=hm_assumptions, **kwargs)
-        finally:
-            if timer is not None:
-                timer.cancel()
-                sat = getattr(self.her_model._inc_state, "sat_solver", None)
-                if sat is not None and hasattr(sat, "clear_interrupt"):
-                    try:
-                        sat.clear_interrupt()
-                    except Exception:
-                        pass
-
+        result = self.her_model.solve(
+            assumptions=hm_assumptions, solver=self.her_solver, **kwargs
+        )
         runtime = time.time() - start
 
         self.cpm_status = SolverStatus(self.name)
         self.cpm_status.runtime = runtime
 
-        status = str(result.status).lower()
-        if status in ("optimum", "optimal"):
+        # Hermax SolveResult.status is one of:
+        # sat | unsat | optimum | interrupted_sat | interrupted | unknown | error
+        status = result.status
+        if status == "optimum":
             self.cpm_status.exitstatus = ExitStatus.OPTIMAL
-        elif status in ("sat", "satisfiable", "feasible"):
-            self.cpm_status.exitstatus = (
-                ExitStatus.OPTIMAL if self.has_objective() else ExitStatus.FEASIBLE
-            )
-        elif status in ("unsat", "unsatisfiable"):
+        elif status in ("sat", "interrupted_sat"):
+            self.cpm_status.exitstatus = ExitStatus.FEASIBLE
+        elif status == "unsat":
             self.cpm_status.exitstatus = ExitStatus.UNSATISFIABLE
-            # extract unsat core from underlying PySAT solver when available
-            sat = getattr(self.her_model._inc_state, "sat_solver", None)
-            if sat is not None and hasattr(sat, "get_core"):
-                try:
-                    dimacs_core = sat.get_core() or []
-                    core = []
-                    for lit in dimacs_core:
-                        if lit in self._assumption_map:
-                            cpm_a = self._assumption_map[lit]
-                            if cpm_a not in core:
-                                core.append(cpm_a)
-                    self._last_core = core
-                except Exception:
-                    self._last_core = None
-        elif status in ("unknown", "timeout", "interrupted"):
+        elif status in ("interrupted", "unknown"):
             self.cpm_status.exitstatus = ExitStatus.UNKNOWN
+        elif status == "error":
+            self.cpm_status.exitstatus = ExitStatus.ERROR
         else:
-            if result.ok:
-                self.cpm_status.exitstatus = (
-                    ExitStatus.OPTIMAL if self.has_objective() else ExitStatus.FEASIBLE
-                )
-            else:
-                self.cpm_status.exitstatus = ExitStatus.UNKNOWN
+            raise ValueError(f"Unknown Hermax status: {result.status!r}, please report on github...")
 
         has_sol = self._solve_return(self.cpm_status)
         self.objective_value_ = None
@@ -259,11 +258,21 @@ class CPM_hermax(SolverInterface):
             Core extraction uses the underlying PySAT SAT backend. It may be
             unavailable when solving through a MaxSAT backend.
         """
-        if self._last_core is None:
-            raise NotSupportedError(
-                "Hermax: no unsat core available (solve under assumptions with a SAT backend first)"
-            )
-        return list(self._last_core)
+        assert self.cpm_status.exitstatus == ExitStatus.UNSATISFIABLE, "get_core(): solver must return UNSAT"
+        assert len(self._assumption_map) > 0, "get_core(): requires a list of assumption variables, e.g. s.solve(assumptions=[...])"
+
+        sat = getattr(self.her_model._inc_state, "sat_solver", None)
+        if sat is None or not hasattr(sat, "get_core"):
+            raise NotSupportedError("Hermax: no unsat core available (solve under assumptions with a SAT backend first)")
+
+        dimacs_core = sat.get_core() or []
+        core = []
+        for lit in dimacs_core:
+            if lit in self._assumption_map:
+                cpm_a = self._assumption_map[lit]
+                if cpm_a not in core:
+                    core.append(cpm_a)
+        return core
 
     def solver_var(self, cpm_var):
         """
@@ -295,25 +304,6 @@ class CPM_hermax(SolverInterface):
 
         raise NotImplementedError("Not a known var {}".format(cpm_var))
 
-    def _bool_as_int(self, cpm_bool):
-        """
-        Return a {0,1} intvar channeled to ``cpm_bool`` (one intvar per underlying bool).
-        """
-        if isinstance(cpm_bool, NegBoolView):
-            cpm_bool = cpm_bool._bv
-
-        name = cpm_bool.name
-        if name in self._bool_intmap:
-            return self._bool_intmap[name]
-
-        iv = intvar(0, 1, name=f"_hm_{name}")
-        self._bool_intmap[name] = iv
-        hm_bv = self.solver_var(cpm_bool)
-        hm_iv = self.solver_var(iv)
-        self.her_model &= hm_bv.implies(hm_iv == 1)
-        self.her_model &= (~hm_bv).implies(hm_iv == 0)
-        return iv
-
     def _make_numexpr(self, cpm_expr):
         """
             Turns a numeric CPMpy 'flat' expression into a solver-specific
@@ -326,13 +316,8 @@ class CPM_hermax(SolverInterface):
         if is_num(cpm_expr):
             return int(cpm_expr)
 
-        # decision variables, check in varmap
-        if isinstance(cpm_expr, _NumVarImpl): 
-            if cpm_expr.is_bool():
-                # Boolvars are not integer for Hermax, channel to 0-1 intvar
-                if isinstance(cpm_expr, NegBoolView):
-                    return 1 - self.solver_var(self._bool_as_int(cpm_expr._bv))
-                return self.solver_var(self._bool_as_int(cpm_expr))
+        # decision variables, check in varmap (bools are native 0/1 in PB context)
+        if isinstance(cpm_expr, _NumVarImpl):
             return self.solver_var(cpm_expr)
 
         if isinstance(cpm_expr, Operator):
@@ -379,22 +364,15 @@ class CPM_hermax(SolverInterface):
             csemap=self._csemap,
         )
         obj, flat_cons = flatten_objective(obj, csemap=self._csemap)
-        obj_var, obj_cons = get_or_make_var(obj)
-        if expr.is_bool():
-            ivar = intvar(0, 1)
-            obj_cons.append(ivar == obj_var)
-            obj_var = ivar
 
-        self.add(safe_cons + decomp_cons + flat_cons + obj_cons)
-        self._objective = obj_var
+        self.add(safe_cons + decomp_cons + flat_cons)
+        self._objective = obj
 
-        hm_obj = self.solver_var(obj_var)
-        # Hermax soft IntVar terms currently require a non-negative domain
-        lb, ub = int(obj_var.lb), int(obj_var.ub)
-        if minimize:
-            hm_expr = hm_obj - lb  # shift to [0, ub-lb]
-        else:
-            hm_expr = ub - hm_obj  # maximize via minimizing (ub - x)
+        hm_obj = self._make_numexpr(obj)
+        # Hermax soft IntVar terms currently require a non-negative domain;
+        # also encode maximize as minimize(ub - expr).
+        lb, ub = obj.get_bounds()
+        hm_expr = (hm_obj - int(lb)) if minimize else (int(ub) - hm_obj)
         if self._objective_posted:
             self.her_model.obj.replace_with(hm_expr)
         else:
@@ -512,6 +490,10 @@ class CPM_hermax(SolverInterface):
                     return self.her_model.max(self.solver_vars(lhs.args)) == self.solver_var(rhs)
                 raise NotImplementedError(f"Hermax: unsupported global function {lhs}")
 
+            # Hermax rejects Literal != Literal; encode as XOR via PB sum
+            if cpm_con.name == "!=" and is_boolexpr(lhs) and is_boolexpr(rhs):
+                return (self.solver_var(lhs) + self.solver_var(rhs)) == 1
+
             hm_lhs = self._make_numexpr(lhs)
             hm_rhs = self._make_numexpr(rhs)
             if cpm_con.name == "==":
@@ -566,3 +548,4 @@ class CPM_hermax(SolverInterface):
             raise NotImplementedError(f"Hermax: unsupported global {cpm_con}")
 
         raise NotImplementedError(f"Hermax: unexpected constraint {cpm_con}")
+

--- a/cpmpy/solvers/hermax.py
+++ b/cpmpy/solvers/hermax.py
@@ -25,6 +25,12 @@
     See detailed installation instructions at:
     https://hermax.readthedocs.io/
 
+    .. note::
+        With a ``time_limit``, satisfaction problems (no objective) are solved
+        non-incrementally (one-shot SAT): Hermax's live incremental SAT backend
+        cannot interrupt. Optimization (MaxSAT) can stay incremental and may
+        return a feasible suboptimal solution when the limit is hit.
+
     The rest of this documentation is for advanced users.
 
     ===============
@@ -87,8 +93,8 @@ class CPM_hermax(SolverInterface):
         try:
             import hermax  # noqa: F401
             her_version = CPM_hermax.version()
-            if her_version is None or Version(her_version) < Version("1.2.3"):
-                warnings.warn(f"CPMpy requires Hermax version >=1.2.3 "
+            if her_version is None or Version(her_version) < Version("1.2.4"):
+                warnings.warn(f"CPMpy requires Hermax version >=1.2.4 "
                               f"but you have version {her_version}")
                 return False
             return True
@@ -128,9 +134,9 @@ class CPM_hermax(SolverInterface):
         """
         if not self.supported():
             her_version = CPM_hermax.version()
-            if her_version is not None and Version(her_version) < Version("1.2.3"):
+            if her_version is not None and Version(her_version) < Version("1.2.4"):
                 raise ImportError(
-                    f"CPM_hermax: CPMpy requires Hermax version >=1.2.3 "
+                    f"CPM_hermax: CPMpy requires Hermax version >=1.2.4 "
                     f"but you have version {her_version}"
                 )
             raise ModuleNotFoundError("CPM_hermax: Install the python package 'hermax' to use this solver interface.")
@@ -173,7 +179,16 @@ class CPM_hermax(SolverInterface):
         Call the Hermax solver
 
         Arguments:
-            time_limit (float, optional): not supported yet (raises ``NotSupportedError``)
+            time_limit (float, optional): Maximum solve time in seconds.
+                                          Must be positive when set.
+
+                                          Satisfaction problems (no objective) use a
+                                          non-incremental one-shot SAT solve under a
+                                          time limit, because Hermax's live incremental
+                                          SAT backend cannot interrupt. Optimization
+                                          (MaxSAT) can interrupt a live backend and may
+                                          return a feasible suboptimal solution
+                                          (``interrupted_sat`` → FEASIBLE).
             assumptions:                  iterable (e.g. list, set, tuple) of CPMpy Boolean variables (or their negation) that are assumed to be true.
                                           For repeated solving, and/or for use with :func:`s.get_core() <get_core()>`: if the model is UNSAT,
                                           get_core() returns a small subset of assumption variables that are unsat together.
@@ -194,7 +209,14 @@ class CPM_hermax(SolverInterface):
             raise ValueError("Hermax subsolver must be selected at construction (e.g. cp.SolverLookup.get('hermax:EvalMaxSAT')), not via solve(solver=...).")
 
         if time_limit is not None:
-            raise NotSupportedError("Hermax: time_limit is not supported yet (no reliable interrupt/anytime API on the default MaxSAT path)")
+            if time_limit <= 0:
+                raise ValueError("Time limit must be positive")
+            # Live incremental SAT cannot interrupt; use one-shot timed SAT.
+            # Live MaxSAT can take time_limit on the bound backend.
+            if self.her_model._inc_state.mode == "sat":
+                self.her_model.close_incremental()
+            if self.her_model._inc_state.mode != "maxsat":
+                kwargs.setdefault("incremental", False)
 
         self.solver_vars(list(self.user_vars))
 
@@ -212,7 +234,8 @@ class CPM_hermax(SolverInterface):
 
         start = time.time()
         result = self.her_model.solve(
-            assumptions=hm_assumptions, solver=self.her_solver, **kwargs
+            assumptions=hm_assumptions, solver=self.her_solver,
+            time_limit=time_limit, **kwargs
         )
         runtime = time.time() - start
 
@@ -231,7 +254,11 @@ class CPM_hermax(SolverInterface):
         elif status in ("interrupted", "unknown"):
             self.cpm_status.exitstatus = ExitStatus.UNKNOWN
         elif status == "error":
-            self.cpm_status.exitstatus = ExitStatus.ERROR
+            # One-shot timed MaxSAT (PortfolioSolver + RC2) can report "error" when the
+            # worker is killed at the limit without a model; treat as UNKNOWN then.
+            self.cpm_status.exitstatus = (
+                ExitStatus.UNKNOWN if time_limit is not None else ExitStatus.ERROR
+            )
         else:
             raise ValueError(f"Unknown Hermax status: {result.status!r}, please report on github...")
 

--- a/cpmpy/solvers/hermax.py
+++ b/cpmpy/solvers/hermax.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+##
+## hermax.py
+##
+"""
+    Interface to Hermax's high-level modeling API
+
+    Hermax is a Python library of incremental MaxSAT solvers with a CP-style
+    modeling layer (typed variables, linear/pseudo-Boolean constraints, and
+    some global constraints). See https://github.com/josalhor/hermax
+
+    Always use :func:`cp.SolverLookup.get("hermax") <cpmpy.solvers.utils.SolverLookup.get>` to instantiate the solver object.
+
+    ============
+    Installation
+    ============
+
+    Requires that the 'hermax' python package is installed:
+
+    .. code-block:: console
+
+        $ pip install hermax
+
+    See detailed installation instructions at:
+    https://hermax.readthedocs.io/
+
+    The rest of this documentation is for advanced users.
+
+    ===============
+    List of classes
+    ===============
+
+    .. autosummary::
+        :nosignatures:
+
+        CPM_hermax
+"""
+import time
+from typing import Optional
+
+from .solver_interface import SolverInterface, SolverStatus, ExitStatus
+from ..exceptions import NotSupportedError
+from ..expressions.core import Expression, Comparison, Operator, BoolVal, NestedBoolExprLike
+from ..expressions.globalconstraints import GlobalConstraint
+from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, intvar
+from ..expressions.utils import is_num, is_int, is_boolexpr
+from ..transformations.get_variables import get_variables
+from ..transformations.normalize import toplevel_list
+from ..transformations.safening import no_partial_functions, safen_objective
+from ..transformations.decompose_global import decompose_in_tree, decompose_objective
+from ..transformations.flatten_model import flatten_constraint, get_or_make_var
+from ..transformations.comparison import only_numexpr_equality
+from ..transformations.negation import push_down_negation
+from ..transformations.reification import reify_rewrite, only_bv_reifies, only_implies
+
+
+class CPM_hermax(SolverInterface):
+    """
+    Interface to Hermax's modeling API (``hermax.model.Model``).
+
+    Creates the following attributes (see parent constructor for more):
+
+    - ``her_model``: the underlying ``hermax.model.Model`` object
+
+    Documentation of the solver's own Python API:
+    https://hermax.readthedocs.io/
+    """
+
+    # CP-level globals Hermax encodes natively
+    supported_global_constraints = frozenset({
+        "alldifferent", "cumulative", "increasing", "lex_less", "min", "max",
+    })
+    supported_reified_global_constraints = frozenset()
+
+    @staticmethod
+    def supported():
+        try:
+            import hermax  # noqa: F401
+            return True
+        except ModuleNotFoundError:
+            return False
+
+    @staticmethod
+    def version() -> Optional[str]:
+        """
+        Returns the installed version of the solver's Python API.
+        """
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return version("hermax")
+        except PackageNotFoundError:
+            return None
+
+    def __init__(self, cpm_model=None, subsolver=None):
+        """
+        Constructor of the native solver object
+
+        Arguments:
+            cpm_model: Model(), a CPMpy Model() (optional)
+            subsolver: None, not used
+        """
+        if not self.supported():
+            raise ModuleNotFoundError("CPM_hermax: Install the python package 'hermax' to use this solver interface.")
+
+        from hermax.model import Model
+
+        assert subsolver is None, "Hermax does not support subsolvers yet"
+
+        self.her_model = Model()
+        self._objective = None
+        self._objective_posted = False
+        self._assumption_map = {}  # dimacs lit -> CPMpy assumption expr
+        self._last_core = None
+        self._bool2int = {}  # CPMpy bool-var name -> Hermax IntVar 0/1
+
+        super().__init__(name="hermax", cpm_model=cpm_model)
+
+    @property
+    def native_model(self):
+        """
+            Returns the solver's underlying native model (for direct solver access).
+        """
+        return self.her_model
+
+    def solve(self, time_limit: Optional[float] = None, assumptions=None, **kwargs):
+        """
+        Call the Hermax solver
+
+        Arguments:
+            time_limit (float, optional): maximum solve time in seconds.
+                Negative values raise ``ValueError``. When supported by the
+                underlying PySAT/backend solver, search is interrupted after
+                the limit.
+            assumptions: iterable of Boolean variables (or their negation) assumed true
+            **kwargs: forwarded to ``hermax.model.Model.solve`` (e.g. ``sat_solver_name``,
+                ``maxsat_backend``, ``incremental``, ``solver``)
+
+        Returns:
+            whether a solution was found
+        """
+        if time_limit is not None and time_limit < 0:
+            raise ValueError(f"Time limit cannot be negative, but got {time_limit}")
+
+        self.solver_vars(list(self.user_vars))
+
+        hm_assumptions = None
+        self._assumption_map = {}
+        self._last_core = None
+        if assumptions is not None:
+            assumptions = list(assumptions)
+            hm_assumptions = []
+            for a in assumptions:
+                hm_a = self.solver_var(a)
+                hm_assumptions.append(hm_a)
+                # signed DIMACS literal (polarity=False -> negative id)
+                dimacs = int(hm_a.id) if hm_a.polarity else -int(hm_a.id)
+                self._assumption_map[dimacs] = a
+
+        start = time.time()
+        timer = None
+        if time_limit is not None and time_limit > 0:
+            from threading import Timer
+
+            def _interrupt():
+                sat = getattr(self.her_model._inc_state, "sat_solver", None)
+                if sat is not None and hasattr(sat, "interrupt"):
+                    try:
+                        sat.interrupt()
+                    except Exception:
+                        pass
+                ip = getattr(self.her_model._inc_state, "ip_solver", None)
+                if ip is not None and hasattr(ip, "interrupt"):
+                    try:
+                        ip.interrupt()
+                    except Exception:
+                        pass
+
+            timer = Timer(time_limit, _interrupt)
+            timer.daemon = True
+            timer.start()
+
+        try:
+            result = self.her_model.solve(assumptions=hm_assumptions, **kwargs)
+        finally:
+            if timer is not None:
+                timer.cancel()
+                sat = getattr(self.her_model._inc_state, "sat_solver", None)
+                if sat is not None and hasattr(sat, "clear_interrupt"):
+                    try:
+                        sat.clear_interrupt()
+                    except Exception:
+                        pass
+
+        runtime = time.time() - start
+
+        self.cpm_status = SolverStatus(self.name)
+        self.cpm_status.runtime = runtime
+
+        status = str(result.status).lower()
+        if status in ("optimum", "optimal"):
+            self.cpm_status.exitstatus = ExitStatus.OPTIMAL
+        elif status in ("sat", "satisfiable", "feasible"):
+            self.cpm_status.exitstatus = (
+                ExitStatus.OPTIMAL if self.has_objective() else ExitStatus.FEASIBLE
+            )
+        elif status in ("unsat", "unsatisfiable"):
+            self.cpm_status.exitstatus = ExitStatus.UNSATISFIABLE
+            # extract unsat core from underlying PySAT solver when available
+            sat = getattr(self.her_model._inc_state, "sat_solver", None)
+            if sat is not None and hasattr(sat, "get_core"):
+                try:
+                    dimacs_core = sat.get_core() or []
+                    core = []
+                    for lit in dimacs_core:
+                        if lit in self._assumption_map:
+                            cpm_a = self._assumption_map[lit]
+                            if cpm_a not in core:
+                                core.append(cpm_a)
+                    self._last_core = core
+                except Exception:
+                    self._last_core = None
+        elif status in ("unknown", "timeout", "interrupted"):
+            self.cpm_status.exitstatus = ExitStatus.UNKNOWN
+        else:
+            if result.ok:
+                self.cpm_status.exitstatus = (
+                    ExitStatus.OPTIMAL if self.has_objective() else ExitStatus.FEASIBLE
+                )
+            else:
+                self.cpm_status.exitstatus = ExitStatus.UNKNOWN
+
+        has_sol = self._solve_return(self.cpm_status)
+        self.objective_value_ = None
+        if has_sol:
+            for cpm_var in self.user_vars:
+                cpm_var._value = result.assignment[self.solver_var(cpm_var)]
+            if self.has_objective():
+                self.objective_value_ = int(self._objective.value())
+        else:
+            for cpm_var in self.user_vars:
+                cpm_var._value = None
+
+        return has_sol
+
+    def get_core(self):
+        """
+        For use with :func:`s.solve(assumptions=[...]) <cpmpy.solvers.hermax.CPM_hermax.solve>`.
+        Only meaningful if the solver returned UNSAT. Returns a subset of the
+        assumption literals that are unsatisfiable together.
+
+        .. note::
+            Core extraction uses the underlying PySAT SAT backend. It may be
+            unavailable when solving through a MaxSAT backend.
+        """
+        if self._last_core is None:
+            raise NotSupportedError(
+                "Hermax: no unsat core available (solve under assumptions with a SAT backend first)"
+            )
+        return list(self._last_core)
+
+    def solver_var(self, cpm_var):
+        """
+            Creates solver variable for cpmpy variable
+            or returns from cache if previously created
+            or returns a constant if the variable is a constant
+        """
+        if isinstance(cpm_var, _NumVarImpl):
+            name = cpm_var.name
+            revar = self._varmap.get(name)
+            if revar is not None:
+                return revar
+
+            # not yet created, make a new solver var
+            if cpm_var.is_bool():
+                if isinstance(cpm_var, NegBoolView):
+                    # special case, negative-bool-view: work directly on var inside the view
+                    revar = ~self.solver_var(cpm_var._bv)
+                else:
+                    revar = self.her_model.bool(name)
+            else:
+                revar = self.her_model.int(name, int(cpm_var.lb), int(cpm_var.ub))
+
+            self._varmap[name] = revar
+            return revar
+
+        if is_int(cpm_var):  # shortcut, eases posting constraints
+            return cpm_var
+
+        raise NotImplementedError("Not a known var {}".format(cpm_var))
+
+    def objective(self, expr: Expression, minimize: bool = True):
+        """
+            Post the given expression to the solver as objective to minimize/maximize
+
+            ``objective()`` can be called multiple times; only the last one is stored.
+            Subsequent calls replace the Hermax objective via ``model.obj.replace_with(...)``.
+
+            Arguments:
+                expr: Expression, the CPMpy expression that represents the objective function
+                minimize: Bool, whether it is a minimization problem (True) or maximization (False)
+        """
+        get_variables(expr, self.user_vars)
+
+        obj, safe_cons = safen_objective(expr)
+        obj, decomp_cons = decompose_objective(
+            obj,
+            supported=self.supported_global_constraints,
+            supported_reified=self.supported_reified_global_constraints,
+            csemap=self._csemap,
+        )
+        obj_var, obj_cons = get_or_make_var(obj)
+        if expr.is_bool():
+            ivar = intvar(0, 1)
+            obj_cons.append(ivar == obj_var)
+            obj_var = ivar
+
+        self.add(safe_cons + decomp_cons + obj_cons)
+        self._objective = obj_var
+
+        hm_obj = self.solver_var(obj_var)
+        # Hermax soft IntVar terms currently require a non-negative domain
+        lb, ub = int(obj_var.lb), int(obj_var.ub)
+        if minimize:
+            hm_expr = hm_obj - lb  # shift to [0, ub-lb]
+        else:
+            hm_expr = ub - hm_obj  # maximize via minimizing (ub - x)
+        if self._objective_posted:
+            self.her_model.obj.replace_with(hm_expr)
+        else:
+            self.her_model.obj += hm_expr
+            self._objective_posted = True
+
+    def has_objective(self):
+        return self._objective is not None
+
+    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+        """
+            Transform arbitrary CPMpy expressions to constraints the solver supports
+
+            Arguments:
+                cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
+
+            Returns:
+                list[Expression]: transformed constraints
+        """
+        cpm_cons = toplevel_list(cpm_expr)
+        cpm_cons = no_partial_functions(cpm_cons)
+        cpm_cons = push_down_negation(cpm_cons)
+        cpm_cons = decompose_in_tree(
+            cpm_cons,
+            supported=self.supported_global_constraints,
+            supported_reified=self.supported_reified_global_constraints,
+            csemap=self._csemap,
+        )
+        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)
+        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
+        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
+        cpm_cons = reify_rewrite(
+            cpm_cons,
+            supported=frozenset({"or", "sum", "wsum", "sub"}),
+            csemap=self._csemap,
+        )
+        # Hermax posts min/max only as equality to a variable; sums support all comparisons
+        cpm_cons = only_numexpr_equality(
+            cpm_cons,
+            supported=frozenset({"sum", "wsum", "sub"}),
+            csemap=self._csemap,
+        )
+        return cpm_cons
+
+    def _bool_as_int(self, cpm_bv):
+        """
+        Channel a Boolean variable to an IntVar in {0,1} for numeric use.
+
+        Needed because Hermax PB comparisons gated by ``only_if`` can be incorrect
+        when the same Literal also appears inside the comparison.
+        """
+        if isinstance(cpm_bv, NegBoolView):
+            # 1 - positive bool
+            return 1 - self._bool_as_int(cpm_bv._bv)
+
+        name = cpm_bv.name
+        revar = self._bool2int.get(name)
+        if revar is not None:
+            return revar
+
+        hm_bv = self.solver_var(cpm_bv)
+        revar = self.her_model.int(f"_b2i_{name}", 0, 1)
+        self.her_model &= (1 * hm_bv) == revar
+        self._bool2int[name] = revar
+        return revar
+
+    def _hm_numexpr(self, cpm_expr):
+        """Convert a flat numeric CPMpy expression to a Hermax numeric expression."""
+        if is_num(cpm_expr):
+            return int(cpm_expr)
+        if isinstance(cpm_expr, _BoolVarImpl):
+            return self._bool_as_int(cpm_expr)
+        if isinstance(cpm_expr, _NumVarImpl):
+            return self.solver_var(cpm_expr)
+
+        if isinstance(cpm_expr, Operator):
+            if cpm_expr.name == "sum":
+                args = [self._hm_numexpr(a) for a in cpm_expr.args]
+                return sum(args) if len(args) else 0
+            if cpm_expr.name == "wsum":
+                weights, vars_ = cpm_expr.args
+                total = 0
+                for w, v in zip(weights, vars_):
+                    if w == 0:
+                        continue
+                    total = total + int(w) * self._hm_numexpr(v)
+                return total
+            if cpm_expr.name == "sub":
+                a, b = cpm_expr.args
+                return self._hm_numexpr(a) - self._hm_numexpr(b)
+            if cpm_expr.name == "-":
+                return (-1) * self._hm_numexpr(cpm_expr.args[0])
+            if cpm_expr.name == "mul":
+                a, b = cpm_expr.args
+                if is_num(a):
+                    return int(a) * self._hm_numexpr(b)
+                if is_num(b):
+                    return self._hm_numexpr(a) * int(b)
+                raise NotSupportedError(f"Hermax: non-linear multiplication not supported: {cpm_expr}")
+
+        raise NotImplementedError(f"Hermax: unsupported numeric expression {cpm_expr}")
+
+    def _as_pb(self, hm_expr):
+        """Ensure a Hermax numeric expression supports all relational operators."""
+        from hermax.model.expressions import PBExpr
+        from hermax.model.variables import IntVar
+        if isinstance(hm_expr, PBExpr) or is_num(hm_expr):
+            return hm_expr
+        if isinstance(hm_expr, IntVar):
+            return hm_expr + 0  # promote to PBExpr (IntVar != PBExpr is broken in Hermax)
+        return hm_expr
+
+    def _hm_comparison(self, cpm_expr):
+        """Convert a flat Comparison to a Hermax constraint / literal."""
+        lhs, rhs = cpm_expr.args
+        op = cpm_expr.name
+
+        # Global functions in equality form: min/max(...) == rhs
+        if op == "==" and isinstance(lhs, Expression) and lhs.name in {"min", "max"}:
+            hm_args = [self.solver_var(a) for a in lhs.args]
+            hm_rhs = self.solver_var(rhs) if isinstance(rhs, _NumVarImpl) else int(rhs)
+            if lhs.name == "min":
+                return self.her_model.min(hm_args) == hm_rhs
+            return self.her_model.max(hm_args) == hm_rhs
+
+        hm_lhs = self._as_pb(self._hm_numexpr(lhs))
+        hm_rhs = self._as_pb(self._hm_numexpr(rhs))
+        if op == "==":
+            return hm_lhs == hm_rhs
+        if op == "!=":
+            return hm_lhs != hm_rhs
+        if op == "<=":
+            return hm_lhs <= hm_rhs
+        if op == "<":
+            return hm_lhs < hm_rhs
+        if op == ">=":
+            return hm_lhs >= hm_rhs
+        if op == ">":
+            return hm_lhs > hm_rhs
+
+        raise NotImplementedError(f"Hermax: unsupported comparison {cpm_expr}")
+
+    def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_hermax":
+        """
+            Eagerly add a constraint to the underlying solver.
+
+            Arguments:
+                cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
+
+            Returns:
+                self
+        """
+        get_variables(cpm_expr, collect=self.user_vars)
+
+        for cpm_con in self.transform(cpm_expr):
+            if isinstance(cpm_con, Operator) and cpm_con.name == "and":
+                for arg in cpm_con.args:
+                    self.add(arg)
+                continue
+
+            hm_con = self._hermax_expr(cpm_con)
+            if hm_con is not None:
+                self.her_model &= hm_con
+
+        return self
+
+    __add__ = add
+
+    def _hermax_expr(self, cpm_con):
+        """
+            Translate a flat CPMpy constraint to a Hermax constraint/expression.
+
+            Accepts single constraints; lists are handled recursively for subexpressions.
+        """
+        if isinstance(cpm_con, BoolVal):
+            return bool(cpm_con.value())
+
+        if isinstance(cpm_con, _BoolVarImpl):
+            return self.solver_var(cpm_con)
+
+        if isinstance(cpm_con, Operator):
+            if cpm_con.name == "or":
+                args = [self._hermax_expr(a) for a in cpm_con.args]
+                clause = args[0]
+                for a in args[1:]:
+                    clause = clause | a
+                return clause
+            if cpm_con.name == "->":
+                bv, subexpr = cpm_con.args
+                hm_bv = self.solver_var(bv)
+                if isinstance(subexpr, _BoolVarImpl):
+                    return hm_bv.implies(self.solver_var(subexpr))
+                if isinstance(subexpr, Operator) and subexpr.name == "or":
+                    return hm_bv.implies(self._hermax_expr(subexpr))
+                if isinstance(subexpr, Comparison):
+                    return self._hermax_expr(subexpr).only_if(hm_bv)
+                raise NotImplementedError(f"Hermax: unsupported implication {cpm_con}")
+            raise NotImplementedError(f"Hermax: unsupported operator {cpm_con}")
+
+        if isinstance(cpm_con, Comparison):
+            lhs, rhs = cpm_con.args
+            if cpm_con.name == "==" and is_boolexpr(lhs) and is_boolexpr(rhs):
+                if isinstance(lhs, _BoolVarImpl) and isinstance(rhs, _BoolVarImpl):
+                    return self.solver_var(lhs) == self.solver_var(rhs)
+                raise NotImplementedError(f"Hermax: unsupported reification {cpm_con}")
+            return self._hm_comparison(cpm_con)
+
+        if isinstance(cpm_con, GlobalConstraint):
+            if cpm_con.name == "alldifferent":
+                hm_vars = [self.solver_var(v) for v in cpm_con.args]
+                return self.her_model.vector(hm_vars).all_different()
+            if cpm_con.name == "increasing":
+                hm_vars = [self.solver_var(v) for v in cpm_con.args]
+                return self.her_model.vector(hm_vars).increasing()
+            if cpm_con.name == "lex_less":
+                x, y = cpm_con.args
+                hx = self.her_model.vector([self.solver_var(v) for v in x])
+                hy = self.her_model.vector([self.solver_var(v) for v in y])
+                return hx.lexicographic_less_than(hy)
+            if cpm_con.name == "cumulative":
+                if len(cpm_con.args) == 4:
+                    start, dur, demand, cap = cpm_con.args
+                else:
+                    start, dur, end, demand, cap = cpm_con.args
+                    for s, d, e in zip(start, dur, end):
+                        self.add(s + d == e)
+
+                if not all(is_num(d) for d in dur):
+                    raise NotSupportedError("Hermax Cumulative only supports fixed durations")
+                if not all(is_num(h) for h in demand):
+                    raise NotSupportedError("Hermax Cumulative only supports fixed demands")
+                if not is_num(cap):
+                    raise NotSupportedError("Hermax Cumulative only supports fixed capacity")
+
+                hm_starts = [self.solver_var(s) for s in start]
+                self.her_model.cumulative(
+                    hm_starts,
+                    [int(d) for d in dur],
+                    [int(h) for h in demand],
+                    int(cap),
+                )
+                return None
+            raise NotImplementedError(f"Hermax: unsupported global {cpm_con}")
+
+        raise NotImplementedError(f"Hermax: unexpected constraint {cpm_con}")

--- a/cpmpy/solvers/hermax.py
+++ b/cpmpy/solvers/hermax.py
@@ -39,6 +39,8 @@
 import time
 from typing import Optional
 
+from cpmpy.expressions.globalfunctions import GlobalFunction
+
 from .solver_interface import SolverInterface, SolverStatus, ExitStatus
 from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, Comparison, Operator, BoolVal, NestedBoolExprLike
@@ -48,11 +50,15 @@ from ..expressions.utils import is_num, is_int, is_boolexpr
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions, safen_objective
-from ..transformations.decompose_global import decompose_in_tree, decompose_objective
-from ..transformations.flatten_model import flatten_constraint, get_or_make_var
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.negation import push_down_negation
+from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.reification import reify_rewrite, only_bv_reifies, only_implies
+from ..transformations.linearize import (
+    decompose_linear,
+    decompose_linear_objective,
+    linearize_reified_variables,
+)
 
 
 class CPM_hermax(SolverInterface):
@@ -112,7 +118,7 @@ class CPM_hermax(SolverInterface):
         self._objective_posted = False
         self._assumption_map = {}  # dimacs lit -> CPMpy assumption expr
         self._last_core = None
-        self._bool2int = {}  # CPMpy bool-var name -> Hermax IntVar 0/1
+        self._bool_intmap = {}  # boolvar name -> channeled {0,1} intvar
 
         super().__init__(name="hermax", cpm_model=cpm_model)
 
@@ -285,9 +291,84 @@ class CPM_hermax(SolverInterface):
             return revar
 
         if is_int(cpm_var):  # shortcut, eases posting constraints
-            return cpm_var
+            return int(cpm_var)
 
         raise NotImplementedError("Not a known var {}".format(cpm_var))
+
+    def _bool_as_int(self, cpm_bool):
+        """
+        Return a {0,1} intvar channeled to ``cpm_bool`` (one intvar per underlying bool).
+        """
+        if isinstance(cpm_bool, NegBoolView):
+            cpm_bool = cpm_bool._bv
+
+        name = cpm_bool.name
+        if name in self._bool_intmap:
+            return self._bool_intmap[name]
+
+        iv = intvar(0, 1, name=f"_hm_{name}")
+        self._bool_intmap[name] = iv
+        hm_bv = self.solver_var(cpm_bool)
+        hm_iv = self.solver_var(iv)
+        self.her_model &= hm_bv.implies(hm_iv == 1)
+        self.her_model &= (~hm_bv).implies(hm_iv == 0)
+        return iv
+
+    @staticmethod
+    def _bool_sum(expr):
+        """True if ``expr`` is a sum/wsum over boolean decision variables."""
+        if not isinstance(expr, Operator):
+            return False
+        if expr.name == "sum":
+            return any(isinstance(a, _BoolVarImpl) for a in expr.args)
+        if expr.name == "wsum":
+            return any(isinstance(a, _BoolVarImpl) for a in expr.args[1])
+        return False
+
+    def _make_numexpr(self, cpm_expr):
+        """
+            Turns a numeric CPMpy 'flat' expression into a solver-specific
+            numeric expression
+
+            Used especially to post an expression as objective function
+
+            Supports sum, wsum , sub operators and single decision variables.
+        """
+        if is_num(cpm_expr):
+            return int(cpm_expr)
+
+        # decision variables, check in varmap
+        if isinstance(cpm_expr, _NumVarImpl): 
+            if cpm_expr.is_bool():
+                # Boolvars are not integer for Hermax, channel to 0-1 intvar
+                if isinstance(cpm_expr, NegBoolView):
+                    return 1 - self.solver_var(self._bool_as_int(cpm_expr._bv))
+                return self.solver_var(self._bool_as_int(cpm_expr))
+            return self.solver_var(cpm_expr)
+
+        if isinstance(cpm_expr, Operator):
+            if cpm_expr.name == "sum":
+                return sum(self.solver_vars(cpm_expr.args))
+            if cpm_expr.name == "wsum":
+                weights, vars_ = cpm_expr.args
+                her_vars = self.solver_vars(cpm_expr.args[1])
+                return sum(w * v for w, v in zip(weights, her_vars))
+            if cpm_expr.name == "sub":
+                a, b = cpm_expr.args
+                return self.solver_var(a) - self.solver_var(b)
+            if cpm_expr.name == "-":
+                return (-1) * self.solver_var(cpm_expr.args[0])
+            if cpm_expr.name == "mul":
+                a, b = cpm_expr.args
+                if is_num(a):
+                    return int(a) * self._make_numexpr(b)
+                if is_num(b):
+                    return self._make_numexpr(a) * int(b)
+                raise NotSupportedError(f"Hermax: non-linear mul {cpm_expr}")
+
+            raise NotSupportedError(f"Hermax: unsupported operator {cpm_expr}")
+
+        raise NotImplementedError("Hermax: Not a known supported numexpr {}".format(cpm_expr))
 
     def objective(self, expr: Expression, minimize: bool = True):
         """
@@ -303,19 +384,21 @@ class CPM_hermax(SolverInterface):
         get_variables(expr, self.user_vars)
 
         obj, safe_cons = safen_objective(expr)
-        obj, decomp_cons = decompose_objective(
+        obj = push_down_negation_objective(obj)
+        obj, decomp_cons = decompose_linear_objective(
             obj,
             supported=self.supported_global_constraints,
             supported_reified=self.supported_reified_global_constraints,
             csemap=self._csemap,
         )
+        obj, flat_cons = flatten_objective(obj, csemap=self._csemap)
         obj_var, obj_cons = get_or_make_var(obj)
         if expr.is_bool():
             ivar = intvar(0, 1)
             obj_cons.append(ivar == obj_var)
             obj_var = ivar
 
-        self.add(safe_cons + decomp_cons + obj_cons)
+        self.add(safe_cons + decomp_cons + flat_cons + obj_cons)
         self._objective = obj_var
 
         hm_obj = self.solver_var(obj_var)
@@ -347,125 +430,27 @@ class CPM_hermax(SolverInterface):
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_in_tree(
+        cpm_cons = decompose_linear(
             cpm_cons,
             supported=self.supported_global_constraints,
             supported_reified=self.supported_reified_global_constraints,
             csemap=self._csemap,
         )
         cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
         cpm_cons = reify_rewrite(
             cpm_cons,
             supported=frozenset({"or", "sum", "wsum", "sub"}),
             csemap=self._csemap,
         )
-        # Hermax posts min/max only as equality to a variable; sums support all comparisons
         cpm_cons = only_numexpr_equality(
             cpm_cons,
             supported=frozenset({"sum", "wsum", "sub"}),
             csemap=self._csemap,
         )
+        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
+        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
+        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
         return cpm_cons
-
-    def _bool_as_int(self, cpm_bv):
-        """
-        Channel a Boolean variable to an IntVar in {0,1} for numeric use.
-
-        Needed because Hermax PB comparisons gated by ``only_if`` can be incorrect
-        when the same Literal also appears inside the comparison.
-        """
-        if isinstance(cpm_bv, NegBoolView):
-            # 1 - positive bool
-            return 1 - self._bool_as_int(cpm_bv._bv)
-
-        name = cpm_bv.name
-        revar = self._bool2int.get(name)
-        if revar is not None:
-            return revar
-
-        hm_bv = self.solver_var(cpm_bv)
-        revar = self.her_model.int(f"_b2i_{name}", 0, 1)
-        self.her_model &= (1 * hm_bv) == revar
-        self._bool2int[name] = revar
-        return revar
-
-    def _hm_numexpr(self, cpm_expr):
-        """Convert a flat numeric CPMpy expression to a Hermax numeric expression."""
-        if is_num(cpm_expr):
-            return int(cpm_expr)
-        if isinstance(cpm_expr, _BoolVarImpl):
-            return self._bool_as_int(cpm_expr)
-        if isinstance(cpm_expr, _NumVarImpl):
-            return self.solver_var(cpm_expr)
-
-        if isinstance(cpm_expr, Operator):
-            if cpm_expr.name == "sum":
-                args = [self._hm_numexpr(a) for a in cpm_expr.args]
-                return sum(args) if len(args) else 0
-            if cpm_expr.name == "wsum":
-                weights, vars_ = cpm_expr.args
-                total = 0
-                for w, v in zip(weights, vars_):
-                    if w == 0:
-                        continue
-                    total = total + int(w) * self._hm_numexpr(v)
-                return total
-            if cpm_expr.name == "sub":
-                a, b = cpm_expr.args
-                return self._hm_numexpr(a) - self._hm_numexpr(b)
-            if cpm_expr.name == "-":
-                return (-1) * self._hm_numexpr(cpm_expr.args[0])
-            if cpm_expr.name == "mul":
-                a, b = cpm_expr.args
-                if is_num(a):
-                    return int(a) * self._hm_numexpr(b)
-                if is_num(b):
-                    return self._hm_numexpr(a) * int(b)
-                raise NotSupportedError(f"Hermax: non-linear multiplication not supported: {cpm_expr}")
-
-        raise NotImplementedError(f"Hermax: unsupported numeric expression {cpm_expr}")
-
-    def _as_pb(self, hm_expr):
-        """Ensure a Hermax numeric expression supports all relational operators."""
-        from hermax.model.expressions import PBExpr
-        from hermax.model.variables import IntVar
-        if isinstance(hm_expr, PBExpr) or is_num(hm_expr):
-            return hm_expr
-        if isinstance(hm_expr, IntVar):
-            return hm_expr + 0  # promote to PBExpr (IntVar != PBExpr is broken in Hermax)
-        return hm_expr
-
-    def _hm_comparison(self, cpm_expr):
-        """Convert a flat Comparison to a Hermax constraint / literal."""
-        lhs, rhs = cpm_expr.args
-        op = cpm_expr.name
-
-        # Global functions in equality form: min/max(...) == rhs
-        if op == "==" and isinstance(lhs, Expression) and lhs.name in {"min", "max"}:
-            hm_args = [self.solver_var(a) for a in lhs.args]
-            hm_rhs = self.solver_var(rhs) if isinstance(rhs, _NumVarImpl) else int(rhs)
-            if lhs.name == "min":
-                return self.her_model.min(hm_args) == hm_rhs
-            return self.her_model.max(hm_args) == hm_rhs
-
-        hm_lhs = self._as_pb(self._hm_numexpr(lhs))
-        hm_rhs = self._as_pb(self._hm_numexpr(rhs))
-        if op == "==":
-            return hm_lhs == hm_rhs
-        if op == "!=":
-            return hm_lhs != hm_rhs
-        if op == "<=":
-            return hm_lhs <= hm_rhs
-        if op == "<":
-            return hm_lhs < hm_rhs
-        if op == ">=":
-            return hm_lhs >= hm_rhs
-        if op == ">":
-            return hm_lhs > hm_rhs
-
-        raise NotImplementedError(f"Hermax: unsupported comparison {cpm_expr}")
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_hermax":
         """
@@ -496,8 +481,6 @@ class CPM_hermax(SolverInterface):
     def _hermax_expr(self, cpm_con):
         """
             Translate a flat CPMpy constraint to a Hermax constraint/expression.
-
-            Accepts single constraints; lists are handled recursively for subexpressions.
         """
         if isinstance(cpm_con, BoolVal):
             return bool(cpm_con.value())
@@ -507,7 +490,7 @@ class CPM_hermax(SolverInterface):
 
         if isinstance(cpm_con, Operator):
             if cpm_con.name == "or":
-                args = [self._hermax_expr(a) for a in cpm_con.args]
+                args = self.solver_vars(cpm_con.args)
                 clause = args[0]
                 for a in args[1:]:
                     clause = clause | a
@@ -517,20 +500,53 @@ class CPM_hermax(SolverInterface):
                 hm_bv = self.solver_var(bv)
                 if isinstance(subexpr, _BoolVarImpl):
                     return hm_bv.implies(self.solver_var(subexpr))
-                if isinstance(subexpr, Operator) and subexpr.name == "or":
-                    return hm_bv.implies(self._hermax_expr(subexpr))
+                elif isinstance(subexpr, Operator) and subexpr.name == "or":
+                    # encode as bigger clause
+                    return ~hm_bv | self._hermax_expr(subexpr)
                 if isinstance(subexpr, Comparison):
-                    return self._hermax_expr(subexpr).only_if(hm_bv)
+                    hm_sub = self._hermax_expr(subexpr)
+                    # Hermax may constant-fold a comparison to True/False once domains
+                    # are fixed by earlier posts; literals have .only_if(), bools do not.
+                    if isinstance(hm_sub, bool):
+                        return True if hm_sub else ~hm_bv
+                    return hm_sub.only_if(hm_bv)
                 raise NotImplementedError(f"Hermax: unsupported implication {cpm_con}")
             raise NotImplementedError(f"Hermax: unsupported operator {cpm_con}")
 
         if isinstance(cpm_con, Comparison):
             lhs, rhs = cpm_con.args
-            if cpm_con.name == "==" and is_boolexpr(lhs) and is_boolexpr(rhs):
-                if isinstance(lhs, _BoolVarImpl) and isinstance(rhs, _BoolVarImpl):
-                    return self.solver_var(lhs) == self.solver_var(rhs)
-                raise NotImplementedError(f"Hermax: unsupported reification {cpm_con}")
-            return self._hm_comparison(cpm_con)
+        
+            # Global functions in equality form: min/max(...) == rhs
+            if isinstance(lhs, GlobalFunction):
+                assert cpm_con.name == "==", "Hermax: only equality comparisons are supported for global functions"
+                if lhs.name == "min":
+                    return self.her_model.min(self.solver_vars(lhs.args)) == self.solver_var(rhs)
+                if lhs.name == "max":
+                    return self.her_model.max(self.solver_vars(lhs.args)) == self.solver_var(rhs)
+                raise NotImplementedError(f"Hermax: unsupported global function {lhs}")
+
+            if cpm_con.name in ("<", ">", ">=") and (self._bool_sum(lhs) or self._bool_sum(rhs)):
+                raise ValueError(
+                    "Hermax: strict comparison (<, >, >=) of a sum of boolean variables against an "
+                    "integer is not supported due to a Hermax encoding bug; use <= or == instead. "
+                    "Issue at https://github.com/josalhor/hermax/issues/3"
+                )
+
+            hm_lhs = self._make_numexpr(lhs)
+            hm_rhs = self._make_numexpr(rhs)
+            if cpm_con.name == "==":
+                return hm_lhs == hm_rhs
+            if cpm_con.name == "!=":
+                return hm_lhs != hm_rhs
+            if cpm_con.name == "<=":
+                return hm_lhs <= hm_rhs
+            if cpm_con.name == "<":
+                return hm_lhs < hm_rhs
+            if cpm_con.name == ">=":
+                return hm_lhs >= hm_rhs
+            if cpm_con.name == ">":
+                return hm_lhs > hm_rhs
+            raise NotImplementedError(f"Hermax: unsupported comparison {cpm_con}")
 
         if isinstance(cpm_con, GlobalConstraint):
             if cpm_con.name == "alldifferent":

--- a/cpmpy/solvers/utils.py
+++ b/cpmpy/solvers/utils.py
@@ -35,6 +35,7 @@ from .pindakaas import CPM_pindakaas
 from .highs import CPM_highs
 from .hexaly import CPM_hexaly
 from .rc2 import CPM_rc2
+from .hermax import CPM_hermax
 
 def param_combinations(all_params, remaining_keys=None, cur_params=None):
     """
@@ -93,6 +94,7 @@ class SolverLookup():
                 ("highs", CPM_highs),
                 ("hexaly", CPM_hexaly),
                 ("rc2", CPM_rc2),
+                ("hermax", CPM_hermax),
                 ("scip", CPM_scip),
                ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,11 @@ Supported solvers
      - OPT
      - pip
      - 
+   * - :doc:`Hermax <api/solvers/hermax>`
+     - MaxSAT
+     - SAT ASAT ISAT - OPT
+     - pip
+     - CP-level modeling API over MaxSAT backends
    * - :doc:`Pindakaas <api/solvers/pindakaas>`
      - SAT
      - SAT ASAT ISAT

--- a/docs/installation_instructions.rst
+++ b/docs/installation_instructions.rst
@@ -43,7 +43,7 @@ CPMpy supports a multitude of solvers of different technologies to be used as ba
 .. code-block:: bash
 
     # Choose any subset of solvers to install
-    $ pip install cpmpy[choco, cpo, exact, gcs, gurobi, minizinc, pysat, pysdd, z3, scip, highs]
+    $ pip install cpmpy[choco, cpo, exact, gcs, gurobi, hermax, minizinc, pysat, pysdd, pindakaas, z3, scip, highs]
 
 Some solvers require additional steps (like acquiring a (aca.) license). Have a look at :ref:`this <supported-solvers>` overview.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -64,6 +64,9 @@ ignore_missing_imports = True
 [mypy-pyscipopt.*]
 ignore_missing_imports = True
 
+[mypy-hermax.*]
+ignore_missing_imports = True
+
 # used in tools/io/nurserostering.py and tools/io/rcpsp.py
 [mypy-pandas.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ solver_dependencies = {
     "cplex": ["docplex>=2.28.240", "cplex>=20.1.0.4"],
     "scip": ["pyscipopt>=6.1"],
     "rc2": ["python-sat>=1.9.dev5", "pypblib"],
-    "hermax": ["hermax>=1.2.3"],
+    "hermax": ["hermax>=1.2.4"],
 }
 solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ solver_dependencies = {
     "pindakaas": ["pindakaas>=0.5.0"],
     "cplex": ["docplex>=2.28.240", "cplex>=20.1.0.4"],
     "scip": ["pyscipopt>=6.1"],
-    "rc2": ["python-sat>=1.9.dev5", "pypblib"]
+    "rc2": ["python-sat>=1.9.dev5", "pypblib"],
+    "hermax": ["hermax>=1.2.1"],
 }
 solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ solver_dependencies = {
     "cplex": ["docplex>=2.28.240", "cplex>=20.1.0.4"],
     "scip": ["pyscipopt>=6.1"],
     "rc2": ["python-sat>=1.9.dev5", "pypblib"],
-    "hermax": ["hermax>=1.2.1"],
+    "hermax": ["hermax>=1.2.3"],
 }
 solver_dependencies["all"] = list({pkg for group in solver_dependencies.values() for pkg in group}) 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -197,7 +197,7 @@ def global_constraints(solver):
             yield cp.all(cp.Cumulative(s, dur, e, demand, cap).decompose(how="task")[0])
 
             yield cp.Cumulative(start=s, duration=dur, demand=demand, capacity=cap) # also try with no end provided
-            if solver != "pumpkin": # only supports with fixed durations
+            if solver not in ("pumpkin", "hermax"): # only supports with fixed durations
                 yield cp.Cumulative(s.tolist()+[cp.intvar(0,10)], dur + [cp.intvar(-3,3)], e.tolist()+[cp.intvar(0,10)], 1, cap)
                 yield cp.Cumulative(s, dur, e, cp.intvar(-3,3,shape=3,name="demand"), cap)
             continue

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1985,14 +1985,14 @@ def test_issue801_expr_in_cumulative(solver):
     bv = cp.boolvar(shape=3,name="bv")
 
     assert cp.Model(cp.NoOverlap(bv * start, dur, end)).solve(solver=solver)
-    if solver != "pumpkin": # Pumpkin does not support variables as duration
+    if solver not in ("pumpkin", "hermax"): #  only support integers as duration, not variables
         assert cp.Model(cp.NoOverlap(bv * start,bv * dur, end)).solve(solver=solver)
     assert cp.Model(cp.NoOverlap(bv * start, dur, bv * end)).solve(solver=solver)
 
     # also for cumulative
     assert cp.Model(cp.Cumulative(bv * start, dur, end,1, 3)).solve(solver=solver)
     assert cp.Model(cp.Cumulative(bv * start, dur, bv * end, 1, 3)).solve(solver=solver)
-    if solver != "pumpkin": # Pumpkin does not support variables as duration, demand or capacity
+    if solver not in ("pumpkin", "hermax"): # only support integers as duration, demand or capacity, not variables
         assert cp.Model(cp.Cumulative(bv * start,bv * dur, end, 1, 3)).solve(solver=solver)
         assert cp.Model(cp.Cumulative(bv * start, dur, end, bv * [2, 3, 4], 3 * bv[0])).solve(solver=solver)
         assert cp.Model(cp.Cumulative(bv * start, dur, end, 1, 3 * bv[0])).solve(solver=solver)

--- a/tests/test_rc2_obj.py
+++ b/tests/test_rc2_obj.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest
 import pytest
 import cpmpy as cp
@@ -5,8 +6,11 @@ from cpmpy.solvers.rc2 import CPM_rc2
 
 # Check if RC2 is available
 rc2_available = CPM_rc2.supported()
+# Check if PyPBlib is available
+pblib_available = importlib.util.find_spec("pypblib") is not None
 
 @pytest.mark.skipif(not rc2_available, reason="RC2 solver not available")
+@pytest.mark.skipif(not pblib_available, reason="PyPBlib not available")
 class TestRC2Transform(unittest.TestCase):
     """
     Test cases for RC2 solver objective transformation functionality

--- a/tests/test_solveAll.py
+++ b/tests/test_solveAll.py
@@ -25,9 +25,7 @@ class TestSolveAll:
         try:
             x = cp.boolvar(shape=32, name="x")
             m = cp.Model(cp.any(x))
-            num_sols = m.solveAll(solver=solver, time_limit=1, solution_limit=limit)
-            assert m.status().exitstatus == ExitStatus.FEASIBLE
-
+            # stop early (no need to enumerate all); FEASIBLE, not OPTIMAL
             num_sols = m.solveAll(solver=solver, solution_limit=10)
             assert num_sols == 10
             assert m.status().exitstatus == ExitStatus.FEASIBLE
@@ -39,7 +37,7 @@ class TestSolveAll:
             assert m.status().exitstatus in (ExitStatus.OPTIMAL, ExitStatus.FEASIBLE)  # which of the two?
 
         except NotImplementedError:
-            pass  # not all solvers support time/solution limits
+            pass  # not all solvers support solution limits
 
         # making the problem unsat
         if solver != "pysdd":  # constraint not supported by pysdd

--- a/tests/test_solverinterface.py
+++ b/tests/test_solverinterface.py
@@ -266,21 +266,21 @@ def test_solver_vars(solver):
 @skip_on_missing_pblib(skip_on_exception_only=True)
 def test_time_limit(solver):
     """Test time limit functionality"""
+    # Skip solvers that don't support time limits (check name before overwriting)
+    if solver in ("pysdd", "hermax"):
+        return
+
     solver_class = SolverLookup.lookup(solver)
     solver = solver_class()
-    
-    # Skip pysdd as it doesn't support time limits
-    if solver == "pysdd":
-        return
-    
+
     bvar = cp.boolvar(shape=3)
     x, y, z = bvar
     solver += [x | y | z]
-    
+
     # Test with positive time limit
     assert solver.solve(time_limit=1.0)
     assert solver.status().exitstatus == ExitStatus.FEASIBLE
-    
+
     # Test with negative time limit should raise ValueError
     try:
         solver.solve(time_limit=-1)

--- a/tests/test_solverinterface.py
+++ b/tests/test_solverinterface.py
@@ -266,8 +266,8 @@ def test_solver_vars(solver):
 @skip_on_missing_pblib(skip_on_exception_only=True)
 def test_time_limit(solver):
     """Test time limit functionality"""
-    # Skip solvers that don't support time limits (check name before overwriting)
-    if solver in ("pysdd", "hermax"):
+    # Skip pysdd as it doesn't support time limits
+    if solver == "pysdd":
         return
 
     solver_class = SolverLookup.lookup(solver)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -864,7 +864,7 @@ class TestSupportedSolvers:
         assert [int(a) for a in v.value()] == [0, 1, 0]
 
     def test_time_limit(self, solver):
-        if solver == "pysdd": # pysdd does not support time limit
+        if solver in ("pysdd", "hermax"):  # no time limit support
             pytest.skip("time limit not supported")
         
         x = cp.boolvar(shape=3)
@@ -1064,7 +1064,7 @@ class TestSupportedSolvers:
     def test_solution_callback(self, solver, capsys):
         
         n = 10
-        kwargs = dict(time_limit=3)
+        kwargs = {} if solver == "hermax" else dict(time_limit=3)
         solver_obj = cp.SolverLookup.get(solver)
         if "display" not in inspect.signature(solver_obj.solve).parameters:
             pytest.skip(f"{solver} does not support solution callbacking")
@@ -1154,6 +1154,8 @@ class TestSupportedSolvers:
             return
 
         # now making a tricky problem to solve
+        if solver == "hermax":
+            return  # no time_limit support; skip timed status checks
         np.random.seed(0)
         start = cp.intvar(0,50, shape=20)
         dur = np.random.randint(1,5, size=20)
@@ -1281,16 +1283,17 @@ def test_objective_numexprs(solver, constraint):
 
     model = cp.Model(cp.intvar(0, 10, shape=3) >= 1) # just to have some constraints
     lb, ub = constraint.get_bounds()
+    kwargs = {} if solver == "hermax" else dict(time_limit=3)
     try:
         # Minimization
         model.minimize(constraint)
-        res = model.solve(solver=solver, time_limit=3)
+        res = model.solve(solver=solver, **kwargs)
         if res is True: # we found a solution
             assert constraint.value() < ub # assume solver finds feasible sol with value lower than ub
 
         # Maximization
         model.maximize(constraint)
-        res = model.solve(solver=solver, time_limit=3)
+        res = model.solve(solver=solver, **kwargs)
         if res is True: # we found a solution
             assert constraint.value() > lb # assume solver finds a feasible sol with value higher than lb
     
@@ -1351,7 +1354,7 @@ class TestRound:
             print(x, x.value())
             assert (x.value() >= 1), f"{x}={x.value()}"
 
-        m.solveAll(solver=solver, solution_limit=1000, time_limit=10, display=check)
+        m.solveAll(solver=solver, solution_limit=1000, time_limit=(None if solver == "hermax" else 10), display=check)
 
 
 def _get_golomb_model(size):

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -13,6 +13,7 @@ from cpmpy.expressions.utils import argvals
 from cpmpy.solvers.pysat import CPM_pysat
 from cpmpy.solvers.pindakaas import CPM_pindakaas
 from cpmpy.solvers.pumpkin import CPM_pumpkin
+from cpmpy.solvers.hermax import CPM_hermax
 from cpmpy.solvers.solver_interface import ExitStatus
 from cpmpy.solvers.z3 import CPM_z3
 from cpmpy.solvers.minizinc import CPM_minizinc
@@ -829,6 +830,16 @@ class TestSolvers:
         assert s.solve()
         assert sum(xi.value() for xi in x) in (2, 4)
 
+    @pytest.mark.skipif(not CPM_hermax.supported(), reason="Hermax not installed")
+    def test_hermax(self):
+        x = cp.intvar(0, 5, shape=3, name="x")
+        m = cp.Model(cp.AllDifferent(x), cp.sum(x) == 6)
+        m.minimize(x[0])
+        assert m.solve(solver="hermax")
+        assert len(set(xi.value() for xi in x)) == 3
+        assert sum(xi.value() for xi in x) == 6
+        assert m.objective_value() == x[0].value()
+
 
 @pytest.mark.usefixtures("solver")
 class TestSupportedSolvers:
@@ -971,8 +982,8 @@ class TestSupportedSolvers:
 
         assert s.solve()
         assert s.objective_value() == 0
-        if solver == "rc2":
-            return # RC2 only supports setting obj once
+        if solver in ("rc2",):
+            return # MaxSAT soft objectives: only supports setting obj once before first opt solve
         s += x[0] == 5
         s.solve()
         assert s.objective_value() == 5

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -864,7 +864,7 @@ class TestSupportedSolvers:
         assert [int(a) for a in v.value()] == [0, 1, 0]
 
     def test_time_limit(self, solver):
-        if solver in ("pysdd", "hermax"):  # no time limit support
+        if solver == "pysdd": # pysdd does not support time limit
             pytest.skip("time limit not supported")
         
         x = cp.boolvar(shape=3)
@@ -1064,7 +1064,7 @@ class TestSupportedSolvers:
     def test_solution_callback(self, solver, capsys):
         
         n = 10
-        kwargs = {} if solver == "hermax" else dict(time_limit=3)
+        kwargs = dict(time_limit=3)
         solver_obj = cp.SolverLookup.get(solver)
         if "display" not in inspect.signature(solver_obj.solve).parameters:
             pytest.skip(f"{solver} does not support solution callbacking")
@@ -1154,8 +1154,6 @@ class TestSupportedSolvers:
             return
 
         # now making a tricky problem to solve
-        if solver == "hermax":
-            return  # no time_limit support; skip timed status checks
         np.random.seed(0)
         start = cp.intvar(0,50, shape=20)
         dur = np.random.randint(1,5, size=20)
@@ -1283,7 +1281,7 @@ def test_objective_numexprs(solver, constraint):
 
     model = cp.Model(cp.intvar(0, 10, shape=3) >= 1) # just to have some constraints
     lb, ub = constraint.get_bounds()
-    kwargs = {} if solver == "hermax" else dict(time_limit=3)
+    kwargs = dict(time_limit=3)
     try:
         # Minimization
         model.minimize(constraint)
@@ -1354,7 +1352,7 @@ class TestRound:
             print(x, x.value())
             assert (x.value() >= 1), f"{x}={x.value()}"
 
-        m.solveAll(solver=solver, solution_limit=1000, time_limit=(None if solver == "hermax" else 10), display=check)
+        m.solveAll(solver=solver, solution_limit=1000, time_limit=10, display=check)
 
 
 def _get_golomb_model(size):


### PR DESCRIPTION
Interface to the HerMax MaxSAT library.

Supports CP-level constraints, so does not require linearize/int2bool.

Two open issues:
1. `__eq__` between two variables with disjoint domains raises a ValueError (see failing test). @josalhor I think it might be more natural to either return an empty clause instead, or return a specialized "trivial unsat" error or something. Then we can catch it at the CPMpy level and convert it to `BoolVal(False)` instead. I don' dare to catch ValueErrors as they can mean lots of things : ) 
2. Time limits are not supported as far as I can tell; I can of course interrupt the process with a Python Timer (as we do in PySAT), but HerMax does not provide a feasible solution in that case