### PR TITLE
Fix name of InDomain global constraint

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1409,7 +1409,7 @@ class InDomain(GlobalConstraint):
         has_subexpr = not isinstance(expr, (_NumVarImpl, BoolVal))
 
         # args: tuple[Expression, np.ndarray]
-        super().__init__("InDomain", (expr, arr), has_subexpr=has_subexpr)
+        super().__init__("indomain", (expr, arr), has_subexpr=has_subexpr)
 
     @property
     def args(self) -> tuple[Expression, np.ndarray]:

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -85,7 +85,7 @@ class CPM_choco(SolverInterface):
     """
 
     supported_global_constraints = frozenset({"alldifferent", "alldifferent_except0", "allequal",
-                                    "table", 'negative_table', "short_table", "regular", "InDomain",
+                                    "table", 'negative_table', "short_table", "regular", "indomain",
                                     "cumulative", "no_overlap", "circuit", "gcc", "inverse", "precedence",
                                     "increasing", "decreasing", "strictly_increasing", "strictly_decreasing",
                                     "lex_lesseq", "lex_less", "mdd",
@@ -650,7 +650,7 @@ class CPM_choco(SolverInterface):
                 _HandleWrapper.__init__(chc_mdd, chc_handle)
                 return self.chc_model.mddc(self._to_vars(array), chc_mdd)
 
-            elif cpm_expr.name == 'InDomain':
+            elif cpm_expr.name == 'indomain':
                 assert len(cpm_expr.args) == 2  # args = [array, list of vals]
                 expr, table = self.solver_vars(cpm_expr.args)
                 return self.chc_model.member(expr, table)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -97,7 +97,7 @@ class CPM_minizinc(SolverInterface):
     """
 
     supported_global_constraints = frozenset({"alldifferent", "alldifferent_except0", "allequal",
-                                              "inverse", "ite", "xor", "table", "InDomain", "negative_table", "mdd", "regular", "cumulative", "circuit", "gcc",
+                                              "inverse", "ite", "xor", "table", "indomain", "negative_table", "mdd", "regular", "cumulative", "circuit", "gcc",
                                               "increasing", "decreasing",
                                               "strictly_increasing", "strictly_decreasing", "lex_lesseq", "lex_less",
                                               "lex_chain_less","lex_chain_lesseq",
@@ -922,7 +922,7 @@ class CPM_minizinc(SolverInterface):
             vals = self._convert_expression(vals).replace("[", "{").replace("]", "}")  # convert to set
             return "among({},{})".format(vars, vals)
 
-        elif expr.name == "InDomain":
+        elif expr.name == "indomain":
             # InDomain(expr, domain_list) - convert domain_list to a set
             arg0_str = self._convert_expression(expr.args[0])
             domain = expr.args[1]

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -72,7 +72,7 @@ class CPM_pumpkin(SolverInterface):
     - ``pum_solver``: the pumpkin.Model() object
     """
 
-    supported_global_constraints = frozenset({"alldifferent", "cumulative", "no_overlap", "table", "negative_table", "InDomain",
+    supported_global_constraints = frozenset({"alldifferent", "cumulative", "no_overlap", "table", "negative_table", "indomain",
                                               "min", "max", "abs", "mul", "div", "element"})
     supported_reified_global_constraints = frozenset()
 
@@ -132,7 +132,7 @@ class CPM_pumpkin(SolverInterface):
         self.predicate_map = {} # cache predicates for reuse
         if proof is not None: # Table and friends are not supported when proof logging
             # see https://github.com/ConSol-Lab/Pumpkin/issues/354
-            self.disabled_global_constraints = {"table", "negative_table", "InDomain"}
+            self.disabled_global_constraints = {"table", "negative_table", "indomain"}
         else:
             self.disabled_global_constraints = set()
 
@@ -608,7 +608,7 @@ class CPM_pumpkin(SolverInterface):
                                                   constraint_tag=tag)
                         ]
             
-            elif cpm_expr.name == "InDomain":
+            elif cpm_expr.name == "indomain":
                 val, domain = cpm_expr.args
                 return [constraints.Table(self.to_pum_ivar([val]),
                                           [[d] for d in domain], # each domain value is its own row

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -641,7 +641,7 @@ def get_linear_decompositions():
         element=lambda expr: expr.decompose_linear(), 
         table=lambda expr: expr.decompose_linear(), 
         short_table=lambda expr: expr.decompose(),
-        InDomain=lambda expr: expr.decompose_linear(),
+        indomain=lambda expr: expr.decompose_linear(),
         regular=lambda expr: expr.decompose_linear(),
     )
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -293,6 +293,7 @@ class TestGlobal:
 
         # Test InDomain with constant list
         vals = [1, 5, 8, -4]
+        assert cp.InDomain(iv, vals).name == "indomain"
         model = cp.Model([cp.InDomain(iv, vals)])
         assert model.solve()
         assert iv.value() in vals


### PR DESCRIPTION
For some historical reason, the `InDomain` global constraint was the only on with a PascalCased name, which has been a source of bugs in the past (due to using the wrong string in the supported set in solver interfaces).

This PR brings it in line with the other globals