### PR TITLE
Simplify trivial arity And/Or

### DIFF
--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -125,7 +125,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                     newargs.append(a)
 
             if newargs is None:
-                newargs = args
+                newargs = list(args)
 
             if len(newargs) == 0: # empty disjunction
                 return True, BoolVal(False)
@@ -150,7 +150,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                     newargs.append(a)
 
             if newargs is None: # when args where simplified recursively above
-                newargs = args
+                newargs = list(args)
 
             if len(newargs) == 0: # empty conjunction
                 return True, BoolVal(True)

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -128,7 +128,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                 newargs = list(args)
 
             if len(newargs) == 0: # empty disjunction
-                return True, BoolVal(False)
+                return True, (0 if num_context else BoolVal(False))
             elif len(newargs) == 1: # single argument, drop the operator
                 return True, newargs[0]
             elif changed:
@@ -153,7 +153,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                 newargs = list(args)
 
             if len(newargs) == 0: # empty conjunction
-                return True, BoolVal(True)
+                return True, (1 if num_context else BoolVal(True))
             elif len(newargs) == 1: # single argument, drop the operator
                 return True, newargs[0]
             elif changed:

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -116,7 +116,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
             newargs = None
             for i, a in enumerate(args):
                 if is_true_cst(a):
-                    return True, BoolVal(True)
+                    return True, (1 if num_context else BoolVal(True))
                 elif is_false_cst(a):
                     changed = True
                     if newargs is None:
@@ -141,7 +141,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
             newargs = None
             for i, a in enumerate(args):
                 if is_false_cst(a):
-                    return True, BoolVal(False)
+                    return True, (0 if num_context else BoolVal(False))
                 elif is_true_cst(a):
                     changed = True
                     if newargs is None:
@@ -165,13 +165,13 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
         elif expr.name == "->":
             cond, bool_expr = args
             if is_false_cst(cond) or is_true_cst(bool_expr):
-                return True, BoolVal(True)
+                return True, (1 if num_context else BoolVal(True))
             elif is_true_cst(cond):
                 if is_bool(bool_expr):
-                    return True, BoolVal(bool_expr)
+                    return True, (int(bool_expr) if num_context else BoolVal(bool_expr))
                 return True, bool_expr
             elif is_false_cst(bool_expr):
-                _, newcond = _simplify_boolean_expr(recurse_negation(cond), num_context=False)
+                _, newcond = _simplify_boolean_expr(recurse_negation(cond), num_context=num_context)
                 # always changed, because negated cond
                 return True, newcond
 
@@ -254,10 +254,9 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
         """
         if isinstance(lhs, Expression) and lhs.is_bool() and is_num(rhs):
             # direct simplification of boolean comparisons
-            if isinstance(rhs, BoolVal):
-                rhs = int(rhs.value())
             if rhs < 0:
-                return True, BoolVal(name in  {"!=", ">", ">="}) # all other operators evaluate to False
+                val = name in {"!=", ">", ">="} # all other operators evaluate to False
+                return True, (int(val) if num_context else BoolVal(val))
             elif rhs == 0:
                 if name == "!=" or name == ">":
                     return True, lhs
@@ -279,7 +278,8 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                 if name == "<=":
                     return True, (1 if num_context else BoolVal(True))
             elif rhs > 1:
-                return True, BoolVal(name in {"!=", "<", "<="}) # all other operators evaluate to False
+                val = name in {"!=", "<", "<="} # all other operators evaluate to False
+                return True, (int(val) if num_context else BoolVal(val))
 
         # normalize comparison orientation to keep expression on lhs
         if is_num(lhs) and isinstance(rhs, Expression):

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -62,6 +62,8 @@ def simplify_boolean(lst_of_expr: list[Expression], num_context=False) -> list[E
     Boolean constants are promoted to integers in numerical context (e.g. in wsum);
     integers are never converted to Booleans. 
 
+    Conjunctions and disjunctions that end up with a single argument are replaced by that argument.
+
     Arguments:
         lst_of_expr (list[Expression]): list of CPMpy expressions
         num_context (bool): whether the expressions are used as numeric arguments (default: False)
@@ -122,9 +124,14 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                 elif newargs is not None:
                     newargs.append(a)
 
-            if changed:
-                if newargs is None: # when args where simplified recursively above
-                    newargs = list(args)
+            if newargs is None:
+                newargs = args
+
+            if len(newargs) == 0: # empty disjunction
+                return True, BoolVal(False)
+            elif len(newargs) == 1: # single argument, drop the operator
+                return True, newargs[0]
+            elif changed:
                 newexpr = copy.copy(expr)
                 newexpr.update_args(newargs)
                 return True, newexpr
@@ -142,9 +149,14 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
                 elif newargs is not None:
                     newargs.append(a)
 
-            if changed:
-                if newargs is None: # when args where simplified recursively above
-                    newargs = list(args)
+            if newargs is None: # when args where simplified recursively above
+                newargs = args
+
+            if len(newargs) == 0: # empty conjunction
+                return True, BoolVal(True)
+            elif len(newargs) == 1: # single argument, drop the operator
+                return True, newargs[0]
+            elif changed:
                 newexpr = copy.copy(expr)
                 newexpr.update_args(newargs)
                 return True, newexpr

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -37,6 +37,27 @@ class TestTransSimplify:
         expr = Operator("->", [False, self.bvs[0]])
         assert str(self.transform(expr)) == "[boolval(True)]"
 
+    def test_degenerate_bool_ops(self):
+        bv = self.bvs
+
+        # a single argument does not need the operator
+        assert str(simplify_boolean([Operator("or", [bv[0]])])) == "[bv[0]]"
+        assert str(simplify_boolean([Operator("and", [bv[0]])])) == "[bv[0]]"
+        # also when the other arguments are constants that get removed
+        assert str(simplify_boolean([Operator("or", [bv[0], False])])) == "[bv[0]]"
+        assert str(simplify_boolean([Operator("and", [bv[0], True])])) == "[bv[0]]"
+        # nothing left, so the identity element of the operator
+        assert str(simplify_boolean([Operator("or", [False, False])])) == "[boolval(False)]"
+        assert str(simplify_boolean([Operator("and", [True, True])])) == "[boolval(True)]"
+
+        # also in a nested context
+        assert str(self.transform(Operator("or", [bv[0]]) == bv[1])) == "[(bv[0]) == (bv[1])]"
+        assert str(self.transform(Operator("and", [bv[0]]).implies(bv[1]))) == "[(bv[0]) -> (bv[1])]"
+        assert str(self.transform(Operator("or", [Operator("and", [bv[0]]), bv[1]]))) == "[(bv[0]) or (bv[1])]"
+
+        # more than one argument is left untouched
+        assert str(simplify_boolean([Operator("or", [bv[0], bv[1]])])) == "[(bv[0]) or (bv[1])]"
+
     def test_bool_in_comp(self):
         expr = self.ivs[0] >= False
         assert str(self.transform(expr)) == '[iv[0] >= 0]'

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -46,17 +46,25 @@ class TestTransSimplify:
         # also when the other arguments are constants that get removed
         assert str(simplify_boolean([Operator("or", [bv[0], False])])) == "[bv[0]]"
         assert str(simplify_boolean([Operator("and", [bv[0], True])])) == "[bv[0]]"
+        assert str(simplify_boolean([Operator("or", [bv[0], BoolVal(False)])])) == "[bv[0]]"
+        assert str(simplify_boolean([Operator("and", [bv[0], BoolVal(True)])])) == "[bv[0]]"
         # nothing left, so the identity element of the operator
         assert str(simplify_boolean([Operator("or", [False, False])])) == "[boolval(False)]"
         assert str(simplify_boolean([Operator("and", [True, True])])) == "[boolval(True)]"
+        assert str(simplify_boolean([Operator("or", [BoolVal(False), BoolVal(False)])])) == "[boolval(False)]"
+        assert str(simplify_boolean([Operator("and", [BoolVal(True), BoolVal(True)])])) == "[boolval(True)]"
 
         # also in a nested context
         assert str(self.transform(Operator("or", [bv[0]]) == bv[1])) == "[(bv[0]) == (bv[1])]"
         assert str(self.transform(Operator("and", [bv[0]]).implies(bv[1]))) == "[(bv[0]) -> (bv[1])]"
         assert str(self.transform(Operator("or", [Operator("and", [bv[0]]), bv[1]]))) == "[(bv[0]) or (bv[1])]"
 
-        # more than one argument is left untouched
-        assert str(simplify_boolean([Operator("or", [bv[0], bv[1]])])) == "[(bv[0]) or (bv[1])]"
+        # empty and/or in a numerical context become 0/1, not BoolVal
+        iv = self.ivs[0]
+        assert str(self.transform(iv + Operator("or", [False, False]) >= 10)) == "[(iv[0]) + 0 >= 10]"
+        assert str(self.transform(iv + Operator("and", [True, True]) >= 10)) == "[(iv[0]) + 1 >= 10]"
+        assert str(self.transform(iv >= Operator("or", [False, False]))) == "[iv[0] >= 0]"
+        assert str(self.transform(iv >= Operator("and", [True, True]))) == "[iv[0] >= 1]"
 
     def test_bool_in_comp(self):
         expr = self.ivs[0] >= False

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -1,3 +1,5 @@
+import pytest
+
 import cpmpy as cp
 from cpmpy.expressions.core import Operator, BoolVal, Comparison
 from cpmpy.transformations.negation import push_down_negation
@@ -17,12 +19,18 @@ class TestTransSimplify:
         assert str(self.transform(expr)) == "[or(bv[0], bv[1], bv[2])]"
         expr = Operator("or", self.bvs.tolist() + [True])
         assert str(self.transform(expr)) == "[boolval(True)]"
+        # False not at the end: remaining args after the constant must be kept
+        expr = Operator("or", [self.bvs[0], False, self.bvs[1]])
+        assert str(self.transform(expr)) == "[(bv[0]) or (bv[1])]"
 
         expr = Operator("and", self.bvs.tolist() + [False]) + self.ivs[0] >= 10
         assert str(self.transform(expr)) == "[0 + (iv[0]) >= 10]"
         expr = Operator("and", self.bvs.tolist() + [True]) + self.ivs[0] >= 10
         assert str(self.transform(expr)) == "[(and(bv[0], bv[1], bv[2])) + (iv[0]) >= 10]"
-
+        # toplevel_list would split a toplevel and, so call simplify_boolean directly
+        assert str(simplify_boolean([Operator("and", self.bvs.tolist() + [False])])) == "[boolval(False)]"
+        assert str(simplify_boolean([Operator("and", [self.bvs[0], True, self.bvs[1]])])) == "[(bv[0]) and (bv[1])]"
+        assert str(simplify_boolean([Operator("and", [self.bvs[0], self.bvs[1]])])) == "[(bv[0]) and (bv[1])]"
 
         expr = Operator("->", [self.bvs[0], True])
         assert str(self.transform(expr)) == "[boolval(True)]"
@@ -36,6 +44,30 @@ class TestTransSimplify:
         assert str(self.transform(expr)) == "[bv[0]]"
         expr = Operator("->", [False, self.bvs[0]])
         assert str(self.transform(expr)) == "[boolval(True)]"
+        expr = Operator("->", [True, True])
+        assert str(self.transform(expr)) == "[boolval(True)]"
+        expr = Operator("->", [True, False])
+        assert str(self.transform(expr)) == "[boolval(False)]"
+        expr = Operator("->", [self.bvs[0], self.bvs[1]])
+        assert str(self.transform(expr)) == "[(bv[0]) -> (bv[1])]"
+        # cond simplified recursively, implication itself stays
+        expr = Operator("->", [Operator("or", [self.bvs[0], False]), self.bvs[1]])
+        assert str(self.transform(expr)) == "[(bv[0]) -> (bv[1])]"
+
+        # Boolean constants that fold an or/and/-> become 0/1 in a numerical context
+        iv = self.ivs[0]
+        expr = iv + Operator("or", self.bvs.tolist() + [True]) >= 10
+        assert str(self.transform(expr)) == "[(iv[0]) + 1 >= 10]"
+        expr = iv + Operator("->", [False, self.bvs[0]]) >= 10
+        assert str(self.transform(expr)) == "[(iv[0]) + 1 >= 10]"
+        expr = iv + Operator("->", [self.bvs[0], True]) >= 10
+        assert str(self.transform(expr)) == "[(iv[0]) + 1 >= 10]"
+        expr = iv + Operator("->", [True, True]) >= 10
+        assert str(self.transform(expr)) == "[(iv[0]) + 1 >= 10]"
+        expr = iv + Operator("->", [True, False]) >= 10
+        assert str(self.transform(expr)) == "[(iv[0]) + 0 >= 10]"
+        expr = iv + Operator("->", [self.bvs[0], False]) >= 10
+        assert str(self.transform(expr)) == "[(iv[0]) + (~bv[0]) >= 10]"
 
     def test_degenerate_bool_ops(self):
         bv = self.bvs
@@ -78,6 +110,11 @@ class TestTransSimplify:
         expr = True + self.ivs[0] >= False
         assert str(self.transform(expr)) == '[1 + (iv[0]) >= 0]'
 
+        expr = Operator("sum", [True, False, self.ivs[0]]) >= 10
+        assert str(self.transform(expr)) == '[sum(1, 0, iv[0]) >= 10]'
+        expr = cp.sum(self.ivs) >= 10
+        assert str(self.transform(expr)) == '[sum(iv[0], iv[1], iv[2]) >= 10]'
+
     def test_boolvar_comps(self):
         num_args = {"<0": -1, "0": 0, "1": 1, ">0": 2}
         # test table from github (#add url)
@@ -97,6 +134,38 @@ class TestTransSimplify:
                 print(expr)
                 expr_should = BoolVal(val_should) if isinstance(val_should, bool) else val_should
                 assert str(self.transform(expr)) == str([expr_should])
+
+                # same comparison in a numerical context: True/False fold to 1/0
+                num_expr = self.ivs[0] + Comparison(op, bv, num_args[rhs]) >= 10
+                if isinstance(val_should, bool):
+                    assert str(self.transform(num_expr)) == f"[(iv[0]) + {int(val_should)} >= 10]"
+                else:
+                    assert str(self.transform(num_expr)) == f"[(iv[0]) + ({val_should}) >= 10]"
+
+        # comparisons written with the number on the left are flipped onto the table above
+        assert str(self.transform(Comparison("<", 0, bv))) == "[bv[0]]"
+        assert str(self.transform(Comparison(">", 0, bv))) == "[boolval(False)]"
+        assert str(self.transform(Comparison("<=", 0, bv))) == "[boolval(True)]"
+        assert str(self.transform(Comparison(">=", 0, bv))) == "[~bv[0]]"
+        assert str(self.transform(Comparison("==", bv, BoolVal(True)))) == "[bv[0]]"
+        assert str(self.transform(Comparison("==", bv, BoolVal(False)))) == "[~bv[0]]"
+
+        # integer-vs-integer comparisons keep the expression on the lhs
+        iv = self.ivs[0]
+        assert str(self.transform(Comparison("<", 0, iv))) == "[iv[0] > 0]"
+        assert str(self.transform(Comparison(">", 5, iv))) == "[iv[0] < 5]"
+        assert str(self.transform(Comparison("<=", 0, iv))) == "[iv[0] >= 0]"
+        assert str(self.transform(Comparison(">=", 5, iv))) == "[iv[0] <= 5]"
+        assert str(self.transform(Comparison("==", 1, iv))) == "[iv[0] == 1]"
+
+        # two numeric constants: eval_comparison folds to a Boolean, 0/1 in numerical context
+        assert str(self.transform(Comparison(">=", 3, 5))) == "[boolval(False)]"
+        assert str(self.transform(Comparison("==", 1, 1))) == "[boolval(True)]"
+        assert str(self.transform(iv + Comparison(">=", 3, 5) >= 10)) == "[(iv[0]) + 0 >= 10]"
+        assert str(self.transform(iv + Comparison("==", 1, 1) >= 10)) == "[(iv[0]) + 1 >= 10]"
+
+        with pytest.raises(ValueError, match="floating point"):
+            self.transform(Comparison("<", bv, 0.5))
 
 
     def test_simplify_expressions(self):
@@ -121,6 +190,11 @@ class TestTransSimplify:
         assert str(self.transform(expr)) == '[max(iv[0],iv[1],iv[2],boolval(False)) == 0]'
         expr = 0 == cp.max(self.ivs.tolist() + [True])
         assert str(self.transform(expr)) == '[max(iv[0],iv[1],iv[2],boolval(True)) == 0]'
+
+        expr = ~cp.AllDifferent(self.ivs)
+        assert str(self.transform(expr)) == '[not(alldifferent(iv[0],iv[1],iv[2]))]'
+        expr = ~cp.AllDifferent(self.ivs.tolist() + [False])
+        assert str(self.transform(expr)) == '[not(alldifferent(iv[0],iv[1],iv[2],boolval(False)))]'
 
         expr = (self.ivs[0] <= self.ivs[1]) == 0
         assert str(self.transform(expr)) == '[(iv[0]) > (iv[1])]'
@@ -148,3 +222,12 @@ class TestTransSimplify:
         cons = sum( weights * (bv != bool_as_ints) ) == 1
         assert str(self.transform(cons)) == "[sum([1, 2] * [bv[0], ~bv[1]]) == 1]"
         assert cp.Model(cons).solve()
+
+        # Boolean constants in a wsum become integers; an already-integer wsum is unchanged
+        iv = self.ivs
+        cons = Operator("wsum", [[1, 2, 3], [iv[0], True, iv[1]]]) == 1
+        assert str(self.transform(cons)) == "[sum([1, 2, 3] * [iv[0], 1, iv[1]]) == 1]"
+        cons = Operator("wsum", [[1, 2, 3], [True, False, iv[0]]]) == 1
+        assert str(self.transform(cons)) == "[sum([1, 2, 3] * [1, 0, iv[0]]) == 1]"
+        cons = Operator("wsum", [[1, 2], [iv[0], iv[1]]]) == 1
+        assert str(self.transform(cons)) == "[sum([1, 2] * [iv[0], iv[1]]) == 1]"


### PR DESCRIPTION
Related to #1077 

Adds cases for 0 and 1 arity versions of `And` and `Or` to `simplify_boolean`.
Returning either a trivial value or the single argument on its own

| Before | After |
| - | - |
| Or([]) | BoolVal(False) |
| And([]) | BoolVal(True) |
| Or([b]) | b |
| And([b]) | b |