### PR TITLE
Arity checks

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -729,8 +729,8 @@ class Operator(Expression):
     it is stored first (as expr[0]), this eases weighted sum detection
 
     N-ary operators (``and``, ``or``, ``sum``) require at least one argument (arity >= 1).
-    Empty argument lists are rejected: while logically plausible, they usually indicate a
-    construction / user mistake (e.g. unexpectedly empty input).
+    ``wsum`` likewise requires at least one term. Empty argument lists are rejected: while
+    logically plausible, they usually indicate a construction / user mistake (e.g. unexpectedly empty input).
     """
     allowed: Final[dict[str, tuple[int, bool]]] = {
         #name: (arity, is_bool)       arity 0 = n-ary, min 1
@@ -794,7 +794,12 @@ class Operator(Expression):
                     weights.append(int(a)) # bool or int, simplifies things later on
                 else:
                     weights.append(a) # can be float
-            arg_list = (weights, arg_list[1])
+            exprs = arg_list[1]
+            if len(weights) != len(exprs):
+                raise ValueError(f"Operator 'wsum' expects equal lengths, got {len(weights)} weights and {len(exprs)} expressions")
+            if len(weights) == 0:
+                raise ValueError("Operator 'wsum' must be given at least one term")
+            arg_list = (weights, exprs)
 
         # small cleanup: nested n-ary operators are merged into the toplevel
         # (this is actually against our design principle of creating

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -727,9 +727,13 @@ class Operator(Expression):
 
     Convention for 2-ary operators: if one of the two is a constant,
     it is stored first (as expr[0]), this eases weighted sum detection
+
+    N-ary operators (``and``, ``or``, ``sum``) require at least one argument (arity >= 1).
+    Empty argument lists are rejected: while logically plausible, they usually indicate a
+    construction / user mistake (e.g. unexpectedly empty input).
     """
     allowed: Final[dict[str, tuple[int, bool]]] = {
-        #name: (arity, is_bool)       arity 0 = n-ary, min 2
+        #name: (arity, is_bool)       arity 0 = n-ary, min 1
         'and': (0, True),
         'or':  (0, True),
         '->':  (2, True),
@@ -747,6 +751,7 @@ class Operator(Expression):
             name (str): Operator name (one of :attr:`Operator.allowed`)
             arg_list (Sequence[ExprLike | ListLike[ExprLike]]): List of expressions/constants, 
                         or list of size 2 with list of weights and list of expressions for wsum.
+                        For n-ary operators (``and``, ``or``, ``sum``), at least one argument is required.
         """
         # sanity checks
         assert (name in Operator.allowed), "Operator {} not allowed".format(name)
@@ -759,9 +764,11 @@ class Operator(Expression):
                     raise TypeError("{}-operator only accepts boolean arguments, not {}".format(name,arg))
         if arity == 0:
             arg_list = flatlist(arg_list)
-            assert (len(arg_list) >= 1), "Operator: n-ary operators require at least one argument"
+            if len(arg_list) == 0:
+                raise ValueError(f"Operator '{name}' must be given at least one argument")
         else:
-            assert (len(arg_list) == arity), "Operator: {}, number of arguments must be {}".format(name, arity)
+            if len(arg_list) != arity:
+                raise ValueError("Operator: {}, number of arguments must be {}".format(name, arity))
 
         # automatic weighted sum (wsum) creation:
         # if all args are an expression (not a constant)

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -787,6 +787,7 @@ class Operator(Expression):
         # we have the requirement that weighted sums are [weights, expressions]
         if name == 'wsum':
             assert isinstance(arg_list[0], (list, tuple, np.ndarray)), "wsum: arg0 has to be a list-like"
+            assert isinstance(arg_list[1], (list, tuple, np.ndarray)), "wsum: arg1 has to be a list-like"
             assert all(is_num(a) for a in arg_list[0]), "wsum: arg0 has to be all constants but is: "+str(arg_list[0])
             weights: list[ExprLike] = []
             for a in arg_list[0]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -236,7 +236,10 @@ class AllDifferent(GlobalConstraint):
         Arguments:
             args (ExprLike|ListLike[ExprLike]): List of expressions or constants to be different from each other
         """
-        super().__init__("alldifferent", tuple(flatlist(args)))
+        flatargs = flatlist(args)
+        if len(flatargs) == 0:
+            raise ValueError('AllDifferent constraint must be given at least one argument')
+        super().__init__("alldifferent", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -285,6 +288,8 @@ class AllDifferentExceptN(GlobalConstraint):
             n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the distinctness constraint
         """
         flatarr = flatlist(arr)
+        if len(flatarr) == 0:
+            raise ValueError('AllDifferentExceptN constraint must be given at least one argument')
         if not is_any_list(n):
             n = cast(int, n)
             n = [n] # ensure n is a list of ints
@@ -339,7 +344,10 @@ class AllEqual(GlobalConstraint):
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to have the same value
         """
-        super().__init__("allequal", tuple(flatlist(args)))
+        flatargs = flatlist(args)
+        if len(flatargs) == 0:
+            raise ValueError('AllEqual constraint must be given at least one argument')
+        super().__init__("allequal", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -374,6 +382,8 @@ class AllEqualExceptN(GlobalConstraint):
             n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the equality constraint
         """
         flatarr = flatlist(arr)
+        if len(flatarr) == 0:
+            raise ValueError('AllEqualExceptN constraint must be given at least one argument')
         if not is_any_list(n):
             n = cast(int, n)
             n = [n] # ensure n is a list of ints
@@ -878,6 +888,8 @@ class Regular(GlobalConstraint):
             accepting (ListLike[int | str]): List of accepting node ids
         """
         array = flatlist(array)
+        if len(array) == 0:
+            raise ValueError('Regular constraint must be given at least one argument in array')
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("The first argument of a regular constraint should only contain variables/expressions")
         
@@ -1100,6 +1112,8 @@ class MDD(GlobalConstraint):
 
         """
         array = flatlist(array)
+        if len(array) == 0:
+            raise ValueError('MDD constraint must be given at least one argument in array')
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
 
@@ -1479,6 +1493,8 @@ class Xor(GlobalConstraint):
         """
         if not all(is_boolexpr(arg) for arg in arg_list):
             raise TypeError("Only Boolean arguments allowed in Xor global constraint: {}".format(arg_list))
+        if len(arg_list) == 0:
+            raise ValueError('Xor constraint must be given at least one argument')
         # convention for commutative binary operators:
         # swap if right is constant and left is not
         arg_list = list(arg_list)
@@ -2261,7 +2277,10 @@ class Increasing(GlobalConstraint):
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to increasing values
         """
-        super().__init__("increasing", tuple(flatlist(args)))
+        flatargs = flatlist(args)
+        if len(flatargs) == 0:
+            raise ValueError('Increasing constraint must be given at least one argument')
+        super().__init__("increasing", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -2294,7 +2313,10 @@ class Decreasing(GlobalConstraint):
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to decreasing values
         """
-        super().__init__("decreasing", tuple(flatlist(args)))
+        flatargs = flatlist(args)
+        if len(flatargs) == 0:
+            raise ValueError('Decreasing constraint must be given at least one argument')
+        super().__init__("decreasing", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -2327,7 +2349,10 @@ class IncreasingStrict(GlobalConstraint):
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly increasing values
         """
-        super().__init__("strictly_increasing", tuple(flatlist(args)))
+        flatargs = flatlist(args)
+        if len(flatargs) == 0:
+            raise ValueError('IncreasingStrict constraint must be given at least one argument')
+        super().__init__("strictly_increasing", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -2361,7 +2386,10 @@ class DecreasingStrict(GlobalConstraint):
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly decreasing values
         """
-        super().__init__("strictly_decreasing", tuple(flatlist(args)))
+        flatargs = flatlist(args)
+        if len(flatargs) == 0:
+            raise ValueError('DecreasingStrict constraint must be given at least one argument')
+        super().__init__("strictly_decreasing", tuple(flatargs))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -915,7 +915,8 @@ class Regular(GlobalConstraint):
     Takes as input a sequence of variables and a automaton representation using a transition table.
     The constraint is satisfied if the sequence of variables corresponds to an accepting path in the automaton.
 
-    Requires a non-empty input sequence (``array`` arity >= 1).
+    Requires a non-empty input sequence (``array`` arity >= 1), at least one transition,
+    and at least one accepting state (OR-Tools ``AddAutomaton`` rejects all three empties).
 
     The automaton is defined by a list of transitions, a starting node and a list of accepting nodes.
     The transitions are represented as a list of tuples, where each tuple is of the form (id1, value, id2).
@@ -935,8 +936,10 @@ class Regular(GlobalConstraint):
             array (ListLike[Expression]): List of expressions representing the input sequence
                 (at least one required)
             transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
+                (at least one required)
             start (int | str): Starting node id
             accepting (ListLike[int | str]): List of accepting node ids
+                (at least one required)
         """
         array = flatlist(array)
         if len(array) == 0:
@@ -946,6 +949,8 @@ class Regular(GlobalConstraint):
         
         if not is_any_list(transitions):
             raise TypeError("The second argument of a regular constraint should be a list of transitions")
+        if len(transitions) == 0:
+            raise ValueError('Regular constraint must be given at least one transition')
         _node_type = type(transitions[0][0])
         for s,v,e in transitions:
             if not isinstance(s, _node_type) or not isinstance(e, _node_type) or not isinstance(v, int):
@@ -954,6 +959,8 @@ class Regular(GlobalConstraint):
             raise TypeError("The third argument of a regular constraint should be a node id")
         if not (is_any_list(accepting) and all(isinstance(e, _node_type) for e in accepting)):
             raise TypeError("The fourth argument of a regular constraint should be a list of node ids")
+        if len(accepting) == 0:
+            raise ValueError('Regular constraint must be given at least one accepting state')
         super().__init__("regular", (list(array), list(transitions), start, list(accepting)))
 
         node_set = set()
@@ -980,8 +987,6 @@ class Regular(GlobalConstraint):
         # Decompose to transition table using Table constraints
 
         arr, transitions, start, accepting = self.args
-        if len(accepting) == 0:
-            return [cp.BoolVal(False)], [] # no accepting states, cannot be satisfied
 
         lbs, ubs = get_bounds(arr)
         lb, ub = min(lbs), max(ubs)
@@ -1024,9 +1029,6 @@ class Regular(GlobalConstraint):
         """
 
         arr, transitions, start, accepting = self.args
-
-        if len(accepting) == 0:
-            return [cp.BoolVal(False)], [] # no accepting states, cannot be satisfied
 
         # Collect all nodes and all transition values in the DFA
         nodes_set = set()

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -2282,13 +2282,17 @@ class Precedence(GlobalConstraint):
 class GlobalCardinalityCount(GlobalConstraint):
     """
     Enforces that the number of occurrences of each value `vals[i]` in the list of variables `vars` is equal to `occ[i]`.
+
+    Requires a non-empty ``vars`` list and a non-empty ``vals``/``occ`` list (arity >= 1).
     """
 
     def __init__(self, vars: ListLike[ExprLike], vals: ListLike[int|np.integer], occ: ListLike[ExprLike], closed: bool = False):
         """
         Arguments:
             vars (ListLike[ExprLike]): List of expressions or constants representing the variables
+                (at least one required)
             vals (ListLike[int | np.integer]): List of integer values
+                (at least one required)
             occ (ListLike[ExprLike]): List of expressions or constants representing the number of occurrences of each value
             closed (bool): Whether the constraint is closed, if true, `vars` can only take values in `vals`
         """
@@ -2298,8 +2302,12 @@ class GlobalCardinalityCount(GlobalConstraint):
             raise TypeError("GlobalCardinalityCount expects a list of values, but got", vals)
         if not is_any_list(occ):
             raise TypeError("GlobalCardinalityCount expects a list of variables as occurrences, but got", occ)
+        if len(vars) == 0:
+            raise ValueError('GlobalCardinalityCount constraint must be given at least one variable')
         if len(vals) != len(occ):
             raise ValueError(f"Number of values and occurrences must be equal, but got {len(vals)} and {len(occ)}")
+        if len(vals) == 0:
+            raise ValueError('GlobalCardinalityCount constraint must be given at least one value')
         super().__init__("gcc", (list(vars), list(vals), list(occ)))
         self.closed = closed
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -2213,7 +2213,7 @@ class Precedence(GlobalConstraint):
     Given an array of variables X and a list of values P, values in P must appear in X in the order specified by P.
     I.e., if X[i] = P[j+1], then there exists a X[i'] = P[j] with i' < i
 
-    Requires a non-empty variable array (``vars`` arity >= 1).
+    Requires a non-empty variable array (``vars`` arity >= 1) and a non-empty precedence list (arity >= 1).
 
     Examples:
         - X = [1,2,1,3] satisfies the precedence [1,2,3].
@@ -2233,6 +2233,8 @@ class Precedence(GlobalConstraint):
             raise TypeError("Precedence expects a list of values as second argument, but got", precedence)
         if len(vars) == 0:
             raise ValueError('Precedence constraint must be given at least one variable')
+        if len(precedence) == 0:
+            raise ValueError('Precedence constraint must be given at least one precedence value')
         super().__init__("precedence", (list(vars), list(precedence)))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1162,6 +1162,7 @@ class MDD(GlobalConstraint):
             array (ListLike[Expression]): List of expressions representing the input sequence
                 (at least one required)
             transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (node_id1, value, node_id2)
+                (at least one required)
             start (Optional[int | str]): Root node_id, if None, the root node is assumed to be the first node in the transition table (i.e., transitions[0][0])
             reduce (bool, default=True): During decomposition, whether to reduce the MDD as a first decomposition step
                 by merging nodes with equivalent suffixes, reducing the size of the MDD
@@ -1173,6 +1174,10 @@ class MDD(GlobalConstraint):
         if not all(isinstance(x, Expression) for x in array):
             raise TypeError("The first argument of an MDD constraint should only contain variables/expressions")
 
+        if not is_any_list(transitions):
+            raise TypeError("The second argument of an MDD constraint should be a list of transitions")
+        if len(transitions) == 0:
+            raise ValueError('MDD constraint must be given at least one transition')
         _node_type = type(transitions[0][0])
         for id1, v, id2 in transitions:
             if not isinstance(id1, _node_type) or not isinstance(v, int) or not isinstance(id2, _node_type):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -529,15 +529,21 @@ class Inverse(GlobalConstraint):
     I.e., fwd[i] == x <==> rev[x] == i
 
     Also known as channeling / assignment constraint.
+
+    Requires non-empty equal-length arrays (arity >= 1).
     """
     def __init__(self, fwd: ListLike[ExprLike], rev: ListLike[ExprLike]):
         """
         Arguments:
             fwd (ListLike[ExprLike]): List of expressions or constants representing the forward function
+                (at least one required)
             rev (ListLike[ExprLike]): List of expressions or constants representing the reverse function
+                (same length as ``fwd``)
         """
         if len(fwd) != len(rev):
             raise ValueError("Length of fwd and rev must be equal for Inverse constraint")
+        if len(fwd) == 0:
+            raise ValueError('Inverse constraint must be given at least one argument')
         super().__init__("inverse", (fwd, rev))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -583,11 +589,14 @@ class Inverse(GlobalConstraint):
 class Table(GlobalConstraint):
     """
     Enforces that the values of the variables in 'array' correspond to a row in 'table'.
+
+    Requires a non-empty ``array`` (arity >= 1), i.e. a table with at least one row.
     """
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the array of variables
+                (at least one required)
             table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
         """
         if isinstance(array, NDVarArray):
@@ -600,6 +609,9 @@ class Table(GlobalConstraint):
                 if isinstance(x, Expression) and not isinstance(x, (_NumVarImpl, BoolVal)):
                     has_subexpr = True
                     break
+
+        if len(array) == 0:
+            raise ValueError('Table constraint must be given at least one argument in array')
 
         if not isinstance(table, np.ndarray):  # Ensure it is a numpy array with integers
             table = np.array(table, dtype=int)
@@ -734,12 +746,15 @@ class ShortTable(GlobalConstraint):
     """
     Extension of the `Table` constraint where the `table` matrix may contain wildcards (STAR), meaning there are
     no restrictions for the corresponding variable in that tuple.
+
+    Requires a non-empty ``array`` (arity >= 1), i.e. a table with at least one row.
     """
 
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int|Literal["*"]]] | np.ndarray):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the array of variables
+                (at least one required)
             table (ListLike[ListLike[int | '*']] | np.ndarray): List of lists or 2D ndarray; entries are integers or STAR ('*')
                 STAR represents a wildcard (corresponding variable can take any value).
         """
@@ -753,6 +768,9 @@ class ShortTable(GlobalConstraint):
                 if isinstance(x, Expression) and not isinstance(x, (_NumVarImpl, BoolVal)):
                     has_subexpr = True
                     break
+
+        if len(array) == 0:
+            raise ValueError('ShortTable constraint must be given at least one argument in array')
 
         if not isinstance(table, np.ndarray):
             table = np.array(table, dtype=object)  # object, otherwise np makes it all string
@@ -817,12 +835,15 @@ class ShortTable(GlobalConstraint):
 class NegativeTable(GlobalConstraint):
     """
     The values of the variables in 'array' do not correspond to any row in 'table'.
+
+    Requires a non-empty ``array`` (arity >= 1), i.e. a table with at least one row.
     """
 
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the array of variables
+                (at least one required)
             table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
         """
         if isinstance(array, NDVarArray):
@@ -835,6 +856,9 @@ class NegativeTable(GlobalConstraint):
                 if isinstance(x, Expression) and not isinstance(x, (_NumVarImpl, BoolVal)):
                     has_subexpr = True
                     break
+
+        if len(array) == 0:
+            raise ValueError('NegativeTable constraint must be given at least one argument in array')
 
         if not isinstance(table, np.ndarray):  # Ensure it is a numpy array
             table = np.array(table, dtype=int)
@@ -1610,11 +1634,14 @@ class Cumulative(GlobalConstraint):
 
     Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlap` when demand and capacity are equal to 1.
     Supports both varying demand across tasks or equal demand for all jobs.
+
+    Requires at least one task (``start`` arity >= 1).
     """
     def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None, demand: Optional[ListLike[ExprLike]|ExprLike] = None, capacity: Optional[ExprLike] = None):
         """
             Arguments:
                 start (ListLike[ExprLike]): Start times of the tasks
+                    (at least one required)
                 duration (ListLike[ExprLike]): Durations of the tasks
                 end (ListLike[ExprLike] | None): Optional end times of the tasks
                 demand (ListLike[ExprLike] | ExprLike): Per-task demands or a single constant demand, required
@@ -1638,6 +1665,8 @@ class Cumulative(GlobalConstraint):
             raise ValueError("Start and duration should have equal length")
         if end is not None and len(start) != len(end):
             raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
+        if len(start) == 0:
+            raise ValueError('Cumulative constraint must be given at least one task')
 
         demand_list = []
         if is_any_list(demand):
@@ -1805,6 +1834,8 @@ class CumulativeOptional(GlobalConstraint):
 
         Equivalent to :class:`~cpmpy.expressions.globalconstraints.NoOverlapOptional` when demand and capacity are equal to 1.
         Supports both varying demand across tasks or equal demand for all jobs.
+
+        Requires at least one task (``start`` arity >= 1).
     """
 
     def __init__(self, start: ListLike[ExprLike], 
@@ -1843,6 +1874,8 @@ class CumulativeOptional(GlobalConstraint):
             raise ValueError("Start and is_present should have equal length")
         if end is not None and len(start) != len(end):
             raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
+        if len(start) == 0:
+            raise ValueError('CumulativeOptional constraint must be given at least one task')
 
         demand_list = []
         if is_any_list(demand):
@@ -2002,12 +2035,15 @@ class NoOverlap(GlobalConstraint):
     Enforces that a set of tasks are scheduled without overlapping, and enforces:
         - duration >= 0
         - start + duration == end
+
+    Requires at least one task (``start`` arity >= 1).
     """
 
     def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None):
         """
         Arguments:
             start (ListLike[ExprLike]): Start times of the tasks
+                (at least one required)
             duration (ListLike[ExprLike]): Durations of the tasks
             end (ListLike[ExprLike] | None): Optional end times of the tasks
         """
@@ -2023,6 +2059,8 @@ class NoOverlap(GlobalConstraint):
             raise ValueError("Start and duration should have equal length")
         if end is not None and len(start) != len(end):
             raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
+        if len(start) == 0:
+            raise ValueError('NoOverlap constraint must be given at least one task')
         
         if end is None:
             super().__init__("no_overlap", (list(start), list(duration)))
@@ -2086,12 +2124,15 @@ class NoOverlapOptional(GlobalConstraint):
         - start + duration == end
 
         if the task is not present, it does not enforce any of the above.
+
+        Requires at least one task (``start`` arity >= 1).
     """
     
     def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None, is_present: Optional[ListLike[BoolExprLike]] = None):
         """
         Arguments:
             start (ListLike[ExprLike]): List of Expression objects representing the start times of the tasks
+                (at least one required)
             duration (ListLike[ExprLike]): List of Expression objects representing the durations of the tasks
             end (ListLike[ExpLike] | None): optional, list of Expression objects representing the end times of the tasks
             is_present (ListLike[BoolExprLike]): List of Boolean Expression objects representing the presence of the tasks
@@ -2112,6 +2153,8 @@ class NoOverlapOptional(GlobalConstraint):
             raise ValueError("Start and is_present should have equal length")
         if end is not None and len(start) != len(end):
             raise ValueError(f"Start and end should have equal length, but got {len(start)} and {len(end)}")
+        if len(start) == 0:
+            raise ValueError('NoOverlapOptional constraint must be given at least one task')
 
         if end is None:
             super().__init__("no_overlap_optional", (list(start), list(duration), list(is_present)))
@@ -2170,6 +2213,8 @@ class Precedence(GlobalConstraint):
     Given an array of variables X and a list of values P, values in P must appear in X in the order specified by P.
     I.e., if X[i] = P[j+1], then there exists a X[i'] = P[j] with i' < i
 
+    Requires a non-empty variable array (``vars`` arity >= 1).
+
     Examples:
         - X = [1,2,1,3] satisfies the precedence [1,2,3].
         - X = [4,1,2,1,3] also satisfies the precedence, as values not appearing in P can appear in any order.
@@ -2179,12 +2224,15 @@ class Precedence(GlobalConstraint):
         """
         Arguments:
             vars (ListLike[ExprLike]): List of expressions or constants representing the variables
+                (at least one required)
             precedence (ListLike[int | np.integer]): List of integer precedence values
         """
         if not is_any_list(vars):
             raise TypeError("Precedence expects a list of variables as first argument, but got", vars)
         if not is_any_list(precedence) or not all(is_num(p) for p in precedence):
             raise TypeError("Precedence expects a list of values as second argument, but got", precedence)
+        if len(vars) == 0:
+            raise ValueError('Precedence constraint must be given at least one variable')
         super().__init__("precedence", (list(vars), list(precedence)))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -2455,15 +2503,20 @@ class DecreasingStrict(GlobalConstraint):
 class LexLess(GlobalConstraint):
     """ 
     Enforces that the first list is lexicographically smaller than the second list.
+
+    Requires non-empty equal-length lists (arity >= 1).
     """
     def __init__(self, list1: ListLike[ExprLike], list2: ListLike[ExprLike]):
         """
         Arguments:
             list1 (ListLike[ExprLike]): First List of expressions or constants to be compared lexicographically
+                (at least one required)
             list2 (ListLike[ExprLike]): Second List of expressions or constants to be compared lexicographically
         """ 
         if len(list1) != len(list2):
             raise ValueError(f"The 2 lists given in LexLess must have the same size: list1 length is {len(list1)} and list2 length is {len(list2)}")
+        if len(list1) == 0:
+            raise ValueError('LexLess constraint must be given at least one argument')
         super().__init__("lex_less", (list1, list2))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -2487,9 +2540,6 @@ class LexLess(GlobalConstraint):
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
         """
         X, Y = cpm_array(self.args)
-
-        if len(X) == 0 == len(Y):
-            return [cp.BoolVal(False)], [] # based on the decomp, it's false...
 
         bvar = boolvar(shape=(len(X) + 1))
 
@@ -2517,15 +2567,20 @@ class LexLess(GlobalConstraint):
 class LexLessEq(GlobalConstraint):
     """
     Enforces that the first list is lexicographically smaller than or equal to the second list.
+
+    Requires non-empty equal-length lists (arity >= 1).
     """
     def __init__(self, list1: ListLike[ExprLike], list2: ListLike[ExprLike]):
         """
         Arguments:
             list1 (ListLike[ExprLike]): First List of expressions or constants to be compared lexicographically
+                (at least one required)
             list2 (ListLike[ExprLike]): Second List of expressions or constants to be compared lexicographically
         """
         if len(list1) != len(list2):
             raise ValueError(f"The 2 lists given in LexLessEq must have the same size: list1 length is {len(list1)} and list2 length is {len(list2)}")
+        if len(list1) == 0:
+            raise ValueError('LexLessEq constraint must be given at least one argument')
         super().__init__("lex_lesseq", (list1, list2))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
@@ -2549,9 +2604,6 @@ class LexLessEq(GlobalConstraint):
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
         """
         X, Y = cpm_array(self.args)
-
-        if len(X) == 0 == len(Y):
-            return [cp.BoolVal(False)], [] # based on the decomp, it's false...
 
         bvar = boolvar(shape=(len(X) + 1))
         defining = []

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -590,7 +590,7 @@ class Table(GlobalConstraint):
     """
     Enforces that the values of the variables in 'array' correspond to a row in 'table'.
 
-    Requires a non-empty ``array`` (arity >= 1), i.e. a table with at least one row.
+    Requires a non-empty ``array`` of variables (arity >= 1).
     """
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
         """
@@ -747,7 +747,7 @@ class ShortTable(GlobalConstraint):
     Extension of the `Table` constraint where the `table` matrix may contain wildcards (STAR), meaning there are
     no restrictions for the corresponding variable in that tuple.
 
-    Requires a non-empty ``array`` (arity >= 1), i.e. a table with at least one row.
+    Requires a non-empty ``array`` of variables (arity >= 1).
     """
 
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int|Literal["*"]]] | np.ndarray):
@@ -836,7 +836,7 @@ class NegativeTable(GlobalConstraint):
     """
     The values of the variables in 'array' do not correspond to any row in 'table'.
 
-    Requires a non-empty ``array`` (arity >= 1), i.e. a table with at least one row.
+    Requires a non-empty ``array`` of variables (arity >= 1).
     """
 
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1482,6 +1482,8 @@ class IfThenElse(GlobalConstraint):
 class InDomain(GlobalConstraint):
     """
     Enforces the expression is assigned to a value in the given domain.
+
+    Requires a non-empty domain (``arr`` arity >= 1).
     """
 
     def __init__(self, expr: Expression, arr: Iterable[int|np.integer]):
@@ -1489,10 +1491,14 @@ class InDomain(GlobalConstraint):
         Arguments:
             expr (Expression): Expression to be assigned to a value in the given domain
             arr (Iterable[int | np.integer]): Iterable of integer constants representing the domain
+                (at least one required)
         """
         if not isinstance(arr, np.ndarray):
             arr = np.array(arr, dtype=int)
-        assert arr.ndim == 1, "The second argument of an InDomain constraint should be a 1D array of integer constants"
+        if arr.ndim != 1:
+            raise ValueError("The second argument of an InDomain constraint should be a 1D array of integer constants")
+        if len(arr) == 0:
+            raise ValueError('InDomain constraint must be given at least one domain value')
 
         has_subexpr = not isinstance(expr, (_NumVarImpl, BoolVal))
 
@@ -1550,7 +1556,10 @@ class InDomain(GlobalConstraint):
 
         # complement of arr
         arr_set = frozenset(arr)
-        return InDomain(expr, [v for v in range(lb,ub+1) if v not in arr_set])
+        complement = [v for v in range(lb,ub+1) if v not in arr_set]
+        if len(complement) == 0:
+            return BoolVal(False)
+        return InDomain(expr, complement)
 
 
 class Xor(GlobalConstraint):

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -2637,15 +2637,20 @@ class LexLessEq(GlobalConstraint):
 class LexChainLess(GlobalConstraint):
     """
     Enforces that all rows of the matrix are lexicographically ordered.
+
+    Requires a non-empty 2D matrix (at least one row and one column).
     """
     def __init__(self, X: ListLike[ListLike[ExprLike]]):
         """
         Arguments:
             X (ListLike[ListLike[ExprLike]]): Matrix (List of lists) of expressions or constants to be compared lexicographically
+                (non-empty 2D matrix required)
         """
         Xarr = np.array(X) # also checks length of each row is equal
         if Xarr.ndim != 2:
             raise ValueError(f"The matrix given in LexChainLess must be 2D, but got {Xarr.ndim} dimensions")
+        if 0 in Xarr.shape:
+            raise ValueError('LexChainLess constraint must be given a non-empty 2D matrix')
         super().__init__("lex_chain_less", tuple(Xarr.tolist()))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -390,7 +390,7 @@ class AllEqualExceptN(GlobalConstraint):
     """
     Enforces that all arguments, except those equal to a value in n, have the same value.
 
-    Requires at least one argument in ``arr`` (arity >= 1).
+    Requires at least one argument in ``arr`` (arity >= 1) and a non-empty exception set ``n``.
     """
 
     def __init__(self, arr: ListLike[ExprLike], n: int|np.integer|list[int|np.integer]):
@@ -399,6 +399,7 @@ class AllEqualExceptN(GlobalConstraint):
             arr (ListLike[ExprLike]): List of expressions or constants to have the same value, except those equal to a value in n
                 (at least one required)
             n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the equality constraint
+                (at least one required)
         """
         flatarr = flatlist(arr)
         if len(flatarr) == 0:
@@ -406,6 +407,8 @@ class AllEqualExceptN(GlobalConstraint):
         if not is_any_list(n):
             n = cast(int, n)
             n = [n] # ensure n is a list of ints
+        if len(n) == 0:
+            raise ValueError('AllEqualExceptN constraint must be given at least one excluded value')
         super().__init__("allequal_except_n", (flatarr, n))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -597,14 +597,15 @@ class Table(GlobalConstraint):
     """
     Enforces that the values of the variables in 'array' correspond to a row in 'table'.
 
-    Requires a non-empty ``array`` of variables (arity >= 1).
+    Requires a non-empty ``array`` of variables (arity >= 1) and a non-empty ``table`` (at least one row).
     """
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the array of variables
                 (at least one required)
-            table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
+            table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table
+                (at least one row required)
         """
         if isinstance(array, NDVarArray):
             has_subexpr = array.has_subexpr()  # fast shortcut
@@ -626,6 +627,8 @@ class Table(GlobalConstraint):
             table = table.astype(int, copy=False)
         if table.ndim != 2:
             raise ValueError("Table's table must be a 2D array")
+        if table.shape[0] == 0:
+            raise ValueError('Table constraint must be given at least one row')
         if table.shape[1] != len(array):
             raise ValueError(f"Table width {table.shape[1]} != array length {len(array)}")
 
@@ -702,9 +705,6 @@ class Table(GlobalConstraint):
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
          """
 
-        if len(self.args[1]) == 0: # empty table, does not allow any assignments
-            return [cp.BoolVal(False)], []
-
         arr, tab = self._variable_ordering(heuristic)
 
         mdd: dict[int, dict[int, int]] = {}
@@ -756,7 +756,7 @@ class ShortTable(GlobalConstraint):
     Extension of the `Table` constraint where the `table` matrix may contain wildcards (STAR), meaning there are
     no restrictions for the corresponding variable in that tuple.
 
-    Requires a non-empty ``array`` of variables (arity >= 1).
+    Requires a non-empty ``array`` of variables (arity >= 1) and a non-empty ``table`` (at least one row).
     """
 
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int|Literal["*"]]] | np.ndarray):
@@ -766,6 +766,7 @@ class ShortTable(GlobalConstraint):
                 (at least one required)
             table (ListLike[ListLike[int | '*']] | np.ndarray): List of lists or 2D ndarray; entries are integers or STAR ('*')
                 STAR represents a wildcard (corresponding variable can take any value).
+                At least one row required.
         """
         if isinstance(array, NDVarArray):
             has_subexpr = array.has_subexpr()  # fast shortcut
@@ -785,6 +786,8 @@ class ShortTable(GlobalConstraint):
             table = np.array(table, dtype=object)  # object, otherwise np makes it all string
         if table.ndim != 2:
             raise ValueError("ShortTable's table must be a 2D array")
+        if table.shape[0] == 0:
+            raise ValueError('ShortTable constraint must be given at least one row')
         if table.shape[1] != len(array):
             raise ValueError(f"ShortTable width {table.shape[1]} != array length {len(array)}")
 
@@ -847,7 +850,7 @@ class NegativeTable(GlobalConstraint):
     """
     The values of the variables in 'array' do not correspond to any row in 'table'.
 
-    Requires a non-empty ``array`` of variables (arity >= 1).
+    Requires a non-empty ``array`` of variables (arity >= 1) and a non-empty ``table`` (at least one row).
     """
 
     def __init__(self, array: ListLike[Expression], table: ListLike[ListLike[int]] | np.ndarray):
@@ -855,7 +858,8 @@ class NegativeTable(GlobalConstraint):
         Arguments:
             array (ListLike[Expression]): List of expressions representing the array of variables
                 (at least one required)
-            table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table.
+            table (ListLike[ListLike[int]] | np.ndarray): List of lists of integers or 2D ndarray of ints representing the table
+                (at least one row required)
         """
         if isinstance(array, NDVarArray):
             has_subexpr = array.has_subexpr()  # fast shortcut
@@ -877,6 +881,8 @@ class NegativeTable(GlobalConstraint):
             table = table.astype(int, copy=False)
         if table.ndim != 2:
             raise ValueError("NegativeTable's table must be a 2D array")
+        if table.shape[0] == 0:
+            raise ValueError('NegativeTable constraint must be given at least one row')
         if table.shape[1] != len(array):
             raise ValueError(f"NegativeTable width {table.shape[1]} != array length {len(array)}")
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -228,13 +228,16 @@ class GlobalConstraint(Expression):
 # Global Constraints (with Boolean return type)
 class AllDifferent(GlobalConstraint):
     """
-    Enforces that all arguments have a different (distinct) value
+    Enforces that all arguments have a different (distinct) value.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, *args: ExprLike|ListLike[ExprLike]):
         """
         Arguments:
             args (ExprLike|ListLike[ExprLike]): List of expressions or constants to be different from each other
+                (at least one required)
         """
         flatargs = flatlist(args)
         if len(flatargs) == 0:
@@ -276,6 +279,8 @@ class AllDifferentExceptN(GlobalConstraint):
     """
     Enforces that all arguments, except those equal to a value in n, have a different (distinct) value.
 
+    Requires at least one argument in ``arr`` (arity >= 1).
+
     Arguments:
         arr (Sequence[Expression]): List of expressions to be different from each other, except those equal to a value in n
         n (int or list[int]): Value or list of values that are excluded from satisfying the alldifferent condition
@@ -285,6 +290,7 @@ class AllDifferentExceptN(GlobalConstraint):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to a value in n
+                (at least one required)
             n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the distinctness constraint
         """
         flatarr = flatlist(arr)
@@ -327,22 +333,28 @@ class AllDifferentExceptN(GlobalConstraint):
 class AllDifferentExcept0(AllDifferentExceptN):
     """
     Enforces that all arguments, except those equal to 0, have a different (distinct) value.
+
+    Requires at least one argument (arity >= 1).
     """
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to 0
+                (at least one required)
         """
         super().__init__(flatlist(args), 0)
 
 class AllEqual(GlobalConstraint):
     """
-    Enforces that all arguments have the same value
+    Enforces that all arguments have the same value.
+
+    Requires at least one argument (arity >= 1).
     """
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to have the same value
+                (at least one required)
         """
         flatargs = flatlist(args)
         if len(flatargs) == 0:
@@ -373,12 +385,15 @@ class AllEqual(GlobalConstraint):
 class AllEqualExceptN(GlobalConstraint):
     """
     Enforces that all arguments, except those equal to a value in n, have the same value.
+
+    Requires at least one argument in ``arr`` (arity >= 1).
     """
 
     def __init__(self, arr: ListLike[ExprLike], n: int|np.integer|list[int|np.integer]):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to have the same value, except those equal to a value in n
+                (at least one required)
             n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the equality constraint
         """
         flatarr = flatlist(arr)
@@ -418,11 +433,14 @@ class AllEqualExceptN(GlobalConstraint):
 class Circuit(GlobalConstraint):
     """
     Enforces that the sequence of variables form a circuit, where x[i] = j means that node j is the successor of node i.
+
+    Requires at least two variables (arity >= 2).
     """
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants representing the successors of the nodes to form the circuit
+                (at least two required)
         """
         flatargs = flatlist(args)
         if len(flatargs) < 2:
@@ -867,6 +885,8 @@ class Regular(GlobalConstraint):
     Takes as input a sequence of variables and a automaton representation using a transition table.
     The constraint is satisfied if the sequence of variables corresponds to an accepting path in the automaton.
 
+    Requires a non-empty input sequence (``array`` arity >= 1).
+
     The automaton is defined by a list of transitions, a starting node and a list of accepting nodes.
     The transitions are represented as a list of tuples, where each tuple is of the form (id1, value, id2).
     An id is an integer or string representing a state in the automaton, and value is an integer representing the value of the variable in the sequence.
@@ -883,6 +903,7 @@ class Regular(GlobalConstraint):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the input sequence
+                (at least one required)
             transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (source, value, destination)
             start (int | str): Starting node id
             accepting (ListLike[int | str]): List of accepting node ids
@@ -1085,6 +1106,8 @@ class MDD(GlobalConstraint):
     The MDD constraint is satisfied when the values in the array correspond to a path in the MDD starting from the root node, and where the first variable
     in the array takes the value of the first edge, the second from the second edge, etc., ending in the accepting sink node.
 
+    Requires a non-empty input sequence (``array`` arity >= 1).
+
     The transitions/edges are given by a `n x 3` matrix, or more precisely a list of `n` tuples `(node_id1, value, node_id2)`.
     A node_id is an integer or string representing a state in the MDD, and value is an integer representing the value of the variable in the sequence.
     If not given explicitly, the root node is the node_id1 of the first entry in the transition table (i.e., transitions[0][0]).
@@ -1105,6 +1128,7 @@ class MDD(GlobalConstraint):
         """
         Arguments:
             array (ListLike[Expression]): List of expressions representing the input sequence
+                (at least one required)
             transitions (ListLike[tuple[int | str, int, int | str]]): List of transition triples (node_id1, value, node_id2)
             start (Optional[int | str]): Root node_id, if None, the root node is assumed to be the first node in the transition table (i.e., transitions[0][0])
             reduce (bool, default=True): During decomposition, whether to reduce the MDD as a first decomposition step
@@ -1483,13 +1507,16 @@ class Xor(GlobalConstraint):
     """
     Enforces the exclusive-or relation of the arguments.
     Supports n-ary xor-constraints, which are treated as cascaed binary xor-constraints.
-    Equivalent to `sum(args) % 2 == 1`
+    Equivalent to `sum(args) % 2 == 1`.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, arg_list: ListLike[BoolExprLike]):
         """
         Arguments:
             arg_list (ListLike[BoolExprLike]): List of expressions or constants, to be xor'ed
+                (at least one required)
         """
         if not all(is_boolexpr(arg) for arg in arg_list):
             raise TypeError("Only Boolean arguments allowed in Xor global constraint: {}".format(arg_list))
@@ -2270,12 +2297,15 @@ class GlobalCardinalityCount(GlobalConstraint):
 class Increasing(GlobalConstraint):
     """
     Enforces that the expressions are assigned to (non-strictly) increasing values.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to increasing values
+                (at least one required)
         """
         flatargs = flatlist(args)
         if len(flatargs) == 0:
@@ -2306,12 +2336,15 @@ class Increasing(GlobalConstraint):
 class Decreasing(GlobalConstraint):
     """
     Enforces that the expressions are assigned to (non-strictly) decreasing values.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to decreasing values
+                (at least one required)
         """
         flatargs = flatlist(args)
         if len(flatargs) == 0:
@@ -2342,12 +2375,15 @@ class Decreasing(GlobalConstraint):
 class IncreasingStrict(GlobalConstraint):
     """
     Enforces that the expressions are assigned to strictly increasing values.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly increasing values
+                (at least one required)
         """
         flatargs = flatlist(args)
         if len(flatargs) == 0:
@@ -2379,12 +2415,15 @@ class IncreasingStrict(GlobalConstraint):
 class DecreasingStrict(GlobalConstraint):
     """
     Enforces that the expressions are assigned to strictly decreasing values.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, *args: ExprLike | ListLike[ExprLike]):
         """
         Arguments:
             args (ListLike[ExprLike]): List of expressions or constants to be assigned to strictly decreasing values
+                (at least one required)
         """
         flatargs = flatlist(args)
         if len(flatargs) == 0:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -279,11 +279,12 @@ class AllDifferentExceptN(GlobalConstraint):
     """
     Enforces that all arguments, except those equal to a value in n, have a different (distinct) value.
 
-    Requires at least one argument in ``arr`` (arity >= 1).
+    Requires at least one argument in ``arr`` (arity >= 1) and a non-empty exception set ``n``.
 
     Arguments:
         arr (Sequence[Expression]): List of expressions to be different from each other, except those equal to a value in n
         n (int or list[int]): Value or list of values that are excluded from satisfying the alldifferent condition
+            (at least one required)
     """
 
     def __init__(self, arr: ListLike[ExprLike], n: int|np.integer|list[int|np.integer]):
@@ -292,6 +293,7 @@ class AllDifferentExceptN(GlobalConstraint):
             arr (ListLike[ExprLike]): List of expressions or constants to be different from each other, except those equal to a value in n
                 (at least one required)
             n (int | np.integer | list[int | np.integer]): Value or list of values that are excluded from the distinctness constraint
+                (at least one required)
         """
         flatarr = flatlist(arr)
         if len(flatarr) == 0:
@@ -299,6 +301,8 @@ class AllDifferentExceptN(GlobalConstraint):
         if not is_any_list(n):
             n = cast(int, n)
             n = [n] # ensure n is a list of ints
+        if len(n) == 0:
+            raise ValueError('AllDifferentExceptN constraint must be given at least one excluded value')
         super().__init__("alldifferent_except_n", (flatarr, n))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -2677,15 +2677,20 @@ class LexChainLess(GlobalConstraint):
 class LexChainLessEq(GlobalConstraint):
     """ 
     Enforces that all rows of the matrix are lexicographically ordered (less or equal)
+
+    Requires a non-empty 2D matrix (at least one row and one column).
     """
     def __init__(self, X: ListLike[ListLike[ExprLike]]):
         """
         Arguments:
             X (ListLike[ListLike[ExprLike]]): Matrix (List of lists) of expressions or constants to be compared lexicographically
+                (non-empty 2D matrix required)
         """
         Xarr = np.array(X) # also checks length of each row is equal
         if Xarr.ndim != 2:
             raise ValueError(f"The matrix given in LexChainLessEq must be 2D, but got {Xarr.ndim} dimensions")
+        if 0 in Xarr.shape:
+            raise ValueError('LexChainLessEq constraint must be given a non-empty 2D matrix')
         super().__init__("lex_chain_lesseq", tuple(Xarr.tolist()))
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -617,8 +617,10 @@ class Table(GlobalConstraint):
             table = np.array(table, dtype=int)
         elif table.dtype.kind != 'i':  # dtype int
             table = table.astype(int, copy=False)
-        assert table.ndim == 2, "Table's table must be a 2D array"
-        assert table.shape[1] == len(array), f"Table width {table.shape[1]} != array length {len(array)}"
+        if table.ndim != 2:
+            raise ValueError("Table's table must be a 2D array")
+        if table.shape[1] != len(array):
+            raise ValueError(f"Table width {table.shape[1]} != array length {len(array)}")
 
         # args: tuple[ListLike[Expression], np.ndarray]
         super().__init__("table", (array, table), has_subexpr=has_subexpr)
@@ -774,8 +776,10 @@ class ShortTable(GlobalConstraint):
 
         if not isinstance(table, np.ndarray):
             table = np.array(table, dtype=object)  # object, otherwise np makes it all string
-        assert table.ndim == 2, "ShortTable's table must be a 2D array"
-        assert table.shape[1] == len(array), f"ShortTable width {table.shape[1]} != array length {len(array)}"
+        if table.ndim != 2:
+            raise ValueError("ShortTable's table must be a 2D array")
+        if table.shape[1] != len(array):
+            raise ValueError(f"ShortTable width {table.shape[1]} != array length {len(array)}")
 
         # args: tuple[ListLike[Expression], np.ndarray]
         super().__init__("short_table", (array, table), has_subexpr=has_subexpr)
@@ -864,8 +868,10 @@ class NegativeTable(GlobalConstraint):
             table = np.array(table, dtype=int)
         elif table.dtype.kind != 'i':  # dtype int
             table = table.astype(int, copy=False)
-        assert table.ndim == 2, "NegativeTable's table must be a 2D array"
-        assert table.shape[1] == len(array), f"NegativeTable width {table.shape[1]} != array length {len(array)}"
+        if table.ndim != 2:
+            raise ValueError("NegativeTable's table must be a 2D array")
+        if table.shape[1] != len(array):
+            raise ValueError(f"NegativeTable width {table.shape[1]} != array length {len(array)}")
 
         # args: tuple[ListLike[Expression], np.ndarray]
         super().__init__("negative_table", (array, table), has_subexpr=has_subexpr)

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -812,7 +812,8 @@ class Element(GlobalFunction):
                 raise TypeError("Element only supports 1D arrays. Use NDElement for multi-dimensional arrays.")
         elif is_any_list(arr) and any(is_any_list(el) for el in arr):
             raise TypeError("Element only supports 1D arrays. Use NDElement for multi-dimensional arrays.")
-        assert len(arr) > 0, "Element: array should not be empty"
+        if len(arr) == 0:
+            raise ValueError('Element function must be given at least one argument')
 
         super().__init__("element", (arr, idx))
 

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -188,13 +188,16 @@ class GlobalFunction(Expression):
 
 class Minimum(GlobalFunction):
     """
-    Computes the minimum value of the arguments
+    Computes the minimum value of the arguments.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, arg_list: ListLike[ExprLike]):
         """
         Arguments:
             arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the minimum
+                (at least one required)
         """
         has_subexpr: Optional[bool] = None
 
@@ -206,6 +209,8 @@ class Minimum(GlobalFunction):
 
         # convert numpy integers to Python integers
         args: tuple[int|Expression, ...] = npint2int(arg_iter)
+        if len(args) == 0:
+            raise ValueError('Minimum function must be given at least one argument')
         super().__init__("min", args, has_subexpr=has_subexpr)
     
     @property
@@ -250,13 +255,16 @@ class Minimum(GlobalFunction):
 
 class Maximum(GlobalFunction):
     """
-    Computes the maximum value of the arguments
+    Computes the maximum value of the arguments.
+
+    Requires at least one argument (arity >= 1).
     """
 
     def __init__(self, arg_list: ListLike[ExprLike]):
         """
         Arguments:
             arg_list (ListLike[ExprLike]): List of expressions or constants of which to compute the maximum
+                (at least one required)
         """
         has_subexpr: Optional[bool] = None
 
@@ -268,6 +276,8 @@ class Maximum(GlobalFunction):
 
         # convert numpy integers to Python integers
         args: tuple[int|Expression, ...] = npint2int(arg_iter)
+        if len(args) == 0:
+            raise ValueError('Maximum function must be given at least one argument')
         super().__init__("max", args, has_subexpr=has_subexpr)
 
     @property
@@ -774,6 +784,8 @@ class Element(GlobalFunction):
     Its return value will be the value of the array element at the index specified by the decision
     variable's value.
 
+    Requires a non-empty array (``arr`` arity >= 1).
+
     When you index into a :class:`NDVarArray <cpmpy.expressions.variables.NDVarArray>` (e.g. when creating a `Arr=boolvar(shape=...)` or
     `Arr=intvar(lb,ub, shape=...)` using :func:`boolvar() <cpmpy.expressions.variables.boolvar>` or :func:`intvar() <cpmpy.expressions.variables.intvar>`), or index into a list wrapped as `Arr = cpm_array(lst)` using :func:`cpm_array() <cpmpy.expressions.variables.cpm_array>`,
     then using standard Python indexing, e.g. `Arr[Idx]` with `Idx` an integer decision variable,
@@ -789,6 +801,7 @@ class Element(GlobalFunction):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to index into
+                (at least one required)
             idx (Expression): Integer expression for the index (not a Boolean expression)
         """
         assert isinstance(idx, Expression), f"Element(arr, idx) takes an integer expression as second argument, got {type(idx)}: {idx}"
@@ -1135,6 +1148,10 @@ class NValue(GlobalFunction):
     """
     The NValue global function counts the number of distinct values in an array.
 
+    Requires at least one argument in ``arr`` (arity >= 1). Empty arrays are rejected:
+    while mathematically the result would be 0, an empty NValue usually indicates a
+    construction mistake.
+
     For example, if variables [x1, x2, x3, x4] take values [1, 2, 1, 3] respectively,
     then `NValue([x1, x2, x3, x4])` returns 3 (the distinct values are 1, 2, and 3).
     """
@@ -1143,9 +1160,12 @@ class NValue(GlobalFunction):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to count distinct values in
+                (at least one required)
         """
         if not is_any_list(arr):
             raise ValueError(f"NValue(arr) takes an array as input, not: {arr}")
+        if len(arr) == 0:
+            raise ValueError('NValue function must be given at least one argument')
         super().__init__("nvalue", tuple(arr))
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
@@ -1196,6 +1216,10 @@ class NValueExcept(GlobalFunction):
     The NValueExcept global function counts the number of distinct values in an array,
     excluding a specified value.
 
+    Requires at least one argument in ``arr`` (arity >= 1). Empty arrays are rejected:
+    while mathematically the result would be 0, an empty NValueExcept usually indicates a
+    construction mistake.
+
     For example, if variables [x1, x2, x3, x4] take values [1, 2, 1, 0] respectively,
     then `NValueExcept([x1, x2, x3, x4], 0)` returns 2 (the distinct values are 1 and 2,
     excluding 0).
@@ -1205,10 +1229,13 @@ class NValueExcept(GlobalFunction):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to count distinct values in
+                (at least one required)
             n (int | np.integer): Integer constant to exclude from the count
         """
         if not is_any_list(arr):
             raise ValueError("NValueExcept takes an array as input")
+        if len(arr) == 0:
+            raise ValueError('NValueExcept function must be given at least one argument')
         if not is_num(n):
             raise ValueError(f"NValueExcept takes an integer as second argument, but got {n} of type {type(n)}")
         super().__init__("nvalue_except", (arr, n))

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -1033,17 +1033,22 @@ def element(arg_list):
 
 class Count(GlobalFunction):
     """
-    The Count global function represents the number of occurrences of a value in an array
+    The Count global function represents the number of occurrences of a value in an array.
+
+    Requires a non-empty ``arr`` (arity >= 1).
     """
 
     def __init__(self, arr: ListLike[ExprLike], val: ExprLike):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to count in
+                (at least one required)
             val (ExprLike): 'Value' to count occurences of (can also be an expression)
         """
         if not is_any_list(arr):
             raise TypeError(f"Count(arr, val) takes an array of expressions as first argument, not: {arr}")
+        if len(arr) == 0:
+            raise ValueError('Count function must be given at least one argument')
         if is_any_list(val):
             raise TypeError(f"Count(arr, val) takes a numeric expression as second argument, not a list: {val}")
         super().__init__("count", (arr, val))

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -907,6 +907,8 @@ class NDElement(GlobalFunction):
     """
     The `NDElement(Arr, Indices)` global function allows indexing into a multi-dimensional array
     with multiple decision variables.
+
+    Requires a non-empty array (no zero-size dimensions).
     """
 
     def __init__(self, arr: ListLike[ExprLike], indices: ListLike[Expression]):
@@ -930,6 +932,8 @@ class NDElement(GlobalFunction):
 
         if nd_array.ndim <= 1:
             raise TypeError("NDElement only supports multi-dimensional arrays. Use cpmpy.globalfunctions.Element for 1D arrays.")
+        if 0 in nd_array.shape:
+            raise ValueError('NDElement function must be given a non-empty array')
         if len(indices) != nd_array.ndim:
             raise ValueError(f"NDElement expects {nd_array.ndim} indices, got {len(indices)}")
 

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -1100,16 +1100,24 @@ class Among(GlobalFunction):
     This is similar to :class:`Count <cpmpy.expressions.globalfunctions.Count>`, but instead of counting occurrences of a single value,
     it counts occurrences of any value in a set. For example, `Among([x1, x2, x3, x4], [1, 2])`
     returns the number of variables among x1, x2, x3, x4 that take the value 1 or 2.
+
+    Requires a non-empty ``arr`` and a non-empty ``vals`` (arity >= 1).
     """
 
     def __init__(self, arr: ListLike[ExprLike], vals: ListLike[int|np.integer]):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to count occurrences in
+                (at least one required)
             vals (ListLike[int | np.integer]): List of integer constants whose occurrences are counted
+                (at least one required)
         """
         if not is_any_list(arr) or not is_any_list(vals):
             raise TypeError(f"Among takes as input two arrays, not: {arr} and {vals}")
+        if len(arr) == 0:
+            raise ValueError('Among function must be given at least one `arr` argument')
+        if len(vals) == 0:
+            raise ValueError('Among function must be given at least one value in `vals`')
         if any(isinstance(val, Expression) for val in vals):
             raise TypeError(f"Among takes a set of integer values as input, not {vals}")
         super().__init__("among", (arr, vals))

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -297,9 +297,14 @@ class TestGlobal:
         assert model.solve()
         assert iv.value() in vals
 
-        # Test InDomain with empty list (should be unsat)
-        model = cp.Model([cp.InDomain(iv, [])])
-        assert not model.solve()
+        # Test InDomain with empty list (construction mistake)
+        pytest.raises(ValueError, cp.InDomain, iv, [])
+
+        # Negating a covering domain must not construct an empty InDomain
+        covering = list(range(-8, 9))
+        neg = cp.InDomain(iv, covering).negate()
+        assert neg.value() is False
+        assert not cp.Model([~cp.InDomain(iv, covering)]).solve()
 
         # Test InDomain with singleton list
         model = cp.Model([cp.InDomain(iv, [1])])
@@ -1839,9 +1844,11 @@ class TestTypeChecks:
         """Globals that require a non-empty argument list must raise ValueError on empty input."""
         pytest.raises(ValueError, cp.AllDifferent, [])
         pytest.raises(ValueError, cp.AllDifferentExceptN, [], 0)
+        pytest.raises(ValueError, cp.AllDifferentExceptN, [cp.intvar(0, 1)], [])
         pytest.raises(ValueError, cp.AllDifferentExcept0, [])
         pytest.raises(ValueError, cp.AllEqual, [])
         pytest.raises(ValueError, cp.AllEqualExceptN, [], 0)
+        pytest.raises(ValueError, cp.AllEqualExceptN, [cp.intvar(0, 1)], [])
         pytest.raises(ValueError, cp.Xor, [])
         pytest.raises(ValueError, cp.Increasing, [])
         pytest.raises(ValueError, cp.Decreasing, [])
@@ -1855,10 +1862,42 @@ class TestTypeChecks:
         pytest.raises(ValueError, cp.Maximum, [])
         pytest.raises(ValueError, cp.NValue, [])
         pytest.raises(ValueError, cp.NValueExcept, [], 0)
+        pytest.raises(ValueError, cp.Count, [], 0)
+        pytest.raises(ValueError, cp.Among, [], [0])
+        pytest.raises(ValueError, cp.Among, [cp.intvar(0, 1)], [])
+        pytest.raises(ValueError, cp.GlobalCardinalityCount, [], [0], [0])
+        pytest.raises(ValueError, cp.GlobalCardinalityCount, [cp.intvar(0, 1)], [], [])
+        pytest.raises(ValueError, cp.Element, [], cp.intvar(0, 1))
+        pytest.raises(ValueError, cp.Inverse, [], [])
+        pytest.raises(ValueError, cp.Table, [], [[]])
+        pytest.raises(ValueError, cp.Table, [cp.intvar(0, 1)], [])
+        pytest.raises(ValueError, cp.Table, [cp.intvar(0, 1)], np.empty((0, 1), dtype=int))
+        pytest.raises(ValueError, cp.ShortTable, [], [[]])
+        pytest.raises(ValueError, cp.ShortTable, [cp.intvar(0, 1)], [])
+        pytest.raises(ValueError, cp.ShortTable, [cp.intvar(0, 1)], np.empty((0, 1), dtype=object))
+        pytest.raises(ValueError, cp.NegativeTable, [], [[]])
+        pytest.raises(ValueError, cp.NegativeTable, [cp.intvar(0, 1)], [])
+        pytest.raises(ValueError, cp.NegativeTable, [cp.intvar(0, 1)], np.empty((0, 1), dtype=int))
+        pytest.raises(ValueError, cp.InDomain, cp.intvar(0, 1), [])
+        pytest.raises(ValueError, cp.Regular, [cp.intvar(0, 1)], [], "A", ["A"])
+        pytest.raises(ValueError, cp.Regular, [cp.intvar(0, 1)], [("A", 0, "A")], "A", [])
+        pytest.raises(ValueError, cp.MDD, [cp.intvar(0, 1)], [])
+        pytest.raises(ValueError, cp.NDElement, np.empty((2, 0), dtype=object), [cp.intvar(0, 1), cp.intvar(0, 1)])
+        pytest.raises(ValueError, cp.Cumulative, [], [], None, [], 1)
+        pytest.raises(ValueError, cp.CumulativeOptional, [], [], None, [], 1, [])
+        pytest.raises(ValueError, cp.NoOverlap, [], [])
+        pytest.raises(ValueError, cp.NoOverlapOptional, [], [], None, [])
+        pytest.raises(ValueError, cp.Precedence, [], [0, 1])
+        pytest.raises(ValueError, cp.Precedence, [cp.intvar(0, 1)], [])
+        pytest.raises(ValueError, cp.LexLess, [], [])
+        pytest.raises(ValueError, cp.LexLessEq, [], [])
+        pytest.raises(ValueError, cp.LexChainLess, np.empty((0, 2)))
+        pytest.raises(ValueError, cp.LexChainLessEq, np.empty((2, 0)))
         from cpmpy.expressions.core import Operator
         pytest.raises(ValueError, Operator, "and", [])
         pytest.raises(ValueError, Operator, "or", [])
         pytest.raises(ValueError, Operator, "sum", [])
+        pytest.raises(ValueError, Operator, "wsum", [[], []])
 
     def test_multicicruit(self):
         c1 = cp.Circuit(cp.intvar(0,4, shape=5))

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1835,6 +1835,31 @@ class TestTypeChecks:
         assert cp.Model([cp.Circuit(x+2,2,0)]).solve()
         assert cp.Model([cp.Circuit(a,b)]).solve()
 
+    def test_minimal_arity(self):
+        """Globals that require a non-empty argument list must raise ValueError on empty input."""
+        pytest.raises(ValueError, cp.AllDifferent, [])
+        pytest.raises(ValueError, cp.AllDifferentExceptN, [], 0)
+        pytest.raises(ValueError, cp.AllDifferentExcept0, [])
+        pytest.raises(ValueError, cp.AllEqual, [])
+        pytest.raises(ValueError, cp.AllEqualExceptN, [], 0)
+        pytest.raises(ValueError, cp.Xor, [])
+        pytest.raises(ValueError, cp.Increasing, [])
+        pytest.raises(ValueError, cp.Decreasing, [])
+        pytest.raises(ValueError, cp.IncreasingStrict, [])
+        pytest.raises(ValueError, cp.DecreasingStrict, [])
+        pytest.raises(ValueError, cp.Circuit, [])
+        pytest.raises(ValueError, cp.Circuit, [cp.intvar(0, 1)])  # arity >= 2
+        pytest.raises(ValueError, cp.Regular, [], [("A", 0, "A")], "A", ["A"])
+        pytest.raises(ValueError, cp.MDD, [], [("A", 0, "B")])
+        pytest.raises(ValueError, cp.Minimum, [])
+        pytest.raises(ValueError, cp.Maximum, [])
+        pytest.raises(ValueError, cp.NValue, [])
+        pytest.raises(ValueError, cp.NValueExcept, [], 0)
+        from cpmpy.expressions.core import Operator
+        pytest.raises(ValueError, Operator, "and", [])
+        pytest.raises(ValueError, Operator, "or", [])
+        pytest.raises(ValueError, Operator, "sum", [])
+
     def test_multicicruit(self):
         c1 = cp.Circuit(cp.intvar(0,4, shape=5))
         c2 = cp.Circuit(cp.intvar(0,2, shape=3))


### PR DESCRIPTION
Part of #1077 

Adds missing arity checks to some global functions and constraints and some cleanup for existing checks in operators.

Whilst technically / logically some constraints allow for 0-arity, this is most likely an indication of user error. We thus chose to raise an error to catch these mistakes instead of supporting these edge-cases (which don't add any modeling expressiveness). Some user-facing apis do still support them, like `cp.all([])`, but the model-facing `cp.Operator("And", [])` is not. 