### PR TITLE
Increase ortools lower bound to 9.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy >= 1.5
-ortools >=9.3.10497,!=9.9.*,!=9.10.*,!=9.11.*
+ortools >=9.12
 packaging # to check solver versions

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r", encoding="utf8") as readme_file:
 
 
 solver_dependencies = {
-    "ortools": ["ortools>=9.3.10497,!=9.9.*,!=9.10.*,!=9.11.*"], # exclusion due to bug #191
+    "ortools": ["ortools>=9.12"],
     "z3": ["z3-solver>=5.0.0"],
     "choco": ["pychoco>=0.2.1,<0.3.0"],  # 0.3.0 breaks CPMpy tests
     "exact": ["exact>=2.1.0"], # older versions (<2.2.1) are bugged on py3.13


### PR DESCRIPTION
Closes #1071. Raise the version lower bound on OR-Tools. Tested across a range of OR-Tools and python versions on the complete test suite to find similar issues.