### PR TITLE
Rewrite Boolean comparisons to Boolean operators

### DIFF
--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -471,6 +471,8 @@ class CPM_choco(SolverInterface):
                 return self.chc_model.and_(self.solver_vars(cpm_expr.args))
             elif cpm_expr.name == 'or':
                 return self.chc_model.or_(self.solver_vars(cpm_expr.args))
+            elif cpm_expr.name == 'not':
+                return self.chc_model.not_(self._get_constraint(cpm_expr.args[0]))
 
             elif cpm_expr.name == "->":
                 cond, subexpr = cpm_expr.args

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -63,7 +63,7 @@ from ..transformations.flatten_model import flatten_constraint, get_or_make_var
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.linearize import canonical_comparison
 from ..transformations.safening import no_partial_functions, safen_objective
-from ..transformations.negation import push_down_negation
+from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.reification import reify_rewrite
 from ..exceptions import ChocoBoundsException, NotSupportedError
 
@@ -365,7 +365,7 @@ class CPM_choco(SolverInterface):
                                                supported=self.supported_global_constraints,
                                                supported_reified=self.supported_reified_global_constraints,
                                                csemap=self._csemap)
-
+        obj = push_down_negation_objective(obj)
         # make objective function non-nested
         obj_var, obj_cons = get_or_make_var(obj) # do not pass csemap here, we will still transform obj_var == obj...
 

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -56,7 +56,7 @@ from ..transformations.normalize import toplevel_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.flatten_model import flatten_constraint, get_or_make_var
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.negation import push_down_negation
+from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.reification import reify_rewrite, only_bv_reifies, only_implies
 from ..transformations.safening import no_partial_functions, safen_objective
 
@@ -346,6 +346,7 @@ class CPM_pumpkin(SolverInterface):
                                                supported=self.supported_global_constraints,
                                                supported_reified=self.supported_reified_global_constraints,
                                                csemap=self._csemap)
+        obj = push_down_negation_objective(obj)
         obj_var, obj_cons = get_or_make_var(obj) # do not pass csemap here, we will still transform obj_var == obj...
         if expr.is_bool():
             ivar = intvar(0,1)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -17,7 +17,7 @@ Base constraints: (no nesting)
 
 =============================  ====================================  ==============
 Boolean variable               ``Var``                                                                                                                                                    
-Boolean operators              ``and([Var])``, ``or([Var])``         :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                        
+Boolean operators              ``or([Var])``                         :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                        
 Boolean implication            ``Var -> Var``                        :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                                                                                
 Boolean equality               ``Var == Var``, ``Var == Constant``   :class:`~cpmpy.expressions.core.Comparison`                                                                          
 Global constraint (Boolean)    ``global([Var]*)``                    :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                                           
@@ -36,7 +36,7 @@ Numeric inequality (>=,>,<,<=)   ``Numexpr >=< Var``                           :
 
 ==================================================  ======================================  ==============
 Operator (non-Boolean) with all args Var/constant   ``+``, ``*``, ``/``, ``mod``, ``wsum``  :class:`~cpmpy.expressions.core.Operator`, not :func:`~cpmpy.expressions.core.Operator.is_bool()`                      
-Global constraint (non-Boolean)                     ``Max``, ``Min``, ``Element``           :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, not :func:`~cpmpy.expressions.core.Operator.is_bool()` 
+Global function                                     ``Max``, ``Element``, ``NValues``, ...   :class:`~cpmpy.expressions.globalfunctions.GlobalFunction` 
 ==================================================  ======================================  ==============
 
 **wsum:**
@@ -92,6 +92,7 @@ import copy
 import math
 import builtins
 import cpmpy as cp
+from cpmpy.expressions.globalconstraints import GlobalConstraint
 
 from .cse import CSEMap
 from .normalize import toplevel_list, simplify_boolean
@@ -436,8 +437,10 @@ def normalized_boolexpr(expr, csemap=None):
             (rhs,rcons) = get_or_make_var(expr.args[1], csemap=csemap)
             return ((recurse_negation(lhs) | rhs), lcons+rcons)
         if expr.name == 'not':
-            flatvar, flatcons = get_or_make_var(expr.args[0], csemap=csemap)
-            return (~flatvar, flatcons)  # flatvar is var, so safe to just negate
+            if not isinstance(expr.args[0], GlobalConstraint):
+                raise ValueError(f"push_down_negation should have eliminated all `not` operators except ~GlobalConstraint,  but got {expr.args[0]} instead, please report on github.")
+            flatexpr, flatcons = normalized_boolexpr(expr.args[0], csemap=csemap)
+            return (~flatexpr, flatcons)
         if not expr.has_subexpr():
             return (expr, [])
         else:

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -6,8 +6,8 @@ either constants, variables, list of constants or list of variables, and
 some binary constraints have a canonical order of variables.
 
 Furthermore, it is 'negated normal' meaning that the ~ (negation operator) only appears
-before a Boolean variable (in CPMpy, absorbed in a 'NegBoolView'),
-and it is 'negation normal' meaning that the - (negative operator) only appears before
+before a Boolean variable (in CPMpy, absorbed in a 'NegBoolView'), or a GlobalConstraint.
+Additionally, it is 'negation normal' meaning that the - (negative operator) only appears before
 a constant, that is a - b :: a + -1*b :: wsum([1,-1],[a,b])
 
 The three families of possible constraints are:
@@ -20,7 +20,8 @@ Boolean variable               ``Var``
 Boolean operators              ``or([Var])``                         :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                        
 Boolean implication            ``Var -> Var``                        :class:`~cpmpy.expressions.core.Operator`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                                                                                
 Boolean equality               ``Var == Var``, ``Var == Constant``   :class:`~cpmpy.expressions.core.Comparison`                                                                          
-Global constraint (Boolean)    ``global([Var]*)``                    :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`, :func:`~cpmpy.expressions.core.Operator.is_bool()`                                           
+Global constraint (Boolean)    ``global([Var]*)``                    :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`       
+Negated global constraint      ``~global([Var]*)``                   :class:`~cpmpy.expressions.globalconstraints.GlobalConstraint`            
 =============================  ====================================  ==============
 
 Comparison constraints: (up to one nesting on one side)
@@ -95,7 +96,7 @@ import cpmpy as cp
 from cpmpy.expressions.globalconstraints import GlobalConstraint
 
 from .cse import CSEMap
-from .normalize import toplevel_list, simplify_boolean
+from .normalize import toplevel_list, simplify_boolean, _simplify_boolean_expr
 from ..expressions.core import Expression, Comparison, Operator
 from ..expressions.core import _wsum_should, _wsum_make
 from ..expressions.variables import _NumVarImpl, _IntVarImpl, _BoolVarImpl
@@ -310,7 +311,7 @@ def flatten_objective(expr, supported=frozenset(["sum", "wsum"]), csemap=None):
         # one source of errors is sum(v) where v is a matrix, use v.sum() instead
         raise Exception(f"Objective expects a single variable/expression, not a list of expressions: {expr}")
 
-    expr = simplify_boolean([expr])[0]
+    _, expr = _simplify_boolean_expr(expr) # avoid re-wrapping in and-operator
     (flatexpr, flatcons) = normalized_numexpr(expr, csemap=csemap)  # might rewrite expr into a (w)sum
     if isinstance(flatexpr, Expression) and flatexpr.name in supported:
         return (flatexpr, flatcons)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -262,17 +262,38 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
 
             # ensure rhs is var
             (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
-            # Reification (double implication): Boolexpr == Var
-            # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
-            if exprname == '==' and lexpr.is_bool():
+
+            # simplify Boolean comparisons, should this become part of simplify_boolean?
+            if lexpr.is_bool():
+
                 if rvar.is_bool():
-                    if csemap is not None and csemap.get(lexpr) is None:
-                        csemap.put(lexpr, rvar)
-                    # this is a reification
-                    (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
-                else:
-                    # integer comparison
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    lhs, lcons = normalized_boolexpr(lexpr, csemap=csemap)
+
+                    if exprname == "==":  # full reification, lhs need not be a var at toplevel
+                        if csemap is not None and csemap.get(lexpr) is None:
+                            csemap.put(lexpr, rvar)
+                        newlist.append(Comparison("==", lhs, rvar))
+                    elif exprname == "!=":  # write as full reification
+                        if csemap is not None and csemap.get(lexpr) is None:
+                            csemap.put(lexpr, ~rvar)
+                        newlist.append(Comparison("==", lhs, ~rvar))
+                    elif exprname == "<=":  # write as half-reification
+                        newlist.append(lhs.implies(rvar))
+                    elif exprname == ">=":  # write as half-reification
+                        newlist.append(rvar.implies(lhs))
+                    elif exprname == "<":
+                        newlist.extend([recurse_negation(lhs), rvar])
+                    elif exprname == ">":
+                        newlist.extend([lhs, ~rvar])  # rvar is var so safe to just negate
+
+                else:  # mix of integer and Boolean comparison
+                    lhs, lcons = get_or_make_var(lexpr, csemap=csemap)
+                    newlist.append(Comparison(exprname, lhs, rvar))
+
+                newlist.extend(lcons)
+                newlist.extend(rcons)
+                continue
+
             else:
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)
 
@@ -455,22 +476,42 @@ def normalized_boolexpr(expr, csemap=None):
             lexpr, rexpr = expr.args
             exprname = expr.name
 
-            # ==,!=: can swap if lhs is var and rhs is not
-            if (exprname == '==' or exprname == '!=') and \
-                not __is_flat_var(rexpr) and __is_flat_var(lexpr):
+            # can swap if lhs is var and rhs is not
+            if not __is_flat_var(rexpr) and __is_flat_var(lexpr):
+                if exprname == "<":
+                    exprname = ">"
+                elif exprname == ">":
+                    exprname = "<"
+                elif exprname == "<=":
+                    exprname = ">="
+                elif exprname == ">=":
+                    exprname = "<="
                 lexpr, rexpr = rexpr, lexpr
 
             # ensure rhs is var
             (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
 
-            # LHS: check if Boolexpr == smth:
-            if (exprname == '==' or exprname == '!=') and lexpr.is_bool():
-                # this is a reified constraint, so lhs must be var too to be in normal form
-                (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                if expr.name == '!=' and rvar.is_bool():
-                    # != not needed, negate RHS variable
-                    rvar = ~rvar  # rvar is var, so safe to just negate
-                    exprname = '=='
+            # simplify Boolean comparisons (nested: must return a normalized boolexpr)
+            if lexpr.is_bool() and rvar.is_bool():
+                if exprname == "==":  # full reification, lexpr needs to be var too to be in normal form
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    return Comparison("==", lhs, rvar), lcons+rcons
+                if exprname == "!=":  # write as full reification
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    return Comparison("==", lhs, ~rvar), lcons+rcons  # rvar is var so safe to just negate
+                if exprname == "<=":  # p <= q :: ~p | q
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    return (~lhs) | rvar, lcons+rcons
+                if exprname == ">=":  # p >= q :: p | ~q
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    return lhs | (~rvar), lcons+rcons
+                if exprname == "<":  # p < q :: ~p & q
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    return (~lhs) & rvar, lcons+rcons
+                if exprname == ">":  # p > q :: p & ~q
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                    return lhs & (~rvar), lcons+rcons
+
             else:
                 # other cases: LHS is numexpr
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -262,38 +262,17 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
 
             # ensure rhs is var
             (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
-
-            # simplify Boolean comparisons, should this become part of simplify_boolean?
-            if lexpr.is_bool():
-
+            # Reification (double implication): Boolexpr == Var
+            # normalize the lhs (does not have to be a var, hence we call normalize instead of get_or_make_var
+            if exprname == '==' and lexpr.is_bool():
                 if rvar.is_bool():
-                    lhs, lcons = normalized_boolexpr(lexpr, csemap=csemap)
-
-                    if exprname == "==":  # full reification, lhs need not be a var at toplevel
-                        if csemap is not None and csemap.get(lexpr) is None:
-                            csemap.put(lexpr, rvar)
-                        newlist.append(Comparison("==", lhs, rvar))
-                    elif exprname == "!=":  # write as full reification
-                        if csemap is not None and csemap.get(lexpr) is None:
-                            csemap.put(lexpr, ~rvar)
-                        newlist.append(Comparison("==", lhs, ~rvar))
-                    elif exprname == "<=":  # write as half-reification
-                        newlist.append(lhs.implies(rvar))
-                    elif exprname == ">=":  # write as half-reification
-                        newlist.append(rvar.implies(lhs))
-                    elif exprname == "<":
-                        newlist.extend([recurse_negation(lhs), rvar])
-                    elif exprname == ">":
-                        newlist.extend([lhs, ~rvar])  # rvar is var so safe to just negate
-
-                else:  # mix of integer and Boolean comparison
-                    lhs, lcons = get_or_make_var(lexpr, csemap=csemap)
-                    newlist.append(Comparison(exprname, lhs, rvar))
-
-                newlist.extend(lcons)
-                newlist.extend(rcons)
-                continue
-
+                    if csemap is not None and csemap.get(lexpr) is None:
+                        csemap.put(lexpr, rvar)
+                    # this is a reification
+                    (lhs, lcons) = normalized_boolexpr(lexpr, csemap=csemap)
+                else:
+                    # integer comparison
+                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
             else:
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)
 
@@ -476,42 +455,22 @@ def normalized_boolexpr(expr, csemap=None):
             lexpr, rexpr = expr.args
             exprname = expr.name
 
-            # can swap if lhs is var and rhs is not
-            if not __is_flat_var(rexpr) and __is_flat_var(lexpr):
-                if exprname == "<":
-                    exprname = ">"
-                elif exprname == ">":
-                    exprname = "<"
-                elif exprname == "<=":
-                    exprname = ">="
-                elif exprname == ">=":
-                    exprname = "<="
+            # ==,!=: can swap if lhs is var and rhs is not
+            if (exprname == '==' or exprname == '!=') and \
+                not __is_flat_var(rexpr) and __is_flat_var(lexpr):
                 lexpr, rexpr = rexpr, lexpr
 
             # ensure rhs is var
             (rvar, rcons) = get_or_make_var(rexpr, csemap=csemap)
 
-            # simplify Boolean comparisons (nested: must return a normalized boolexpr)
-            if lexpr.is_bool() and rvar.is_bool():
-                if exprname == "==":  # full reification, lexpr needs to be var too to be in normal form
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                    return Comparison("==", lhs, rvar), lcons+rcons
-                if exprname == "!=":  # write as full reification
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                    return Comparison("==", lhs, ~rvar), lcons+rcons  # rvar is var so safe to just negate
-                if exprname == "<=":  # p <= q :: ~p | q
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                    return (~lhs) | rvar, lcons+rcons
-                if exprname == ">=":  # p >= q :: p | ~q
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                    return lhs | (~rvar), lcons+rcons
-                if exprname == "<":  # p < q :: ~p & q
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                    return (~lhs) & rvar, lcons+rcons
-                if exprname == ">":  # p > q :: p & ~q
-                    (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
-                    return lhs & (~rvar), lcons+rcons
-
+            # LHS: check if Boolexpr == smth:
+            if (exprname == '==' or exprname == '!=') and lexpr.is_bool():
+                # this is a reified constraint, so lhs must be var too to be in normal form
+                (lhs, lcons) = get_or_make_var(lexpr, csemap=csemap)
+                if expr.name == '!=' and rvar.is_bool():
+                    # != not needed, negate RHS variable
+                    rvar = ~rvar  # rvar is var, so safe to just negate
+                    exprname = '=='
             else:
                 # other cases: LHS is numexpr
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 
 from ..expressions.core import BoolVal, Expression, Comparison, Operator, NestedBoolExprLike
+from ..expressions.variables import _BoolVarImpl
 from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.utils import eval_comparison, is_false_cst, is_true_cst, is_boolexpr, is_num, is_bool
 from ..exceptions import NotSupportedError
@@ -77,7 +78,10 @@ def simplify_boolean(lst_of_expr: list[Expression], num_context=False) -> list[E
         if changed_expr:
             changed = True
             assert not isinstance(newexpr, int)
-            newlist.append(newexpr)
+            if isinstance(newexpr, Operator) and newexpr.name == "and":
+                newlist.extend(newexpr.args)
+            else:
+                newlist.append(newexpr)
         else:
             newlist.append(expr)
     
@@ -268,6 +272,28 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                     return True, (1 if num_context else BoolVal(True))
             elif rhs > 1:
                 return True, BoolVal(name in {"!=", "<", "<="}) # all other operators evaluate to False
+
+        # Boolean-Boolean comparisons: rewrite to reification / half-reification / and
+        if is_boolexpr(lhs) and is_boolexpr(rhs):
+            # '==' left unchanged, just a full reification
+            if name == "==":
+                pass # just a reification
+            elif name == "!=": 
+                # need to negate one of the sides, pick a side that is a variable or constant if it exists
+                if isinstance(lhs, (_BoolVarImpl, BoolVal)):
+                    lhs = ~lhs
+                else:
+                    rhs = recurse_negation(rhs)
+                return True, Comparison("==", lhs, rhs)
+            elif name == "<=":
+                return True, lhs.implies(rhs)
+            elif name == ">=":
+                return True, rhs.implies(lhs)
+            elif name == "<":
+                return True, recurse_negation(lhs) & rhs
+            elif name == ">":
+                return True, lhs & recurse_negation(rhs)
+            
 
         # normalize comparison orientation to keep expression on lhs
         if is_num(lhs) and isinstance(rhs, Expression):

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -76,7 +76,57 @@ class TestFlattenConstraint:
         assert "[(IV1 < 3) == (BV0)]" == str(flatten_constraint(e))
         e = ((a > 5) == (b < 3))
         assert len(flatten_constraint(e)) == 2
-    
+
+    def test_bool_comparisons(self):
+        """Boolean <=/>=/</>/!= rewrite to reification / half-reification / and."""
+        (a, b) = self.ivars[:2]
+        (x, y) = self.bvars[:2]
+
+        # top-level: boolexpr # boolvar
+        assert str(flatten_constraint((a > 5) != x)) == "[(IV0 > 5) == (~BV0)]"
+        assert str(flatten_constraint((a > 5) <= x)) == "[(IV0 > 5) -> (BV0)]"
+        assert str(flatten_constraint((a > 5) >= x)) == "[(BV0) -> (IV0 > 5)]"
+        assert str(flatten_constraint((a > 5) < x)) == "[IV0 <= 5, BV0]"
+        assert str(flatten_constraint((a > 5) > x)) == "[IV0 > 5, ~BV0]"
+
+        # swap when lhs is the var
+        assert str(flatten_constraint(x != (a > 5))) == "[(IV0 > 5) == (~BV0)]"
+        assert str(flatten_constraint(x <= (a > 5))) == "[(BV0) -> (IV0 > 5)]"
+        assert str(flatten_constraint(x >= (a > 5))) == "[(IV0 > 5) -> (BV0)]"
+
+        # nested (via normalized_boolexpr): half-reif becomes or of vars
+        assert str(normalized_boolexpr((a > 5) <= x)) == "((~BV3) or (BV0), [(IV0 >= 6) == (BV3)])"
+        assert str(normalized_boolexpr((a > 5) >= x)) == "((BV4) or (~BV0), [(IV0 >= 6) == (BV4)])"
+        assert str(normalized_boolexpr((a > 5) < x)) == "((~BV5) and (BV0), [(IV0 >= 6) == (BV5)])"
+        assert str(normalized_boolexpr((a > 5) > x)) == "((BV6) and (~BV0), [(IV0 >= 6) == (BV6)])"
+
+        # implication wrapping a bool comparison must stay flat-normal
+        flat = flatten_constraint(y.implies((a > 5) <= x))
+        assert str(flat) == "[(BV1) -> ((~BV7) or (BV0)), (IV0 >= 6) == (BV7)]"
+
+        # bool vs int still stays a numeric comparison
+        assert str(flatten_constraint((a + b == 2) <= b)) == \
+            "[(BV8) <= (IV1), ((IV0) + (IV1) == 2) == (BV8)]"
+
+    def test_bool_comparisons_both_sides(self):
+        """Both sides Boolean expressions (RHS reified, possibly CSE-canonicalized)."""
+        (a, b) = self.ivars[:2]
+
+        # b < 3 is stored as ~(b >= 3) via CSE canonicalization
+        assert str(flatten_constraint((a > 5) <= (b < 3))) == \
+            "[(IV0 > 5) -> (~BV3), (IV1 >= 3) == (BV3)]"
+        assert str(flatten_constraint((a > 5) >= (b < 3))) == \
+            "[(~BV4) -> (IV0 > 5), (IV1 >= 3) == (BV4)]"
+        assert str(flatten_constraint((a > 5) < (b < 3))) == \
+            "[IV0 <= 5, ~BV5, (IV1 >= 3) == (BV5)]"
+        assert str(flatten_constraint((a > 5) > (b < 3))) == \
+            "[IV0 > 5, BV6, (IV1 >= 3) == (BV6)]"
+        assert str(flatten_constraint((a > 5) != (b < 3))) == \
+            "[(IV0 > 5) == (BV7), (IV1 >= 3) == (BV7)]"
+        assert str(flatten_constraint((a > 5) == (b < 3))) == \
+            "[(IV0 > 5) == (~BV8), (IV1 >= 3) == (BV8)]"
+
+
 class TestFlattenExpr:
     def setup_method(self):
         _IntVarImpl.counter = 0
@@ -290,16 +340,16 @@ class TestFlattenExpr:
         assert  str(flatten_constraint( (a > 10) == 1 )) == "[IV0 > 10]"
         # assert  str(flatten_constraint( (a > 10) == 0 )) == "[IV0 <= 10]" -> part of push_down_negation now
         assert  str(flatten_constraint( (a > 10) == x )) == "[(IV0 > 10) == (BV0)]"
-        #self.assertEqual( str(flatten_constraint( x == (a > 10) )), "[(IV0 > 10) == (BV0)]" ) # TODO, make it do the swap (again)
+        assert  str(flatten_constraint( x == (a > 10) )) == "[(IV0 > 10) == (BV0)]"
         assert  str(flatten_constraint( (a >= 10) | (b + c >= 2) )) == "[(BV5) or (BV6), (IV0 >= 10) == (BV5), ((IV1) + (IV2) >= 2) == (BV6)]"
         assert  str(flatten_constraint( a > 10 )) == "[IV0 > 10]"
         assert  str(flatten_constraint( 10 > a )) == "[IV0 < 10]"# surprising
         assert  str(flatten_constraint( a+b > c )) == "[((IV0) + (IV1)) > (IV2)]"
-        #self.assertEqual( str(flatten_constraint( c < a+b )), "[((IV0) + (IV1)) > (IV2)]" ) # TODO, make it do the swap (again)
+        assert  str(flatten_constraint( c < a+b )) == "[((IV0) + (IV1)) > (IV2)]"
         assert  str(flatten_constraint( (a+b > c) == x|y )) == "[(((IV0) + (IV1)) > (IV2)) == (BV7), ((BV0) or (BV1)) == (BV7)]"
 
         assert  str(flatten_constraint( a + b == c )) == "[((IV0) + (IV1)) == (IV2)]"
-        #self.assertEqual( str(flatten_constraint( c != a + b )), "[((IV0) + (IV1)) != (IV2)]" ) # TODO, make it do the swap (again)
+        assert  str(flatten_constraint( c != a + b )) == "[((IV0) + (IV1)) != (IV2)]"
         assert  str(flatten_constraint( ((a > 5) == (b >= 3)) )) == "[(IV0 > 5) == (BV8), (IV1 >= 3) == (BV8)]"
 
         assert  str(flatten_constraint( cp.cpm_array([1,2,3])[a] == b )) == "[([1 2 3][IV0]) == (IV1)]"

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -77,55 +77,6 @@ class TestFlattenConstraint:
         e = ((a > 5) == (b < 3))
         assert len(flatten_constraint(e)) == 2
 
-    def test_bool_comparisons(self):
-        """Boolean <=/>=/</>/!= rewrite to reification / half-reification / and."""
-        (a, b) = self.ivars[:2]
-        (x, y) = self.bvars[:2]
-
-        # top-level: boolexpr # boolvar
-        assert str(flatten_constraint((a > 5) != x)) == "[(IV0 > 5) == (~BV0)]"
-        assert str(flatten_constraint((a > 5) <= x)) == "[(IV0 > 5) -> (BV0)]"
-        assert str(flatten_constraint((a > 5) >= x)) == "[(BV0) -> (IV0 > 5)]"
-        assert str(flatten_constraint((a > 5) < x)) == "[IV0 <= 5, BV0]"
-        assert str(flatten_constraint((a > 5) > x)) == "[IV0 > 5, ~BV0]"
-
-        # swap when lhs is the var
-        assert str(flatten_constraint(x != (a > 5))) == "[(IV0 > 5) == (~BV0)]"
-        assert str(flatten_constraint(x <= (a > 5))) == "[(BV0) -> (IV0 > 5)]"
-        assert str(flatten_constraint(x >= (a > 5))) == "[(IV0 > 5) -> (BV0)]"
-
-        # nested (via normalized_boolexpr): half-reif becomes or of vars
-        assert str(normalized_boolexpr((a > 5) <= x)) == "((~BV3) or (BV0), [(IV0 >= 6) == (BV3)])"
-        assert str(normalized_boolexpr((a > 5) >= x)) == "((BV4) or (~BV0), [(IV0 >= 6) == (BV4)])"
-        assert str(normalized_boolexpr((a > 5) < x)) == "((~BV5) and (BV0), [(IV0 >= 6) == (BV5)])"
-        assert str(normalized_boolexpr((a > 5) > x)) == "((BV6) and (~BV0), [(IV0 >= 6) == (BV6)])"
-
-        # implication wrapping a bool comparison must stay flat-normal
-        flat = flatten_constraint(y.implies((a > 5) <= x))
-        assert str(flat) == "[(BV1) -> ((~BV7) or (BV0)), (IV0 >= 6) == (BV7)]"
-
-        # bool vs int still stays a numeric comparison
-        assert str(flatten_constraint((a + b == 2) <= b)) == \
-            "[(BV8) <= (IV1), ((IV0) + (IV1) == 2) == (BV8)]"
-
-    def test_bool_comparisons_both_sides(self):
-        """Both sides Boolean expressions (RHS reified, possibly CSE-canonicalized)."""
-        (a, b) = self.ivars[:2]
-
-        # b < 3 is stored as ~(b >= 3) via CSE canonicalization
-        assert str(flatten_constraint((a > 5) <= (b < 3))) == \
-            "[(IV0 > 5) -> (~BV3), (IV1 >= 3) == (BV3)]"
-        assert str(flatten_constraint((a > 5) >= (b < 3))) == \
-            "[(~BV4) -> (IV0 > 5), (IV1 >= 3) == (BV4)]"
-        assert str(flatten_constraint((a > 5) < (b < 3))) == \
-            "[IV0 <= 5, ~BV5, (IV1 >= 3) == (BV5)]"
-        assert str(flatten_constraint((a > 5) > (b < 3))) == \
-            "[IV0 > 5, BV6, (IV1 >= 3) == (BV6)]"
-        assert str(flatten_constraint((a > 5) != (b < 3))) == \
-            "[(IV0 > 5) == (BV7), (IV1 >= 3) == (BV7)]"
-        assert str(flatten_constraint((a > 5) == (b < 3))) == \
-            "[(IV0 > 5) == (~BV8), (IV1 >= 3) == (BV8)]"
-
 
 class TestFlattenExpr:
     def setup_method(self):

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -87,7 +87,7 @@ class TestFlattenExpr:
 
     # not directly tested on its own, new functions 'normalized_boolexpr' and 'normalized_numexpr'
 
-    def test_get_or_make_var__bool(self):
+    def test_get_or_make_var_bool(self):
         (a,b,c,d,e) = self.ivars[:5]
         (x,y,z) = self.bvars[:3]
 
@@ -191,9 +191,9 @@ class TestFlattenExpr:
             "(IV0 >= 10) == (BV27)",
         }
 
-        v, cons = get_or_make_var(Operator('not', [x]) == y)
-        assert str(v) == "BV29"
-        assert {str(c) for c in cons} == {"((~BV0) == (BV1)) == (BV29)"}
+        # v, cons = get_or_make_var(Operator('not', [x]) == y) # no longer supported, not-operators are eliminated by push_down_negation
+        # assert str(v) == "BV29"
+        # assert {str(c) for c in cons} == {"((~BV0) == (BV1)) == (BV29)"}
 
     def test_get_or_make_var__num(self):
         (a,b,c,d,e) = self.ivars[:5]
@@ -324,7 +324,7 @@ class TestFlattenExpr:
         # != in boolexpr, bug #170
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
         #simplify output
-        assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])"
+        # assert  str(normalized_boolexpr(Operator('not',[x]) == y)) == "((~BV0) == (BV1), [])" # no longer supported, not-operators are eliminated by push_down_negation
 
         # wsum negation shares the vars list; flatten must not corrupt paired coefficients
         vars_list = [a, Operator('sum', [x, y]), 1]

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -70,6 +70,38 @@ class TestTransSimplify:
                 assert str(self.transform(expr)) == str([expr_should])
 
 
+    def test_bool_comparisons(self):
+        """Boolean <=/>=/</>/!= rewritten in simplify_boolean."""
+        a, b = self.ivs[0], self.ivs[1]
+        x, y = self.bvs[0], self.bvs[1]
+
+        # boolexpr # boolvar
+        assert str(self.transform((a > 5) != x)) == "[(iv[0] > 5) == (~bv[0])]"
+        assert str(self.transform((a > 5) <= x)) == "[(iv[0] > 5) -> (bv[0])]"
+        assert str(self.transform((a > 5) >= x)) == "[(bv[0]) -> (iv[0] > 5)]"
+        assert str(self.transform((a > 5) < x)) == "[iv[0] <= 5, bv[0]]"
+        assert str(self.transform((a > 5) > x)) == "[iv[0] > 5, ~bv[0]]"
+
+        # boolvar # boolexpr
+        assert str(self.transform(x != (a > 5))) == "[(bv[0]) == (iv[0] <= 5)]"
+        assert str(self.transform(x <= (a > 5))) == "[(bv[0]) -> (iv[0] > 5)]"
+        assert str(self.transform(x >= (a > 5))) == "[(iv[0] > 5) -> (bv[0])]"
+
+        # nested under implication
+        assert str(self.transform(y.implies((a > 5) <= x))) == "[(bv[1]) -> ((iv[0] > 5) -> (bv[0]))]"
+        assert str(self.transform(y.implies((a > 5) < x))) == "[(bv[1]) -> ((iv[0] <= 5) and (bv[0]))]"
+
+    def test_bool_comparisons_both_sides(self):
+        """Both sides Boolean expressions."""
+        a, b = self.ivs[0], self.ivs[1]
+
+        assert str(self.transform((a > 5) <= (b < 3))) == "[(iv[0] > 5) -> (iv[1] < 3)]"
+        assert str(self.transform((a > 5) >= (b < 3))) == "[(iv[1] < 3) -> (iv[0] > 5)]"
+        assert str(self.transform((a > 5) < (b < 3))) == "[iv[0] <= 5, iv[1] < 3]"
+        assert str(self.transform((a > 5) > (b < 3))) == "[iv[0] > 5, iv[1] >= 3]"
+        assert str(self.transform((a > 5) != (b < 3))) == "[(iv[0] > 5) == (iv[1] >= 3)]"
+        assert str(self.transform((a > 5) == (b < 3))) == "[(iv[0] > 5) == (iv[1] < 3)]"
+
     def test_simplify_expressions(self):
         # global constraints
         expr = cp.AllDifferent(self.ivs) == 0
@@ -101,7 +133,7 @@ class TestTransSimplify:
 
         # very nested one
         expr = Operator("and", self.bvs[:1].tolist() + [BoolVal(False)]) == Operator("or", self.bvs)
-        assert str(self.transform(expr)) == '[and(~bv[0], ~bv[1], ~bv[2])]'
+        assert str(self.transform(expr)) == '[~bv[0], ~bv[1], ~bv[2]]'
 
     def test_nested_boolval(self):
 


### PR DESCRIPTION
Improvement to flattening to avoid making some auxiliary variables.

I'm not conviced yet it should live in flatten, might be better to make it part of simplify_bool instead?

(Some int2bool tests still failing, will investigate)