### PR TITLE
Typo csemap ortools

### DIFF
--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -766,12 +766,13 @@ class CPM_ortools(SolverInterface):
                     else:
                         tasks.append(self.ort_model.NewOptionalFixedSizeIntervalVar(ort_s, ort_d, ort_p, f"interval_{cpm_s}-{cpm_d}-{is_present[i]}"))
                 else: # variable sized interval, need to make the end variable ourself
-                    cpm_e, end_cons = get_or_make_var(cpm_s + cpm_d, csemap=self.csemap)
+                    cpm_e, end_cons = get_or_make_var(cpm_s + cpm_d, csemap=self._csemap)
                     cons.extend(end_cons)
+                    ort_e = self.solver_var(cpm_e)
                     if ort_p is None:
-                        tasks.append(self.ort_model.NewIntervalVar(ort_s, ort_d, cpm_e, f"interval_{cpm_s}-{cpm_d}-{cpm_e}"))
+                        tasks.append(self.ort_model.NewIntervalVar(ort_s, ort_d, ort_e, f"interval_{cpm_s}-{cpm_d}-{cpm_e}"))
                     else:
-                        tasks.append(self.ort_model.NewOptionalIntervalVar(ort_s, ort_d, cpm_e, ort_p, f"interval_{cpm_s}-{cpm_d}-{cpm_e}-{is_present[i]}"))
+                        tasks.append(self.ort_model.NewOptionalIntervalVar(ort_s, ort_d, ort_e, ort_p, f"interval_{cpm_s}-{cpm_d}-{cpm_e}-{is_present[i]}"))
             
             elif ort_p is None: # mandatory interval
                 tasks.append(self.ort_model.NewIntervalVar(ort_s, ort_d, self.solver_var(end[i]), f"interval_{cpm_s}-{cpm_d}-{end[i]}"))

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -200,6 +200,7 @@ def global_constraints(solver):
             if solver != "pumpkin": # only supports with fixed durations
                 yield cp.Cumulative(s.tolist()+[cp.intvar(0,10)], dur + [cp.intvar(-3,3)], e.tolist()+[cp.intvar(0,10)], 1, cap)
                 yield cp.Cumulative(s, dur, e, cp.intvar(-3,3,shape=3,name="demand"), cap)
+                yield cp.Cumulative(start=s, duration=cp.intvar(1, 5, shape=3), demand=demand, capacity=cap)
             continue
 
         elif name == "CumulativeOptional":
@@ -210,6 +211,8 @@ def global_constraints(solver):
             is_present = [cp.boolvar(), cp.boolvar(), True, False]
             cap = 10
             yield cls(s, dur, e, demand, cap, is_present)
+            if solver != "pumpkin": # only supports with fixed durations
+                yield cls(start=s, duration=cp.intvar(1, 5, shape=4), demand=demand, capacity=cap, is_present=is_present)
         elif name == "GlobalCardinalityCount":
             vals = [1, 2, 3]
             cnts = cp.intvar(0,10,shape=3)
@@ -231,6 +234,7 @@ def global_constraints(solver):
             yield cp.NoOverlap(s, dur)
             if solver != "pumpkin": # only supports with fixed durations
                 yield cp.NoOverlap(s.tolist()+[cp.intvar(0,10)], dur + [cp.intvar(-3,3)], e.tolist()+[cp.intvar(0,10)])
+                yield cp.NoOverlap(s, cp.intvar(1, 5, shape=3))
             continue
         elif name == "NoOverlapOptional":
             s = cp.intvar(0, 10, shape=4, name="start")
@@ -238,6 +242,8 @@ def global_constraints(solver):
             dur = [1, 4, 3, 2]
             is_present = [cp.boolvar(), cp.boolvar(), True, False]
             yield cls(s, dur, e, is_present)
+            if solver != "pumpkin": # only supports with fixed durations
+                yield cls(start=s, duration=cp.intvar(1, 5, shape=4), is_present=is_present)
         elif name == "GlobalCardinalityCount":
             vals = [1, 2, 3]
             cnts = cp.intvar(0,10,shape=3)

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1256,6 +1256,25 @@ class TestGlobal:
         assert cp.Model(bv == expr).solve()
         assert not bv.value()
 
+    def test_cumulative_var_duration_no_end(self):
+        # regression: OR-Tools interval construction used self.csemap (missing) when
+        # duration is variable and end is not provided
+        start = cp.intvar(0, 10, shape=3, name="start")
+        duration = cp.intvar(1, 5, shape=3, name="dur")
+        demand = [1, 2, 1]
+        capacity = 3
+        cons = cp.Cumulative(start=start, duration=duration, demand=demand, capacity=capacity)
+        assert cp.Model(cons).solve(solver="ortools")
+        assert cons.value()
+
+    def test_no_overlap_var_duration_no_end(self):
+        # same OR-Tools path as Cumulative for variable-sized intervals without end
+        start = cp.intvar(0, 10, shape=3, name="start")
+        duration = cp.intvar(1, 4, shape=3, name="dur")
+        cons = cp.NoOverlap(start, duration)
+        assert cp.Model(cons).solve(solver="ortools")
+        assert cons.value()
+
     def test_optional_cumulative(self):
         start = cp.intvar(0, 10, shape=4, name="start")
         duration = [1, 4, 3, 2]


### PR DESCRIPTION
The OR-Tools interface had a typo (`self.csemap` instead of `self._csemap`).
Typo fixed and added missing test cases