### PR TITLE
NoOverlapOptional and CumulativeOptional mapping to MiniZinc

### DIFF
--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -776,16 +776,16 @@ class CPM_minizinc(SolverInterface):
             demand, demand_cons = get_nonneg_args(demand, is_present)
             extra_cons += demand_cons
 
-            # absent tasks consume no resources
-            demand_str = "[{}]".format(",".join(
-                "if {} then {} else 0 endif".format(self._convert_expression(p), self._convert_expression(d))
-                for d, p in zip(demand, is_present)))
+            # absent tasks do not have to be scheduled: expressed with an optional start time
+            opt_start = ["if {} then {} else <> endif".format(self._convert_expression(p),
+                                                              self._convert_expression(s))
+                         for s, p in zip(start, is_present)]
 
             format_str = "forall(" + self._convert_expression(extra_cons) + " ++ [" + global_str + "])"
 
-            return format_str.format(self._convert_expression(start),
+            return format_str.format("[{}]".format(",".join(opt_start)),
                                      self._convert_expression(dur),
-                                     demand_str,
+                                     self._convert_expression(demand),
                                      self._convert_expression(capacity))
 
         elif expr.name == "no_overlap":
@@ -818,7 +818,7 @@ class CPM_minizinc(SolverInterface):
             dur, dur_cons = get_nonneg_args(dur, is_present)
             extra_cons += dur_cons
 
-            # absent tasks do not have to be scheduled
+            # absent tasks do not have to be scheduled: expressed with an optional start time
             opt_start = ["if {} then {} else <> endif".format(self._convert_expression(p),
                                                               self._convert_expression(s))
                          for s, p in zip(start, is_present)]

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -73,7 +73,7 @@ from ..expressions.python_builtins import any as cpm_any
 from ..expressions.variables import _NumVarImpl, NegBoolView
 from ..expressions.globalconstraints import DirectConstraint, GlobalCardinalityCount, MDD, Regular
 from ..expressions.globalfunctions import Multiplication, FloatSum
-from ..expressions.utils import is_int, is_any_list, get_bounds, get_nonneg_args
+from ..expressions.utils import is_int, is_any_list, get_bounds, get_nonneg_args, implies
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
@@ -97,11 +97,11 @@ class CPM_minizinc(SolverInterface):
     """
 
     supported_global_constraints = frozenset({"alldifferent", "alldifferent_except0", "allequal",
-                                              "inverse", "ite", "xor", "table", "InDomain", "negative_table", "mdd", "regular", "cumulative", "circuit", "gcc",
+                                              "inverse", "ite", "xor", "table", "InDomain", "negative_table", "mdd", "regular", "cumulative", "cumulative_optional", "circuit", "gcc",
                                               "increasing", "decreasing",
                                               "strictly_increasing", "strictly_decreasing", "lex_lesseq", "lex_less",
                                               "lex_chain_less","lex_chain_lesseq",
-                                              "precedence", "no_overlap",
+                                              "precedence", "no_overlap", "no_overlap_optional",
                                               "min", "max", "abs", "mul", "div", "mod", "pow", "element", "count", "nvalue", "among", "nd_element"})
     supported_reified_global_constraints = supported_global_constraints - {"circuit", "precedence", "regular"}
 
@@ -760,6 +760,34 @@ class CPM_minizinc(SolverInterface):
                                      self._convert_expression(demand),
                                      self._convert_expression(capacity))
 
+        elif expr.name == "cumulative_optional":
+            extra_cons = []
+            if len(expr.args) == 5:
+                start, dur, demand, capacity, is_present = expr.args
+            else:
+                start, dur, end, demand, capacity, is_present = expr.args
+                extra_cons += [implies(p, s + d == e) for s, d, e, p in zip(start, dur, end, is_present)]
+
+            global_str = "cumulative({},{},{},{})"
+            # ensure duration is non-negative (only enforced for the tasks that are present)
+            dur, dur_cons = get_nonneg_args(dur, is_present)
+            extra_cons += dur_cons
+            # ensure demand is non-negative (only enforced for the tasks that are present)
+            demand, demand_cons = get_nonneg_args(demand, is_present)
+            extra_cons += demand_cons
+
+            # absent tasks consume no resources
+            demand_str = "[{}]".format(",".join(
+                "if {} then {} else 0 endif".format(self._convert_expression(p), self._convert_expression(d))
+                for d, p in zip(demand, is_present)))
+
+            format_str = "forall(" + self._convert_expression(extra_cons) + " ++ [" + global_str + "])"
+
+            return format_str.format(self._convert_expression(start),
+                                     self._convert_expression(dur),
+                                     demand_str,
+                                     self._convert_expression(capacity))
+
         elif expr.name == "no_overlap":
             extra_cons = []
             if len(expr.args) == 2:
@@ -776,6 +804,28 @@ class CPM_minizinc(SolverInterface):
             format_str = "forall(" + self._convert_expression(extra_cons) + " ++ [" + global_str + "])"
 
             return format_str.format(self._convert_expression(start), self._convert_expression(dur))
+
+        elif expr.name == "no_overlap_optional":
+            extra_cons = []
+            if len(expr.args) == 3:
+                start, dur, is_present = expr.args
+            else:
+                start, dur, end, is_present = expr.args
+                extra_cons += [implies(p, s + d == e) for s, d, e, p in zip(start, dur, end, is_present)]
+
+            global_str = "disjunctive({},{})"
+            # ensure duration is non-negative (only enforced for the tasks that are present)
+            dur, dur_cons = get_nonneg_args(dur, is_present)
+            extra_cons += dur_cons
+
+            # absent tasks do not have to be scheduled
+            opt_start = ["if {} then {} else <> endif".format(self._convert_expression(p),
+                                                              self._convert_expression(s))
+                         for s, p in zip(start, is_present)]
+
+            format_str = "forall(" + self._convert_expression(extra_cons) + " ++ [" + global_str + "])"
+
+            return format_str.format("[{}]".format(",".join(opt_start)), self._convert_expression(dur))
 
         args_str = [self._convert_expression(e) for e in expr.args]
         # standard expressions: comparison, operator, element

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1258,8 +1258,10 @@ class TestGlobal:
 
     @pytest.mark.usefixtures("solver")
     def test_optional_cumulative(self, solver):
-        if solver in ("pysat", "pysdd", "pindakaas", "rc2"):
+        if solver == "pysdd":
             pytest.skip(f"{solver} does not support integer variables")
+        if solver == "rc2":
+            pytest.skip(f"{solver} only supports optimization problems")
 
         start = cp.intvar(0, 10, shape=4, name="start")
         duration = [1, 4, 3, 2]
@@ -1307,8 +1309,10 @@ class TestGlobal:
 
     @pytest.mark.usefixtures("solver")
     def test_optional_no_overlap(self, solver):
-        if solver in ("pysat", "pysdd", "pindakaas", "rc2"):
+        if solver == "pysdd":
             pytest.skip(f"{solver} does not support integer variables")
+        if solver == "rc2":
+            pytest.skip(f"{solver} only supports optimization problems")
 
         start = cp.intvar(0, 10, shape=4, name="start")
         duration = [1, 4, 6, 2]

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1256,7 +1256,11 @@ class TestGlobal:
         assert cp.Model(bv == expr).solve()
         assert not bv.value()
 
-    def test_optional_cumulative(self):
+    @pytest.mark.usefixtures("solver")
+    def test_optional_cumulative(self, solver):
+        if solver in ("pysat", "pysdd", "pindakaas", "rc2"):
+            pytest.skip(f"{solver} does not support integer variables")
+
         start = cp.intvar(0, 10, shape=4, name="start")
         duration = [1, 4, 3, 2]
         end = cp.intvar(0, 10, shape=4, name="end")
@@ -1264,45 +1268,71 @@ class TestGlobal:
         is_present = cp.boolvar(shape=4)
         capacity = 10
         expr = cp.CumulativeOptional(start, duration, end, demand, capacity, is_present)
-        assert cp.Model(expr).solve()
+        assert cp.Model(expr).solve(solver=solver)
         assert expr.value()
         assert is_present[0].value() is False, "Task 0 cannot be scheduled as it exceeds the capacity"
         # also test decomposition
-        assert cp.Model(expr.decompose()).solve()
+        assert cp.Model(expr.decompose()).solve(solver=solver)
         assert expr.value()
         assert is_present[0].value() is False, "Task 0 cannot be scheduled as it exceeds the capacity"
 
+        # also test without end times
+        expr = cp.CumulativeOptional(start, duration, demand=demand, capacity=capacity, is_present=is_present)
+        assert cp.Model(expr).solve(solver=solver)
+        assert expr.value()
+        assert is_present[0].value() is False, "Task 0 cannot be scheduled as it exceeds the capacity"
+
+        # absent tasks consume none of the resource, so they can overlap freely
+        expr = cp.CumulativeOptional(start, duration, end, demand, capacity, [False, True, False, False])
+        assert cp.Model(expr, cp.all(start == start[0])).solve(solver=solver)
+        assert expr.value()
+
         # weird cases, allow negative duration or demand when task is not present
         expr = cp.CumulativeOptional(start, [1,4,3,-2], end, demand, capacity, [False, True, True, False])
-        assert cp.Model(expr).solve()
-        assert cp.Model(expr.decompose()).solve()
+        assert cp.Model(expr).solve(solver=solver)
+        assert cp.Model(expr.decompose()).solve(solver=solver)
 
         expr = cp.CumulativeOptional(start, [1,4,3,-2], end, demand, capacity, [False, True, True, True])
-        assert cp.Model(expr).solve() is False
-        assert cp.Model(expr.decompose()).solve() is False
+        assert cp.Model(expr).solve(solver=solver) is False
+        assert cp.Model(expr.decompose()).solve(solver=solver) is False
 
         expr = cp.CumulativeOptional(start, duration, end, [11,4,8,-7], capacity, [False, True, True, False])
-        assert cp.Model(expr).solve()
-        assert cp.Model(expr.decompose()).solve()
+        assert cp.Model(expr).solve(solver=solver)
+        assert cp.Model(expr.decompose()).solve(solver=solver)
 
         expr = cp.CumulativeOptional(start, duration, end, [11,4,8,-7], capacity, [False, True, True, True])
-        assert cp.Model(expr).solve() is False
-        assert cp.Model(expr.decompose()).solve() is False
+        assert cp.Model(expr).solve(solver=solver) is False
+        assert cp.Model(expr.decompose()).solve(solver=solver) is False
 
 
-    def test_optional_no_overlap(self):
+    @pytest.mark.usefixtures("solver")
+    def test_optional_no_overlap(self, solver):
+        if solver in ("pysat", "pysdd", "pindakaas", "rc2"):
+            pytest.skip(f"{solver} does not support integer variables")
+
         start = cp.intvar(0, 10, shape=4, name="start")
         duration = [1, 4, 6, 2]
         end = cp.intvar(0, 10, shape=4, name="end")
         is_present = cp.boolvar(shape=4)
         expr = cp.NoOverlapOptional(start, duration, end, is_present)
-        assert cp.Model(expr, cp.any(is_present)).solve()
+        assert cp.Model(expr, cp.any(is_present)).solve(solver=solver)
         assert expr.value()
         assert not all(is_present.value()), "Not all tasks can be scheduled without overlapping, given the domains"
         # also test decomposition
-        assert cp.Model(expr.decompose(), cp.any(is_present)).solve()
+        assert cp.Model(expr.decompose(), cp.any(is_present)).solve(solver=solver)
         assert expr.value()
         assert not all(is_present.value()), "Not all tasks can be scheduled without overlapping, given the domains"
+
+        # also test without end times
+        expr = cp.NoOverlapOptional(start, duration, is_present=is_present)
+        assert cp.Model(expr, cp.any(is_present)).solve(solver=solver)
+        assert expr.value()
+        assert not all(is_present.value()), "Not all tasks can be scheduled without overlapping, given the domains"
+
+        # absent tasks do not have to be scheduled, so they can overlap freely
+        expr = cp.NoOverlapOptional(start, duration, end, [False, True, False, False])
+        assert cp.Model(expr, cp.all(start == start[0])).solve(solver=solver)
+        assert expr.value()
 
         # test large task
         start = cp.intvar(0, 10, shape=4, name="start")
@@ -1310,9 +1340,9 @@ class TestGlobal:
         end = cp.intvar(0, 10, shape=4, name="end")
         is_present = cp.boolvar(shape=4)
         expr = cp.NoOverlapOptional(start, duration, end, is_present)
-        assert cp.Model(expr, cp.any(is_present)).solve() is False
+        assert cp.Model(expr, cp.any(is_present)).solve(solver=solver) is False
 
-    
+
     def test_ite(self):
         x = cp.intvar(0, 5, shape=3, name="x")
         iter = cp.IfThenElse(x[0] > 2, x[1] > x[2], x[1] == x[2])


### PR DESCRIPTION
This PR addresses the two global constraints left in #966: NoOverlapOptional and CumulativeOptional, which were not yet mapped to the MiniZinc interface. Similar to the mappings for NoOverlap and Cumulative respectively, except for the necessary changes for optional tasks.