### PR TITLE
Fix `.value` for nested partial functions

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -70,9 +70,11 @@ from __future__ import annotations
         or in logical operators.
 
     - :func:`~cpmpy.expressions.core.Expression.value`    
-        computes the value of this expression, by calling .value() on its
-        subexpressions and doing the appropriate computation
-        this is used to conveniently print variable values, objective values
+        computes the value of this expression, by calling :meth:`~cpmpy.expressions.core.Expression.compute_value`
+        on the expression (subclasses implement ``compute_value()``, not ``value()``).
+        For Boolean expressions, nested partial functions that are undefined
+        (e.g. division by zero) evaluate to False, following relational semantics.
+        This is used to conveniently print variable values, objective values
         and any other expression value (e.g. during debugging).
 
     :class:`~cpmpy.expressions.core.Description` bundles optional human-readable text and print flags for
@@ -98,7 +100,7 @@ import numpy as np
 import cpmpy as cp
 
 from .utils import is_num, is_any_list, flatlist, get_bounds, is_boolexpr, is_true_cst, is_false_cst, argvals, is_bool
-from ..exceptions import TypeError
+from ..exceptions import TypeError, IncompleteFunctionError
 
 # Common typing helpers
 T = TypeVar("T")
@@ -118,7 +120,7 @@ class Expression(object):
 
     - :attr:`~cpmpy.expressions.core.Expression.args`:                  can override it with a narrower type for the arguments
     - :func:`~cpmpy.expressions.core.Expression.is_bool`:               whether its return type is Boolean
-    - :func:`~cpmpy.expressions.core.Expression.value`:                 the value of the expression, default None
+    - :func:`~cpmpy.expressions.core.Expression.compute_value`:         implementation of ``value()``; subclasses override this, not ``value()``
     - :func:`implies(x) <cpmpy.expressions.core.Expression.implies>`:   logical implication of this expression towards `x`
     - :func:`~cpmpy.expressions.core.Expression.__repr__`:              for pretty printing the expression
     - :meth:`~cpmpy.expressions.core.Expression.set_description`:      optional custom :meth:`__str__` text (class default ``_description`` is ``None``; set on the instance when used)
@@ -239,8 +241,29 @@ class Expression(object):
         """
         return True
 
-    def value(self) -> Optional[int]:
-        raise NotImplementedError(f"`value` is not yet implemented for type {self}")
+    def value(self) -> Optional[int|bool]:
+        """
+        Compute the value of this expression under the current variable assignment.
+
+        For Boolean expressions, nested partial functions that are undefined
+        (e.g. division by zero, out-of-range Element) evaluate to False, following
+        relational semantics.
+
+        Returns:
+            Optional[int]: The value of the expression, or None if any variable is unassigned
+        """
+        try:
+            return self.compute_value()
+        except IncompleteFunctionError:
+            if self.is_bool():
+                return False
+            raise
+
+    def compute_value(self) -> Optional[int]:
+        """
+        Compute the value of this expression. Called by :meth:`value`. Subclasses override this, not ``value()``.
+        """
+        raise NotImplementedError(f"`compute_value` is not yet implemented for type {self}")
 
     def get_bounds(self) -> tuple[int, int]:
         if self.is_bool():
@@ -561,7 +584,7 @@ class BoolVal(Expression):
         arg = bool(arg)
         super(BoolVal, self).__init__("boolval", (arg,))
 
-    def value(self) -> bool:
+    def value(self) -> bool:  # no compute_value because no subexpressions
         return self.args[0]
 
     def __invert__(self) -> Expression:
@@ -708,7 +731,7 @@ class Comparison(Expression):
 
     # return the value of the expression
     # optional, default: None
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         arg_vals = argvals(self.args)
 
         if any(a is None for a in arg_vals): return None
@@ -832,7 +855,7 @@ class Operator(Expression):
         else:  # n-ary
             return "{}{}".format(self.name, self.args)  # args is a tuple, will be in ()
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns the value of the expression (or None if not everything has a value).
         """

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -65,14 +65,20 @@
             def decompose(self):
                 return [self.args[0] != self.args[1]] # your decomposition
 
+            def compute_value(self):                
+                return argval(self.args[0]) != argval(self.args[1])
+
     ..
 
     You can also implement a `.negate()` method if the global constraint has a better way to negate it than negating the decomposition.
     The expression returned by `.negate()` should be equivalent to the negation of the global constraint, and is not allowed to introduce explicit `not` operators.
     Instead, use cpmpy.transformations.negation.recurse_negation to push down the negation if you want to negate an expression.
 
+    Implement ``compute_value()`` to evaluate the constraint under the current assignment.
+    :meth:`~cpmpy.expressions.core.Expression.value` wraps ``compute_value()`` and applies relational semantics for Boolean expressions.
+
     If it is a :class:`~cpmpy.expressions.globalfunctions.GlobalFunction` meaning that its return type is numeric (see :class:`~cpmpy.expressions.globalfunctions.Minimum` and :class:`~cpmpy.expressions.globalfunctions.Element`)
-    then set `is_bool=False` in the super() constructor and preferably implement `.value()` accordingly.
+    then set `is_bool=False` in the super() constructor and implement ``compute_value()`` accordingly.
 
 
     Alternative decompositions
@@ -159,6 +165,7 @@ class GlobalConstraint(Expression):
 
         Like all expressions it has a ``.name`` and ``.args`` property.
         Overwrites the ``.is_bool()`` method as all global constraints are Boolean.
+        Subclasses implement :meth:`compute_value` (called by :meth:`~cpmpy.expressions.core.Expression.value`).
     """
 
     def is_bool(self) -> bool:
@@ -170,15 +177,17 @@ class GlobalConstraint(Expression):
         """
         return True
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
-        Returns whether the global constraint is satisfied under the current variable assignment.
+        Evaluate the constraint under the current assignment (called by :meth:`~cpmpy.expressions.core.Expression.value`).
+
+        Subclasses must implement this method. Do not override ``value()``.
 
         Returns:
             Optional[bool]: True or False when all variables within its scope are assigned;
             None if any variable within its scope is unassigned.
         """
-        raise NotImplementedError(f"`value` is not implemented for {self}")
+        raise NotImplementedError(f"`compute_value` is not implemented for {self}")
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
@@ -258,7 +267,7 @@ class AllDifferent(GlobalConstraint):
         lb, ub = min(lbs), max(ubs)
         return [cp.sum((arg_i == val) for arg_i in self.args) <= 1 for val in range(lb, ub + 1)], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -306,7 +315,7 @@ class AllDifferentExceptN(GlobalConstraint):
             cons.append(cond.implies(cp.any([x == a for a in n]))) # equivalent to (x in n) | (y in n) | (x != y)
         return cons, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -351,7 +360,7 @@ class AllEqual(GlobalConstraint):
         # arg0 == arg1, arg1 == arg2, arg2 == arg3... no need to post n^2 equalities
         return [x == y for x, y in zip(self.args[:-1], self.args[1:])], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -394,7 +403,7 @@ class AllEqualExceptN(GlobalConstraint):
             constraints.append(cp.any(x == a for a in n) | (x == y) | cp.any(y == a for a in n))
         return constraints, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -475,7 +484,7 @@ class Circuit(GlobalConstraint):
 
         return constraining, defining
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -536,7 +545,7 @@ class Inverse(GlobalConstraint):
         
         return constraining, toplevel
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -686,7 +695,7 @@ class Table(GlobalConstraint):
 
         return [MDD(arr, transitions, start=ROOT)], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -769,7 +778,7 @@ class ShortTable(GlobalConstraint):
             defining.append(row_selected[i].implies(subexpr))  # implication-only decomposition
         return [cp.sum(row_selected) == 1], defining
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -835,7 +844,7 @@ class NegativeTable(GlobalConstraint):
         arr, tab = self.args
         return [cp.all([cp.any([ai != ri for ai, ri in zip(arr, row)]) for row in tab])], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -1048,7 +1057,7 @@ class Regular(GlobalConstraint):
         return constraining, defining
 
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -1309,7 +1318,7 @@ class MDD(GlobalConstraint):
             return value_cons + cons, []
 
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -1356,7 +1365,7 @@ class IfThenElse(GlobalConstraint):
                             f"{condition, if_true, if_false}")
         super().__init__("ite", (condition, if_true, if_false))
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -1441,7 +1450,7 @@ class InDomain(GlobalConstraint):
         arr_set = frozenset(arr)
         return [cp.any([expr == val for val in arr_set])], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -1528,7 +1537,7 @@ class Xor(GlobalConstraint):
 
         return [prev], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         arrvals = argvals(self.args)
         if any(a is None for a in arrvals):
             return None
@@ -1715,7 +1724,7 @@ class Cumulative(GlobalConstraint):
 
         return cons, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -1920,7 +1929,7 @@ class CumulativeOptional(GlobalConstraint):
 
         return cons, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2008,7 +2017,7 @@ class NoOverlap(GlobalConstraint):
             cons.append((e1 <= s2) | (e2 <= s1))
         return cons, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2096,7 +2105,7 @@ class NoOverlapOptional(GlobalConstraint):
             cons += [implies(p1 & p2, (e1 <= s2) | (e2 <= s1))]
         return cons, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2168,7 +2177,7 @@ class Precedence(GlobalConstraint):
                 constraints.append(lhs.implies(cp.any(args[:j] == s)))
         return constraints, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2231,7 +2240,7 @@ class GlobalCardinalityCount(GlobalConstraint):
             
         return constraints, []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2273,7 +2282,7 @@ class Increasing(GlobalConstraint):
         args = self.args
         return [args[i] <= args[i+1] for i in range(len(args)-1)], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2306,7 +2315,7 @@ class Decreasing(GlobalConstraint):
         args = self.args
         return [args[i] >= args[i+1] for i in range(len(args)-1)], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2339,7 +2348,7 @@ class IncreasingStrict(GlobalConstraint):
         args = self.args
         return [args[i] < args[i+1] for i in range(len(args)-1)], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2373,7 +2382,7 @@ class DecreasingStrict(GlobalConstraint):
         args = self.args
         return [(args[i] > args[i+1]) for i in range(len(args)-1)], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2436,7 +2445,7 @@ class LexLess(GlobalConstraint):
 
         return constraining, defining
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2494,7 +2503,7 @@ class LexLessEq(GlobalConstraint):
 
         return constraining, defining
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2529,7 +2538,7 @@ class LexChainLess(GlobalConstraint):
         X = self.args
         return [LexLess(prev_row, curr_row) for prev_row, curr_row in zip(X, X[1:])], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned
@@ -2560,7 +2569,7 @@ class LexChainLessEq(GlobalConstraint):
         X = self.args
         return [LexLessEq(prev_row, curr_row) for prev_row, curr_row in zip(X, X[1:])], []
 
-    def value(self) -> Optional[bool]:
+    def compute_value(self) -> Optional[bool]:
         """
         Returns:
             Optional[bool]: True if the global constraint is satisfied, False otherwise, or None if any argument is not assigned

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -51,6 +51,9 @@
             def decompose(self):
                 return (self.args[0] + self.args[1]), []  # the decomposition
 
+            def compute_value(self):
+                return argval(self.args[0]) + argval(self.args[1])
+
     Objective-only :class:`FloatSum`
     -------------------------------
 
@@ -103,6 +106,7 @@ class GlobalFunction(Expression):
 
     Like all expressions it has a `.name` and `.args` property.
     It overwrites the :meth:`is_bool() <cpmpy.expressions.core.Expression.is_bool>` method to return False, as global functions are numeric.
+    Subclasses implement :meth:`compute_value` (called by :meth:`~cpmpy.expressions.core.Expression.value`).
     """
 
     def is_bool(self) -> bool:
@@ -112,15 +116,17 @@ class GlobalFunction(Expression):
         """
         return False
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
-        Returns whether the global function can be evaluated under the current variable assignment.
+        Evaluate the function under the current assignment (called by :meth:`~cpmpy.expressions.core.Expression.value`).
+
+        Subclasses must implement this method. Do not override ``value()``.
 
         Returns:
             Optional[int]: The numeric value when all variables within its scope are assigned;
             None if any variable within its scope is unassigned.
         """
-        raise NotImplementedError(f"`value` is not implemented for {self}")
+        raise NotImplementedError(f"`compute_value` is not implemented for {self}")
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
         """
@@ -213,7 +219,7 @@ class Minimum(GlobalFunction):
         """ READ-ONLY, well-typed argument of this global function"""
         return self._args
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The minimum value of the arguments, or None if any argument is not assigned
@@ -275,7 +281,7 @@ class Maximum(GlobalFunction):
         """ READ-ONLY, well-typed argument of this global function"""
         return self._args
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The maximum value of the arguments, or None if any argument is not assigned
@@ -328,7 +334,7 @@ class Abs(GlobalFunction):
         """ READ-ONLY, well-typed argument of this global function"""
         return self._args
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The absolute value of the argument, or None if the argument is not assigned
@@ -447,7 +453,7 @@ class Multiplication(GlobalFunction):
             return Multiplication(-self.args[0], self.args[1])
         return super().__neg__()
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         x, y = self.args
         val_y = y.value()
         if val_y is None:
@@ -581,7 +587,7 @@ class Division(GlobalFunction):
         _div = intvar(*self.get_bounds())
         return _div, safen + [(x == (y * _div) + r), abs(r) < abs(y), abs(y) * abs(_div) <= abs(x)]
 
-    def value(self):
+    def compute_value(self):
         """
         Returns:
             int: The integer division of the arguments, or None if the arguments are not assigned
@@ -593,9 +599,7 @@ class Division(GlobalFunction):
         try:
             return int(x / y)  # integer division, rounding towards zero
         except ZeroDivisionError:
-            raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}"
-                                          + "\n Use argval(expr) to get the value of expr with relational "
-                                            "semantics.")
+            raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}")
 
     def get_bounds(self):
         """
@@ -677,7 +681,7 @@ class Modulo(GlobalFunction):
             x * _mod >= 0        # remainder is negative iff x is negative
         ]
 
-    def value(self):
+    def compute_value(self):
         """
         Returns:
             int: The modulo of the arguments, or None if the arguments are not assigned
@@ -689,9 +693,7 @@ class Modulo(GlobalFunction):
         try:  # modulo defined with integer division
             return x - (y * int(x / y))
         except ZeroDivisionError:
-            raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}"
-                                          + "\n Use argval(expr) to get the value of expr with relational "
-                                            "semantics.")
+            raise IncompleteFunctionError(f"Division by zero during value computation for expression {self}")
 
     def get_bounds(self):
         """
@@ -760,7 +762,7 @@ class Power(GlobalFunction):
             _pow *= base
         return _pow,[]
 
-    def value(self):
+    def compute_value(self):
         """
         Returns:
             int: The power of the arguments, or None if the arguments are not assigned
@@ -831,7 +833,7 @@ class Element(GlobalFunction):
     def __getitem__(self, index):
         raise CPMpyException("For using multi-dimensional Element, use comma-separated indices on the original array, e.g. instead of Arr[Idx1][Idx2], do Arr[Idx1, Idx2].")
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The value of the array element at the given index, or None if the index is not assigned or the array element is not assigned
@@ -844,8 +846,7 @@ class Element(GlobalFunction):
             return None
 
         if vidx < 0 or vidx >= len(arr):
-            raise IncompleteFunctionError(f"Index {vidx} out of range for array of length {len(arr)} while calculating value for expression {self}"
-                                            + "\n Use argval(expr) to get the value of expr with relational semantics.")
+            raise IncompleteFunctionError(f"Index {vidx} out of range for array of length {len(arr)} while calculating value for expression {self}")
         return argval(arr[vidx])  # can be None
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
@@ -949,7 +950,7 @@ class NDElement(GlobalFunction):
     def __getitem__(self, index):
         raise CPMpyException("For using multi-dimensional Element, use comma-separated indices on the original array.")
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The value of the array element at the given indices, or None if any index is not assigned or the array element is not assigned
@@ -962,10 +963,7 @@ class NDElement(GlobalFunction):
             return None
         for v, dim in zip(vidxs, arr.shape):
             if v < 0 or v >= dim:
-                raise IncompleteFunctionError(
-                    f"Index {v} out of range for dimension size {dim} while calculating value for expression {self}"
-                    + "\n Use argval(expr) to get the value of expr with relational semantics."
-                )
+                raise IncompleteFunctionError(f"Index {v} out of range for dimension size {dim} while calculating value for expression {self}")
         return argval(arr[tuple(vidxs)])
 
     def decompose(self) -> tuple[Expression, list[Expression]]:
@@ -1071,7 +1069,7 @@ class Count(GlobalFunction):
         arr, val = self.args
         return cp.sum((a == val) for a in arr), []
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The number of occurrences of val in arr, or None if val or any element in arr is not assigned
@@ -1133,7 +1131,7 @@ class Among(GlobalFunction):
         arr, vals = self.args
         return cp.sum(Count(arr, val) for val in vals), []
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The number of variables in arr that take a value present in vals, or None if any element in arr is not assigned
@@ -1195,7 +1193,7 @@ class NValue(GlobalFunction):
 
         return cp.sum(cp.any(a == v for a in self.args) for v in range(lb, ub+1)), []
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The number of distinct values in the array, or None if any element in arr is not assigned
@@ -1256,7 +1254,7 @@ class NValueExcept(GlobalFunction):
 
         return cp.sum([cp.any(a == v for a in arr) for v in range(lb, ub+1) if v != n]), []
 
-    def value(self) -> Optional[int]:
+    def compute_value(self) -> Optional[int]:
         """
         Returns:
             Optional[int]: The number of distinct values in the array, excluding value n, or None if any element in arr is not assigned

--- a/cpmpy/expressions/utils.py
+++ b/cpmpy/expressions/utils.py
@@ -36,7 +36,6 @@ import math
 from collections.abc import Iterable  # for flatten
 from itertools import combinations
 from typing import TYPE_CHECKING, TypeGuard, Optional, overload, Final
-from cpmpy.exceptions import IncompleteFunctionError
 
 if TYPE_CHECKING:
     # only import for type checking
@@ -138,13 +137,7 @@ def argval(a):
         We check with hasattr instead of isinstance to avoid circular dependency
     """
     if hasattr(a, "value"):
-        try:
-            val = a.value()
-        except IncompleteFunctionError as e:
-            if isinstance(a, cp.expressions.core.Expression) and a.is_bool():
-                return False
-            else:
-                raise e
+        val = a.value()
     else:
         val = a
 

--- a/cpmpy/tools/xcsp3/globals.py
+++ b/cpmpy/tools/xcsp3/globals.py
@@ -80,7 +80,7 @@ class AllDifferentLists(GlobalConstraint):
             constraints.append(cpm_any(var1 != var2 for var1, var2 in zip(lst1, lst2)))
         return constraints, []
 
-    def value(self):
+    def compute_value(self):
         lst_vals = [tuple(argvals(a)) for a in self.args]
         return len(set(lst_vals)) == len(self.args)
 class AllDifferentListsExceptN(GlobalConstraint):
@@ -111,7 +111,7 @@ class AllDifferentListsExceptN(GlobalConstraint):
             constraints.append(cpm_all(var1 == var2 for var1, var2 in zip(lst1, lst2)).implies(Table(lst1, self.args[1])))
         return constraints, []
 
-    def value(self):
+    def compute_value(self):
         lst_vals = [tuple(argvals(a)) for a in self.args[0]]
         except_vals = [tuple(argvals(a)) for a in self.args[1]]
         return len(set(lst_vals) - set(except_vals)) == len([x for x in lst_vals if x not in except_vals])
@@ -191,7 +191,7 @@ class SubCircuit(GlobalConstraint):
 
         return constraining, defining
 
-    def value(self):
+    def compute_value(self):
 
         succ = [argval(a) for a in self.args]
         n = len(succ)
@@ -286,7 +286,7 @@ class SubCircuitWithStart(GlobalConstraint):
 
         return constraining, defining
 
-    def value(self):
+    def compute_value(self):
         start_index = self.args[-1]
         succ = [argval(a) for a in self.args[:-1]] # Successor variables
 
@@ -324,7 +324,7 @@ class SafeOnlyInverse(GlobalConstraint):
         rev = cpm_array(rev)
         return [cp.all(rev[x] == i for i, x in enumerate(fwd))], []
 
-    def value(self):
+    def compute_value(self):
         fwd = argvals(self.args[0])
         rev = argvals(self.args[1])
         # args are fine, now evaluate actual inverse cons
@@ -351,7 +351,7 @@ class InverseOne(GlobalConstraint):
         arr = cpm_array(arr)
         return [all(arr[x] == i for i, x in enumerate(arr))], []
 
-    def value(self):
+    def compute_value(self):
         valsx = argvals(self.args[0])
         try:
             return all(valsx[x] == i for i, x in enumerate(valsx))
@@ -378,7 +378,7 @@ class Channel(GlobalConstraint):
         arr, v = self.args
         return [(arr[i] == 1) == (v == i) for i in range(len(arr))] + [v >= 0, v < len(arr)], []
 
-    def value(self):
+    def compute_value(self):
         arr, v = self.args
         return sum(argvals(x) for x in arr) == 1 and 0 <= argval(v) < len(arr) and arr[argval(v)] == 1
 
@@ -415,7 +415,7 @@ class NegativeShortTable(GlobalConstraint):
         arr, tab = self.args
         return [cpm_all(cpm_any([ai != ri for ai, ri in zip(arr, row) if ri != "*"]) for row in tab)], []
 
-    def value(self):
+    def compute_value(self):
         arr, tab = self.args
         arrval = np.asarray(argvals(arr))
         if arrval.dtype == object and any(x is None for x in arrval.flat):  # if not object, there is no None
@@ -463,7 +463,7 @@ class NotInDomain(GlobalConstraint):
         return [all([(expr != a) for a in arr])], defining
 
 
-    def value(self):
+    def compute_value(self):
         return argval(self.args[0]) not in argvals(self.args[1])
 
     def __repr__(self):
@@ -489,7 +489,7 @@ class NoOverlap2d(GlobalConstraint):
             cons.append(cpm_any([end_x[i] <= start_x[j], end_x[j] <= start_x[i],
                                  end_y[i] <= start_y[j], end_y[j] <= start_y[i]]))
         return cons,[]
-    def value(self):
+    def compute_value(self):
         start_x, dur_x, end_x,  start_y, dur_y, end_y = argvals(self.args)
         n = len(start_x)
         if any(s + d != e for s, d, e in zip(start_x, dur_x, end_x)):
@@ -524,7 +524,7 @@ class IfThenElseNum(GlobalFunction):
         b,x,y = self.args
         lbs,ubs = get_bounds([x,y])
         return min(lbs), max(ubs)
-    def value(self):
+    def compute_value(self):
         b,x,y = self.args
         if argval(b):
             return argval(x)
@@ -623,7 +623,7 @@ class DynamicCumulative(GlobalConstraint):
 
         return cons, []
 
-    def value(self):
+    def compute_value(self):
         arg_vals = [np.array(argvals(arg)) if is_any_list(arg)
                    else argval(arg) for arg in self.args]
 
@@ -724,7 +724,7 @@ class OrtSubcircuitWithStart(DirectConstraint):
 
         return Native_solver.AddCircuit(ort_arcs)
 
-    def value(self):
+    def compute_value(self):
         from cpmpy.expressions.utils import argval
         arguments, start_index = self.args
         N = len(arguments)

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -61,7 +61,9 @@ If you want a **sparse domain**, containing only a few values, you can either de
 
 Decision variables have a **unique name**. You can set it yourself, otherwise a unique name will automatically be assigned. If you print decision variables (`print(b)` or `print(x)`), it will display the name. Did we already say the name <u>must be unique</u>? Many solvers use the name as unique identifier, and it is near-impossible to debug with non-uniquely named decision variables.
 
-A solver will set the **value** of the decision variables for which it solved, if it can find a solution. You can retrieve it with `v.value()`. Variables are not tied to a solver, so you can use the same variable across multiple models and solvers. When a solve call finishes, it will overwrite the value of all its decision variables. Before solving, this value will be `None`. After solving it has either taken a boolean or integer value, or it is still None. For example when the solver didn't find any solution or when the decision variable was never used in the model, i.e. a "stale" decision variable which never appeared in a constraint or the objective function.
+A solver will set the **value** of the decision variables for which it solved, if it can find a solution. You can retrieve it with `v.value()`. The same `.value()` call works on any CPMpy expression (a constraint, a sum, `arr[idx]`, …): it evaluates the expression under the current assignment, or returns `None` if some variable is still unassigned. See [Partial functions and value()](#partial-functions-and-value) for undefined values of partial functions.
+
+Variables are not tied to a solver, so you can use the same variable across multiple models and solvers. When a solve call finishes, it will overwrite the value of all its decision variables. Before solving, this value will be `None`. After solving it has either taken a boolean or integer value, or it is still None. For example when the solver didn't find any solution or when the decision variable was never used in the model, i.e. a "stale" decision variable which never appeared in a constraint or the objective function.
 
 Finally, by providing a **shape** you automatically create a **numpy n-dimensional array** of decision variables. These variables automatically get their index appended to their name (the name is provided on the array-level) as to ensure its uniqueness:
 
@@ -434,8 +436,25 @@ print(f"arr: {arr.value()}, idx: {idx.value()}, val: {arr[idx].value()}")
 # arr: [0 1 2 3], idx: 2, val: 2
 ```
 
-         
+### Partial functions and value()
 
+Integer division `x // y`, modulo `x % y`, and `Element` (`arr[idx]`) are partial: they are undefined for some inputs (divisor `0`, or an index outside the array). After solving, you can still ask for the value of a constraint that nests such a function:
+
+- On a Boolean expression, `.value()` follows *relational semantics*: if a nested partial function is undefined, the Boolean expression evaluates to `False`. So `(x // y >= 3).value()` is `False` when `y` is `0`, rather than raising.
+- On the undefined numeric expression, `.value()` raises `IncompleteFunctionError`. So `(x // y).value()` with `y.value() = 0` returns an error as the result is undefined. 
+
+This matches how CPMpy (and the solver, after [safening](./api/transformations/safening.rst)) treat undefinedness in reified or nested constraints: the nearest Boolean parent becomes false, the unsafe argument is not forced in-bounds.
+
+```python
+import cpmpy as cp
+
+x, y = cp.intvar(0, 5, shape=2, name=("x","y"))
+b = cp.boolvar(name="b")
+cons = x // y >= 3
+cp.Model(cons, y == 0).solve() # b :: False allows for solution where y == 0
+print(cons.value())          # False
+# print((x // y).value())    # IncompleteFunctionError
+```
 
 ## Objective functions
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1521,6 +1521,54 @@ class TestGlobal:
 
         cp.Model(~cons).solveAll(display=check_val)
 
+
+class TestIncompleteFunctions:
+
+    def test_numeric_value_raises(self):
+        a, b = cp.intvar(1, 2, shape=2)
+        a._value, b._value = 1, 1
+        with pytest.raises(IncompleteFunctionError):
+            (42 // (a - b)).value()
+
+        arr = cp.cpm_array([1, 2, 3])
+        i = cp.intvar(0, 5)
+        i._value = 5
+        with pytest.raises(IncompleteFunctionError):
+            arr[i].value()
+
+    def test_numeric_sum_with_partial_raises(self):
+        x = cp.intvar(0, 5)
+        a, b = cp.intvar(1, 2, shape=2)
+        x._value = 1
+        a._value, b._value = 1, 1
+        with pytest.raises(IncompleteFunctionError):
+            (x + (42 // (a - b))).value()
+
+    def test_boolean_partial_as_first_child(self):
+        a, b = cp.intvar(1, 2, shape=2)
+        a._value, b._value = 1, 1
+        assert ((42 // (a - b)) >= 3).value() is False
+
+        arr = cp.cpm_array([1, 2, 3])
+        i = cp.intvar(0, 5)
+        p = cp.boolvar()
+        i._value, p._value = 5, False
+        assert (arr[i] == 1).implies(p).value() is True  # (undefined == 1) is False, False -> p is True
+
+    def test_boolean_deeply_nested_partial(self):
+        x = cp.intvar(0, 5)
+        a, b = cp.intvar(1, 2, shape=2)
+        x._value = 1
+        a._value, b._value = 1, 1
+        assert ((x + (42 // (a - b))) >= 3).value() is False
+
+        arr = cp.cpm_array([1, 2, 3])
+        p = cp.boolvar()
+        p._value = False
+        assert (arr[10 // (a - b)] == 1).implies(p).value() is True
+
+    
+
 class TestBounds:
     def test_bounds_minimum(self):
         x = cp.intvar(-8, 8)
@@ -1655,39 +1703,6 @@ class TestBounds:
         assert ub ==9
         assert not cp.Model(expr < lb).solve()
         assert not cp.Model(expr > ub).solve()
-
-    def test_incomplete_func(self):
-        # element constraint
-        arr = cp.cpm_array([1,2,3])
-        i = cp.intvar(0,5,name="i")
-        p = cp.boolvar()
-
-        cons = (arr[i] == 1).implies(p)
-        m = cp.Model([cons, i == 5])
-        assert m.solve()
-        assert cons.value()
-
-        # div constraint
-        a,b = cp.intvar(1,2,shape=2)
-        cons = (42 // (a - b)) >= 3
-        a._value, b._value = 1, 1
-        assert cons.value() is False
-        assert argval(cons) is False
-        pytest.raises(IncompleteFunctionError, (42 // (a - b)).value)
-
-        m = cp.Model([p.implies(cons), a == b])
-        if cp.SolverLookup.lookup("z3").supported():
-            assert m.solve(solver="z3")# ortools does not support divisor spanning 0 work here
-            assert cons.value() is False
-            assert argval(cons) is False
-            pytest.raises(IncompleteFunctionError, (42 // (a - b)).value)
-
-        # mayhem
-        cons = (arr[10 // (a - b)] == 1).implies(p)
-        m = cp.Model([cons, a == b])
-        if cp.SolverLookup.lookup("z3").supported():
-            assert m.solve(solver="z3")
-            assert cons.value()
 
     def test_bounds_count(self):
         x = cp.intvar(-8, 8)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1670,11 +1670,17 @@ class TestBounds:
         # div constraint
         a,b = cp.intvar(1,2,shape=2)
         cons = (42 // (a - b)) >= 3
+        a._value, b._value = 1, 1
+        assert cons.value() is False
+        assert argval(cons) is False
+        pytest.raises(IncompleteFunctionError, (42 // (a - b)).value)
+
         m = cp.Model([p.implies(cons), a == b])
         if cp.SolverLookup.lookup("z3").supported():
             assert m.solve(solver="z3")# ortools does not support divisor spanning 0 work here
-            pytest.raises(IncompleteFunctionError, cons.value)
-            assert not argval(cons)
+            assert cons.value() is False
+            assert argval(cons) is False
+            pytest.raises(IncompleteFunctionError, (42 // (a - b)).value)
 
         # mayhem
         cons = (arr[10 // (a - b)] == 1).implies(p)


### PR DESCRIPTION
As discussed in #1082 there is an inconsistency in the value computation for expressions with partial functions, as the previous argval approach did not catch all cases.

To fix it I had to make quite in-depth changes to the value function: basically, to be correct, each Boolean expression should wrap its `argval` computation in a try/catch and propagate `IncompleteFunctionErrors` to False as its return value.
But that's cumbersome, so it's implemented in the `Expression` superclass instead.
This superclass function now calls `compute_value()` on the subclass (which is the old `.value()`) and does the try/catch there.

