### PR TITLE
Split up value/defining constraints in all transformations

### DIFF
--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -61,7 +61,7 @@ from ..transformations.get_variables import get_variables
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
-from ..transformations.flatten_model import flatten_constraint, flatten_objective
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.reification import reify_rewrite, only_bv_reifies
 from ..transformations.safening import safen_objective
@@ -390,7 +390,7 @@ class CPM_template(SolverInterface):
         raise NotImplementedError("TEMPLATE: Not a known supported numexpr {}".format(cpm_expr))
 
     # `add()` first calls `transform()`
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -403,7 +403,7 @@ class CPM_template(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
         # XXX chose the transformations your solver needs, see cpmpy/transformations/
@@ -415,12 +415,16 @@ class CPM_template(SolverInterface):
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons)  # flat normal form
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']))  # constraints that support reification
-        cpm_cons = only_bv_reifies(cpm_cons)
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=
+        value, defining = flatten_constraint(cpm_cons)  # flat normal form
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(['sum', 'wsum']))  # constraints that support reification
+
+        value, defining = apply_transform(only_bv_reifies, value, defining)
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum", "sub"]))  # supports >, <, !=
+
         # ...
-        return cpm_cons
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_template":
         """
@@ -446,8 +450,8 @@ class CPM_template(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
-
+        _value, _defining = self.transform(cpm_expr)
+        for con in _value + _defining:
             if isinstance(con, _BoolVarImpl):
                 # base case, just var or ~var
                 self.TPL_solver.add_clause([ self.solver_var(con) ])

--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -407,15 +407,15 @@ class CPM_template(SolverInterface):
         """
         # apply transformations
         # XXX chose the transformations your solver needs, see cpmpy/transformations/
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons) # if the solver requires supported partial function globals to be safened, use the follwing instead:
-        # cpm_cons = no_partial_functions(cpm_cons, safen_toplevel=frozenset({"element", "nd_element", "div", "mod"}))        
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining) # if the solver requires supported partial function globals to be safened, use the follwing instead:
+        # value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel=frozenset({"element", "nd_element", "div", "mod"}))        
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining)  # flat normal form
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset(['sum', 'wsum']))  # constraints that support reification
 

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -408,14 +408,14 @@ class CPM_choco(SolverInterface):
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
 
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel={"nd_element"})
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel={"nd_element"})
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(canonical_comparison, value, defining)
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported = self.supported_global_constraints | {"sum", "wsum"},

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -59,7 +59,7 @@ from ..expressions.utils import is_num, is_int, is_boolexpr, is_any_list, get_bo
     get_nonneg_args
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.get_variables import get_variables
-from ..transformations.flatten_model import flatten_constraint, get_or_make_var
+from ..transformations.flatten_model import flatten_constraint, get_or_make_var, apply_transform
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.linearize import canonical_comparison
 from ..transformations.safening import no_partial_functions, safen_objective
@@ -392,7 +392,7 @@ class CPM_choco(SolverInterface):
         return self._to_var(vals)
 
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -405,7 +405,7 @@ class CPM_choco(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
 
         cpm_cons = toplevel_list(cpm_expr)
@@ -415,14 +415,17 @@ class CPM_choco(SolverInterface):
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = canonical_comparison(cpm_cons)
-        cpm_cons = reify_rewrite(cpm_cons,
-                                 supported = self.supported_global_constraints | {"sum", "wsum"},
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(canonical_comparison, value, defining)
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported = self.supported_global_constraints | {"sum", "wsum"},
                                  csemap=self._csemap)  # constraints that support reification
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]), csemap=self._csemap)  # support >, <, !=
 
-        return cpm_cons
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum", "sub"]), csemap=self._csemap)  # support >, <, !=
+
+
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_choco":
         """
@@ -448,7 +451,8 @@ class CPM_choco(SolverInterface):
         # ensure all vars are known to solver
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for con in _value + _defining:
             c = self._get_constraint(con)
             if c is not None: # Reification constraints are not posted
                 c.post()

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -398,14 +398,14 @@ class CPM_cplex(SolverInterface):
         """
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining,
                                     supported=self.supported_global_constraints,
                                     supported_reified=self.supported_reified_global_constraints,
                                     csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset(['sum', 'wsum', 'sub']), csemap=self._csemap)
         value, defining = apply_transform(only_numexpr_equality, value, defining,

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -63,7 +63,7 @@ from ..expressions.utils import eval_comparison, flatlist, is_bool, is_num, is_i
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, intvar
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.flatten_model import flatten_constraint, flatten_objective
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, linearize_reified_variables, only_positive_bv, \
     only_positive_bv_wsum_const, decompose_linear, decompose_linear_objective
@@ -381,7 +381,7 @@ class CPM_cplex(SolverInterface):
         raise NotImplementedError("CPLEX: Not a known supported numexpr {}".format(cpm_expr))
 
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -394,7 +394,7 @@ class CPM_cplex(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
@@ -405,15 +405,21 @@ class CPM_cplex(SolverInterface):
                                     supported=self.supported_global_constraints,
                                     supported_reified=self.supported_reified_global_constraints,
                                     csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum', 'sub']), csemap=self._csemap)  # constraints that support reification
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub", "mul"]), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)  # anything that can create full reif should go above...
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum", "wsum", "->", "sub"} | self.supported_global_constraints), csemap=self._csemap)  # CPLEX supports quadratic constraints and division by constants
-        cpm_cons = only_positive_bv(cpm_cons, csemap=self._csemap)  # after linearization, rewrite ~bv into 1-bv
-        return cpm_cons
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(['sum', 'wsum', 'sub']), csemap=self._csemap)
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum", "sub", "mul"]), csemap=self._csemap)
+        # linearize_reified_variables may append encoding constraints; keep them with the stream
+        value, defining = apply_transform(linearize_reified_variables, value, defining,
+                                                min_values=2, csemap=self._csemap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
+        lin_supported = frozenset({"sum", "wsum", "->", "sub"} | self.supported_global_constraints)
+        value, defining = apply_transform(linearize_constraint, value, defining,
+                                                supported=lin_supported, csemap=self._csemap)
+        value, defining = apply_transform(only_positive_bv, value, defining, csemap=self._csemap)
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_cplex":
       """
@@ -438,7 +444,8 @@ class CPM_cplex(SolverInterface):
       get_variables(cpm_expr, collect=self.user_vars)
 
       # transform and post the constraints
-      for con in self.transform(cpm_expr):
+      _value, _defining = self.transform(cpm_expr)
+      for con in _value + _defining:
 
         # Comparisons: only numeric ones as 'only_implies()' has removed the '==' reification for Boolean expressions
         # numexpr `comp` bvar|const

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -55,6 +55,7 @@ from ..expressions.globalfunctions import GlobalFunction
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
 from ..expressions.utils import is_num, is_int, is_any_list, eval_comparison, argval, argvals, get_bounds, get_nonneg_args, implies
 from ..transformations.get_variables import get_variables
+from ..transformations.flatten_model import apply_transform
 from ..transformations.normalize import toplevel_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.safening import no_partial_functions
@@ -439,14 +440,14 @@ class CPM_cpo(SolverInterface):
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
         # no flattening required
-        return cpm_cons, []
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_cpo":
         """

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -423,7 +423,7 @@ class CPM_cpo(SolverInterface):
         return self.cpo_model.get_objective() is not None
 
     # `add()` first calls `transform()`
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -436,7 +436,7 @@ class CPM_cpo(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
         cpm_cons = toplevel_list(cpm_expr)
@@ -446,7 +446,7 @@ class CPM_cpo(SolverInterface):
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
         # no flattening required
-        return cpm_cons
+        return cpm_cons, []
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_cpo":
         """
@@ -471,7 +471,9 @@ class CPM_cpo(SolverInterface):
         # add new user vars to the set
         get_variables(cpm_expr, collect=self.user_vars)
 
-        for cpm_con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+
+        for cpm_con in _value + _defining:
             # translate each expression tree, then post straight away
             cpo_con = self._cpo_expr(cpm_con, boolexpr=True)
             self.cpo_model.add(cpo_con)

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -60,7 +60,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal, Nested
 from ..expressions.globalfunctions import Multiplication
 from ..expressions.variables import intvar, boolvar, _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.flatten_model import flatten_constraint, flatten_objective
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, only_positive_bv, only_positive_bv_wsum, decompose_linear, decompose_linear_objective, linearize_constraint, linearize_reified_variables
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
@@ -501,7 +501,7 @@ class CPM_exact(SolverInterface):
 
         return xcfvars, self.fix(xrhs)
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
         Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -514,7 +514,7 @@ class CPM_exact(SolverInterface):
             cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
         Returns:
-            list[Expression]: transformed constraints
+            tuple[list[Expression], list[Expression]]: (value, defining)
         """
 
         cpm_cons = toplevel_list(cpm_expr)
@@ -524,16 +524,26 @@ class CPM_exact(SolverInterface):
                                     supported=self.supported_global_constraints,
                                     supported_reified = self.supported_reified_global_constraints,
                                     csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)  # anything that can create full reif should go above...
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum","wsum","->","mul"}), csemap=self._csemap)  # the core of the MIP-linearization
-        cpm_cons = only_positive_bv(cpm_cons, csemap=self._csemap)  # after linearisation, rewrite ~bv into 1-bv
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
 
-        return cpm_cons
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum"]), csemap=self._csemap)  # supports >, <, !=
+
+        value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining,
+                                                csemap=self._csemap)  # anything that can create full reif should go above...
+
+        value, defining = apply_transform(linearize_constraint, value, defining,
+                                                supported=frozenset({"sum","wsum","->","mul"}), csemap=self._csemap)  # the core of the MIP-linearization
+
+        value, defining = apply_transform(only_positive_bv, value, defining,
+                                                csemap=self._csemap)  # after linearisation, rewrite ~bv into 1-bv
+
+
+        return value, defining
 
         # NOTE: the transformations that are still done specifically for Exact are two-fold:
         # transform '==' and '<=' to '>='
@@ -574,7 +584,8 @@ class CPM_exact(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for con in _value + _defining:
             # Comparisons: only numeric ones as 'only_implies()' has removed the '==' reification for Boolean expressions
             # numexpr `comp` bvar|const
             if isinstance(con, Comparison):

--- a/cpmpy/solvers/exact.py
+++ b/cpmpy/solvers/exact.py
@@ -517,14 +517,14 @@ class CPM_exact(SolverInterface):
             tuple[list[Expression], list[Expression]]: (value, defining)
         """
 
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining,
                                     supported=self.supported_global_constraints,
                                     supported_reified = self.supported_reified_global_constraints,
                                     csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
 

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -66,7 +66,7 @@ from ..expressions.utils import is_int, is_any_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.get_variables import get_variables
 from ..transformations.negation import push_down_negation
-from ..transformations.flatten_model import flatten_constraint, get_or_make_var
+from ..transformations.flatten_model import flatten_constraint, get_or_make_var, apply_transform
 from ..transformations.safening import no_partial_functions
 
 from ..transformations.normalize import toplevel_list
@@ -467,7 +467,7 @@ class CPM_gcs(SolverInterface):
         else:
             self.gcs.maximise(self.solver_var(obj_var))
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -480,7 +480,7 @@ class CPM_gcs(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons)
@@ -489,18 +489,21 @@ class CPM_gcs(SolverInterface):
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
 
         # NB: GCS supports full reification for linear equality and linear inequaltiy constraints
         # but no reification for linear not equals and not half reification for linear equality. 
         # Maybe a future transformation (or future work on the GCS solver).
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['==']), csemap=self._csemap)
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]), csemap=self._csemap)  # supports >, <, !=
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(['==']), csemap=self._csemap)
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum"]), csemap=self._csemap)  # supports >, <, !=
+
 
         # NB: GCS supports a small number of simple expressions as the reifying term
         # e.g. (x > 3) -> constraint could in principle be supported in the future.
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        return cpm_cons
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        return value, defining
 
     def verify(self, name=None, location=".", time_limit=None, display_output=False, veripb_args=[]):
         """
@@ -566,7 +569,9 @@ class CPM_gcs(SolverInterface):
         # add new user vars to the set
         get_variables(cpm_expr, collect=self.user_vars)
 
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+
+        for con in _value + _defining:
             if isinstance(con, _BoolVarImpl):
                 # base case, just var or ~var
                 self.gcs.post_or([self.solver_var(con)])

--- a/cpmpy/solvers/gcs.py
+++ b/cpmpy/solvers/gcs.py
@@ -482,14 +482,14 @@ class CPM_gcs(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
 
         # NB: GCS supports full reification for linear equality and linear inequaltiy constraints
         # but no reification for linear not equals and not half reification for linear equality. 

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -591,31 +591,26 @@ class CPM_gurobi(SolverInterface):
         grb_hard_cons = []
         grb_soft_cons = []
 
-        # Defining constraints from softs are posted as hard (already transformed).
-        defining_hard = []
-        # Multi-constraint softs need an indicator; those expressions still need transform.
-        indicator_hard = []
-
         for soft_con in soft_cons:
-            # transform each constraint separately; keep defining cons out of the soft group
+            # transform each constraint seperately, can map to multiple Gurobi-level constraints
             value, defining = s.transform(soft_con)
-            defining_hard.extend(defining)
+            soft_con_tf = value + defining
 
-            if len(value) == 0:
+            if len(soft_con_tf) == 0:
                 # uncommon case, just ensure `grb_soft_con` and `soft` are same length
-                value = [cp.BoolVal(True)]
+                soft_con_tf = [cp.BoolVal(True)]
             
-            if len(value) == 1:
-                # if `con` represented by a single value constraint, it can be added as-is
-                soft_con_rep = value[0]
+            if len(soft_con_tf) == 1:
+                # if `con` represented by a single transformed constraint, it can be added as-is
+                soft_con_rep = soft_con_tf[0]
                 grb_soft_cons.append(s._add_transformed(soft_con_rep))
             else:
-                # We introduce an assumption variable `a` and add *hard* constraints `a -> /\ value`.
+                # We introduce an assumption variable `a` and add *hard* constraints `a -> /\ tf_cons`.
                 # The lower bound fixing `a == 1` is the soft part Gurobi can select in the IIS.
                 assumption = cp.boolvar()
 
-                # add `a -> /\ C` as a hard constraint (value side only; defs already hard)
-                indicator_hard.append(assumption.implies(cp.all(value)))
+                # add `a -> /\ C` as a hard constraint
+                hard.append(assumption.implies(cp.all(soft_con_tf)))
 
                 soft_con_rep = s.solver_var(assumption)
                 soft_con_rep.setAttr("LB", 1)
@@ -623,12 +618,10 @@ class CPM_gurobi(SolverInterface):
 
                 
 
-        # transform and add user hard + indicators; defining is already transformed
-        _value, _defining = s.transform(list(hard) + indicator_hard)
+        # transform and add all hard constraints
+        _value, _defining = s.transform(hard)
         for cpm_con in _value + _defining:
             # use ._add_transformed instead of .add because we need the Gurobi constraint object later
-            grb_hard_cons.append(s._add_transformed(cpm_con))
-        for cpm_con in defining_hard:
             grb_hard_cons.append(s._add_transformed(cpm_con))
 
         # update model so we can access constraint attribtutes

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -393,14 +393,14 @@ class CPM_gurobi(SolverInterface):
         """
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining,
                                     supported=self.supported_global_constraints,
                                     supported_reified=self.supported_reified_global_constraints,
                                     csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset(['sum', 'wsum']), csemap=self._csemap)
         value, defining = apply_transform(only_numexpr_equality, value, defining,
@@ -582,7 +582,7 @@ class CPM_gurobi(SolverInterface):
         Returns a MUS (list of constraints from soft that is unsatisfiable together, and subset minimal).
         """
 
-        soft_cons = toplevel_list(soft, merge_and=False)
+        soft_cons, _ = toplevel_list(soft, merge_and=False)
 
         # instantiate Gurobi solver
         s = cls()

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -57,7 +57,7 @@ from ..expressions.utils import argvals, argval, is_any_list, is_num, is_int
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl, intvar
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.flatten_model import flatten_constraint, flatten_objective
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import linearize_constraint, linearize_reified_variables, only_positive_bv, only_positive_bv_wsum, decompose_linear, decompose_linear_objective
 from ..transformations.normalize import toplevel_list
@@ -376,7 +376,7 @@ class CPM_gurobi(SolverInterface):
 
         raise NotImplementedError("gurobi: Not a known supported numexpr {}".format(cpm_expr))
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -389,7 +389,7 @@ class CPM_gurobi(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations, then post internally
         # expressions have to be linearized to fit in MIP model. See /transformations/linearize
@@ -400,16 +400,21 @@ class CPM_gurobi(SolverInterface):
                                     supported=self.supported_global_constraints,
                                     supported_reified=self.supported_reified_global_constraints,
                                     csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)  # anything that can create full reif should go above...
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(['sum', 'wsum']), csemap=self._csemap)
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum", "sub"]), csemap=self._csemap)
+        value, defining = apply_transform(linearize_reified_variables, value, defining,
+                                                min_values=2, csemap=self._csemap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
         # gurobi does not round towards zero, so no 'div' in supported set: https://github.com/CPMpy/cpmpy/pull/593#issuecomment-2786707188
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum", "wsum","->","sub","min","max","mul","abs","pow"}), csemap=self._csemap)  # the core of the MIP-linearization
-        cpm_cons = only_positive_bv(cpm_cons, csemap=self._csemap)  # after linearization, rewrite ~bv into 1-bv
-        return cpm_cons
+        lin_supported = frozenset({"sum", "wsum", "->", "sub", "min", "max", "mul", "abs", "pow"})
+        value, defining = apply_transform(linearize_constraint, value, defining,
+                                                supported=lin_supported, csemap=self._csemap)
+        value, defining = apply_transform(only_positive_bv, value, defining, csemap=self._csemap)
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_gurobi":
       """
@@ -436,7 +441,8 @@ class CPM_gurobi(SolverInterface):
       get_variables(cpm_expr, collect=self.user_vars)
 
       # transform and post the constraints
-      for con in self.transform(cpm_expr):
+      _value, _defining = self.transform(cpm_expr)
+      for con in _value + _defining:
           self._add_transformed(con)
 
       return self
@@ -585,25 +591,31 @@ class CPM_gurobi(SolverInterface):
         grb_hard_cons = []
         grb_soft_cons = []
 
-        for soft_con in soft_cons:
-            # transform each constraint seperately, can map to multiple Gurobi-level constraints
-            soft_con_tf = s.transform(soft_con)
+        # Defining constraints from softs are posted as hard (already transformed).
+        defining_hard = []
+        # Multi-constraint softs need an indicator; those expressions still need transform.
+        indicator_hard = []
 
-            if len(soft_con_tf) == 0:
+        for soft_con in soft_cons:
+            # transform each constraint separately; keep defining cons out of the soft group
+            value, defining = s.transform(soft_con)
+            defining_hard.extend(defining)
+
+            if len(value) == 0:
                 # uncommon case, just ensure `grb_soft_con` and `soft` are same length
-                soft_con_tf = [cp.BoolVal(True)]
+                value = [cp.BoolVal(True)]
             
-            if len(soft_con_tf) == 1:
-                # if `con` represented by a single transformed constraint, it can be added as-is
-                soft_con_rep = soft_con_tf[0]
+            if len(value) == 1:
+                # if `con` represented by a single value constraint, it can be added as-is
+                soft_con_rep = value[0]
                 grb_soft_cons.append(s._add_transformed(soft_con_rep))
             else:
-                # We introduce an assumption variable `a` and add *hard* constraints `a -> /\ tf_cons`.
+                # We introduce an assumption variable `a` and add *hard* constraints `a -> /\ value`.
                 # The lower bound fixing `a == 1` is the soft part Gurobi can select in the IIS.
                 assumption = cp.boolvar()
 
-                # add `a -> /\ C` as a hard constraint
-                hard.append(assumption.implies(cp.all(soft_con_tf)))
+                # add `a -> /\ C` as a hard constraint (value side only; defs already hard)
+                indicator_hard.append(assumption.implies(cp.all(value)))
 
                 soft_con_rep = s.solver_var(assumption)
                 soft_con_rep.setAttr("LB", 1)
@@ -611,9 +623,12 @@ class CPM_gurobi(SolverInterface):
 
                 
 
-        # transform and add all hard constraints
-        for cpm_con in s.transform(hard):
+        # transform and add user hard + indicators; defining is already transformed
+        _value, _defining = s.transform(list(hard) + indicator_hard)
+        for cpm_con in _value + _defining:
             # use ._add_transformed instead of .add because we need the Gurobi constraint object later
+            grb_hard_cons.append(s._add_transformed(cpm_con))
+        for cpm_con in defining_hard:
             grb_hard_cons.append(s._add_transformed(cpm_con))
 
         # update model so we can access constraint attribtutes

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -347,7 +347,7 @@ class CPM_hexaly(SolverInterface):
 
 
     # `add()` first calls `transform()`
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -360,7 +360,7 @@ class CPM_hexaly(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
         cpm_cons = toplevel_list(cpm_expr)
@@ -369,7 +369,7 @@ class CPM_hexaly(SolverInterface):
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        return cpm_cons
+        return cpm_cons, []
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_hexaly":
         """
@@ -394,7 +394,8 @@ class CPM_hexaly(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for con in _value + _defining:
             hex_expr = self._hex_expr(con)
             self.hex_model.add_constraint(hex_expr)
 

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -55,6 +55,7 @@ from ..expressions.globalfunctions import GlobalFunction, FloatSum
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _IntVarImpl, _NumVarImpl
 from ..expressions.utils import argval, argvals, is_num, is_any_list, eval_comparison, flatlist
 from ..transformations.get_variables import get_variables
+from ..transformations.flatten_model import apply_transform
 from ..transformations.normalize import toplevel_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.safening import no_partial_functions
@@ -363,13 +364,13 @@ class CPM_hexaly(SolverInterface):
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel={"nd_element"})
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel={"nd_element"})
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        return cpm_cons, []
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_hexaly":
         """

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -222,11 +222,11 @@ class CPM_highs(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(cpm_cons, supported=self.supported_global_constraints, supported_reified=self.supported_reified_global_constraints, csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining, supported=self.supported_global_constraints, supported_reified=self.supported_reified_global_constraints, csemap=self._csemap)
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset({"sum", "wsum", "sub"}), csemap=self._csemap)  # constraints that support reification
 

--- a/cpmpy/solvers/highs.py
+++ b/cpmpy/solvers/highs.py
@@ -54,7 +54,7 @@ from ..expressions.variables import NegBoolView, _NumVarImpl, intvar
 from ..expressions.globalfunctions import FloatSum
 from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.flatten_model import flatten_constraint, flatten_objective
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import decompose_linear, decompose_linear_objective, linearize_constraint, linearize_reified_variables, only_positive_bv, only_positive_bv_wsum_const
 from ..transformations.normalize import toplevel_list
@@ -210,7 +210,7 @@ class CPM_highs(SolverInterface):
 
         raise NotImplementedError(f"HiGHS: unexpected linear expression {linexpr}, please report on our issue tracker.")
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports.
 
@@ -220,21 +220,31 @@ class CPM_highs(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = push_down_negation(cpm_cons)
         cpm_cons = decompose_linear(cpm_cons, supported=self.supported_global_constraints, supported_reified=self.supported_reified_global_constraints, csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset({"sum", "wsum", "sub"}), csemap=self._csemap)  # constraints that support reification
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset({"sum", "wsum", "sub"}), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)  # anything that can create full reif should go above...
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum", "wsum"}), csemap=self._csemap)  # the core of the MIP-linearization; rewrites sub to wsum
-        cpm_cons = only_positive_bv(cpm_cons, csemap=self._csemap)  # after linearisation, rewrite ~bv into 1-bv
-        return cpm_cons
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset({"sum", "wsum", "sub"}), csemap=self._csemap)  # constraints that support reification
+
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset({"sum", "wsum", "sub"}), csemap=self._csemap)  # supports >, <, !=
+
+        value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining,
+                                                csemap=self._csemap)  # anything that can create full reif should go above...
+
+        value, defining = apply_transform(linearize_constraint, value, defining,
+                                                supported=frozenset({"sum", "wsum"}), csemap=self._csemap)  # the core of the MIP-linearization; rewrites sub to wsum
+
+        value, defining = apply_transform(only_positive_bv, value, defining,
+                                                csemap=self._csemap)  # after linearisation, rewrite ~bv into 1-bv
+
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_highs":
         """
@@ -252,7 +262,9 @@ class CPM_highs(SolverInterface):
         # track user vars and ensure newly seen ones have solver columns
         get_variables(cpm_expr, collect=self.user_vars)
 
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+
+        for con in _value + _defining:
             if isinstance(con, Comparison):
                 lhs, rhs = con.args
                 if not is_num(rhs):

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -76,6 +76,7 @@ from ..expressions.globalfunctions import Multiplication, FloatSum
 from ..expressions.utils import is_int, is_any_list, get_bounds, get_nonneg_args
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.get_variables import get_variables
+from ..transformations.flatten_model import apply_transform
 from ..transformations.normalize import toplevel_list
 
 
@@ -624,12 +625,12 @@ class CPM_minizinc(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        return cpm_cons, []
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_minizinc":
         """

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -613,7 +613,7 @@ class CPM_minizinc(SolverInterface):
     def has_objective(self):
         return self.mzn_txt_solve != "solve satisfy;"
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Decompose globals not supported (and flatten globalfunctions)
             ensure it is a list of constraints
@@ -622,14 +622,14 @@ class CPM_minizinc(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = decompose_in_tree(cpm_cons,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        return cpm_cons
+        return cpm_cons, []
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_minizinc":
         """
@@ -652,7 +652,8 @@ class CPM_minizinc(SolverInterface):
         """
         get_variables(cpm_expr, collect=self.user_vars)
         # transform and post the constraints
-        for cpm_con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for cpm_con in _value + _defining:
             # Get text expression, add to the solver
             mzn_str = f"constraint {self._convert_expression(cpm_con)};\n"
             self.mzn_model.add_string(mzn_str)

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -455,14 +455,14 @@ class CPM_ortools(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel={"div", "mod"}) # no support for `0` in denominator in API
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel={"div", "mod"}) # no support for `0` in denominator in API
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
 

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -63,7 +63,7 @@ from ..expressions.utils import is_bool, get_nonneg_args, is_num, is_int, eval_c
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
 from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.get_variables import get_variables
-from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, get_or_make_var, apply_transform
 from ..transformations.normalize import toplevel_list
 from ..transformations.reification import only_implies, reify_rewrite, only_bv_reifies
 from ..transformations.comparison import only_numexpr_equality
@@ -440,7 +440,7 @@ class CPM_ortools(SolverInterface):
         raise NotImplementedError("ORTools: Not a known supported numexpr {}".format(cpm_expr))
 
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -453,7 +453,7 @@ class CPM_ortools(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons, safen_toplevel={"div", "mod"}) # no support for `0` in denominator in API
@@ -462,13 +462,17 @@ class CPM_ortools(SolverInterface):
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]), csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)  # everything that can create
-                                             # reified expr must go before this
-        return cpm_cons
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(['sum', 'wsum']), csemap=self._csemap)  # constraints that support reification
+
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum", "sub"]), csemap=self._csemap)  # supports >, <, !=
+
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining,
+                                                csemap=self._csemap)  # everything that can create reified expr must go before this
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_ortools":
         """
@@ -493,7 +497,8 @@ class CPM_ortools(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for con in _value + _defining:
             self._post_constraint(con)
 
         return self

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -271,17 +271,16 @@ class CPM_pindakaas(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(
-            cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining,
             supported=self.supported_global_constraints,
             supported_reified=self.supported_reified_global_constraints,
             csemap=self._csemap,
         )
-        cpm_cons = simplify_boolean(cpm_cons)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(simplify_boolean, value, defining)
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap)
         value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
         value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -45,7 +45,7 @@ from ..exceptions import NotSupportedError
 from ..expressions.core import Expression, BoolVal, Comparison, NestedBoolExprLike
 from ..expressions.utils import eval_comparison, is_int
 from ..expressions.variables import NegBoolView, _BoolVarImpl, _NumVarImpl
-from ..transformations.flatten_model import flatten_constraint
+from ..transformations.flatten_model import flatten_constraint, apply_transform
 from ..transformations.get_variables import get_variables
 from ..transformations.int2bool import _decide_encoding, _encode_int_var, int2bool, replace_int_user_vars
 from ..transformations.linearize import linearize_constraint, linearize_reified_variables, decompose_linear
@@ -141,7 +141,8 @@ class CPM_pindakaas(SolverInterface):
             if isinstance(cpm_var, _NumVarImpl) and not cpm_var.is_bool():
                 if cpm_var.name not in self.ivarmap:
                     _, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
-                    for cpm_expr in self.transform(cons):
+                    _value, _defining = self.transform(cons)
+                    for cpm_expr in _value + _defining:
                         self._post_constraint(cpm_expr)
                 for bv in self.ivarmap[cpm_var.name].vars().flatten():
                     self.solver_var(bv)
@@ -255,7 +256,7 @@ class CPM_pindakaas(SolverInterface):
 
         raise TypeError(f"Unexpected type: {cpm_var}")
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -268,7 +269,7 @@ class CPM_pindakaas(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons)
@@ -280,13 +281,14 @@ class CPM_pindakaas(SolverInterface):
             csemap=self._csemap,
         )
         cpm_cons = simplify_boolean(cpm_cons)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum", "wsum", "->", "and", "or"}), csemap=self._csemap)
-        cpm_cons = int2bool(cpm_cons, self.ivarmap, encoding=self.encoding, csemap=self._csemap)
-        return cpm_cons
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(linearize_constraint, value, defining, supported=frozenset({"sum", "wsum", "->", "and", "or"}), csemap=self._csemap)
+        value, defining = apply_transform(int2bool, value, defining,
+                                          ivarmap=self.ivarmap, encoding=self.encoding, csemap=self._csemap)
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_pindakaas":
         """
@@ -317,7 +319,8 @@ class CPM_pindakaas(SolverInterface):
 
         # transform and post the constraints
         try:
-            for con in self.transform(cpm_expr):
+            _value, _defining = self.transform(cpm_expr)
+            for con in _value + _defining:
                 self._post_constraint(con)
         except pdk.Unsatisfiable:
             self.unsatisfiable = True

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -54,7 +54,7 @@ from ..transformations.get_variables import get_variables
 from ..transformations.linearize import canonical_comparison
 from ..transformations.normalize import toplevel_list
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
-from ..transformations.flatten_model import flatten_constraint, get_or_make_var
+from ..transformations.flatten_model import flatten_constraint, get_or_make_var, apply_transform
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.negation import push_down_negation
 from ..transformations.reification import reify_rewrite, only_bv_reifies, only_implies
@@ -362,7 +362,7 @@ class CPM_pumpkin(SolverInterface):
         return self._objective is not None
 
     # `__add__()` first calls `transform()`
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -375,7 +375,7 @@ class CPM_pumpkin(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
         cpm_cons = toplevel_list(cpm_expr)
@@ -386,14 +386,19 @@ class CPM_pumpkin(SolverInterface):
                                      supported=self.supported_global_constraints - self.disabled_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints - self.disabled_global_constraints,
                                      csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
         supported_halfreif = {"or", "sum", "wsum", "sub", "mul", "div", "abs", "min", "max"}
-        cpm_cons = reify_rewrite(cpm_cons, supported=supported_halfreif, csemap=self._csemap) # reified element not supported yet
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum", "sub"]),csemap=self._csemap)  # supports >, <, !=
-        cpm_cons = canonical_comparison(cpm_cons) # ensure rhs is always a constant
-        return cpm_cons
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=supported_halfreif, csemap=self._csemap)  # reified element not supported yet
+
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum", "sub"]),csemap=self._csemap)  # supports >, <, !=
+
+        value, defining = apply_transform(canonical_comparison, value, defining)  # ensure rhs is always a constant
+
+        return value, defining
 
     def to_predicate(self, cpm_expr):
         """
@@ -576,7 +581,8 @@ class CPM_pumpkin(SolverInterface):
                 else:
                     start, dur, end, demand, cap = cpm_expr.args
                     end_cons = [s + d == e for s,d,e in zip(start, dur, end)]
-                    for cons in self.transform(end_cons):
+                    _value, _defining = self.transform(end_cons)
+                    for cons in _value + _defining:
                         pum_cons.extend(self._get_constraint(cons, tag=tag))
 
                 assert all(is_num(d) for d in dur), "Pumpkin only accepts Cumulative with fixed durations"
@@ -657,7 +663,8 @@ class CPM_pumpkin(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         try:
-            for con in self.transform(cpm_expr):
+            _value, _defining = self.transform(cpm_expr)
+            for con in _value + _defining:
                 if isinstance(con, Operator) and con.name == "->": # found implication
                     bv, subexpr = con.args
                     for pum_cons in self._get_constraint(subexpr):

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -378,15 +378,15 @@ class CPM_pumpkin(SolverInterface):
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # apply transformations
-        cpm_cons = toplevel_list(cpm_expr)
+        value, defining = toplevel_list(cpm_expr)
 
-        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel=frozenset({"div"}))
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel=frozenset({"div"}))
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints - self.disabled_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints - self.disabled_global_constraints,
                                      csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
         value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
         supported_halfreif = {"or", "sum", "wsum", "sub", "mul", "div", "abs", "min", "max"}

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -383,17 +383,16 @@ class CPM_pysat(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(
-            cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining,
             supported=self.supported_global_constraints,
             supported_reified=self.supported_reified_global_constraints,
             csemap=self._csemap
         )
-        cpm_cons = simplify_boolean(cpm_cons) # why is this needed here? Also in flatten_constraint?
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(simplify_boolean, value, defining) # why is this needed here? Also in flatten_constraint?
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)  # flat normal form
         value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap)
         value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
         value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -63,7 +63,7 @@ from ..expressions.globalconstraints import DirectConstraint
 from ..transformations.linearize import only_positive_coefficients, decompose_linear
 from ..expressions.utils import flatlist, is_int
 from ..transformations.get_variables import get_variables
-from ..transformations.flatten_model import flatten_constraint
+from ..transformations.flatten_model import flatten_constraint, apply_transform
 from ..transformations.linearize import linearize_constraint, linearize_reified_variables
 from ..transformations.negation import push_down_negation
 from ..transformations.normalize import toplevel_list, simplify_boolean
@@ -232,7 +232,8 @@ class CPM_pysat(SolverInterface):
             if isinstance(cpm_var, _NumVarImpl) and not cpm_var.is_bool():
                 if cpm_var.name not in self.ivarmap:
                     _, cons = _encode_int_var(self.ivarmap, cpm_var, _decide_encoding(cpm_var, None, encoding=self.encoding))
-                    for cpm_expr in self.transform(cons):
+                    _value, _defining = self.transform(cons)
+                    for cpm_expr in _value + _defining:
                         self._post_constraint(cpm_expr)
                 for bv in self.ivarmap[cpm_var.name].vars().flatten():
                     self.solver_var(bv)
@@ -360,7 +361,7 @@ class CPM_pysat(SolverInterface):
 
         raise NotImplementedError(f"CPM_pysat: variable {cpm_var} not supported")
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -380,7 +381,7 @@ class CPM_pysat(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons)
@@ -392,14 +393,17 @@ class CPM_pysat(SolverInterface):
             csemap=self._csemap
         )
         cpm_cons = simplify_boolean(cpm_cons) # why is this needed here? Also in flatten_constraint?
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum","wsum", "->", "and", "or"}), csemap=self._csemap)  # the core of the MIP-linearization
-        cpm_cons = int2bool(cpm_cons, self.ivarmap, encoding=self.encoding, csemap=self._csemap)
-        cpm_cons = only_positive_coefficients(cpm_cons)
-        return cpm_cons
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)  # flat normal form
+        value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap, ivarmap=self.ivarmap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(linearize_constraint, value, defining,
+                                                supported=frozenset({"sum","wsum", "->", "and", "or"}), csemap=self._csemap)  # the core of the MIP-linearization
+
+        value, defining = apply_transform(int2bool, value, defining,
+                                          ivarmap=self.ivarmap, encoding=self.encoding, csemap=self._csemap)
+        value, defining = apply_transform(only_positive_coefficients, value, defining)
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_pysat":
         """
@@ -427,7 +431,8 @@ class CPM_pysat(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for con in _value + _defining:
             self._post_constraint(con)
 
         return self

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -286,7 +286,7 @@ class CPM_pysdd(SolverInterface):
 
         raise NotImplementedError("Not a known var {}".format(cpm_var))
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -301,7 +301,7 @@ class CPM_pysdd(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # works on list of nested expressions
         cpm_cons = toplevel_list(cpm_expr)
@@ -311,7 +311,7 @@ class CPM_pysdd(SolverInterface):
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
         cpm_cons = simplify_boolean(cpm_cons)  # for cleaning (BE >= 0) and such
-        return cpm_cons
+        return cpm_cons, []
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_pysdd":
         """
@@ -340,7 +340,8 @@ class CPM_pysdd(SolverInterface):
 
         # transform and post the constraints
         # XXX the order in the for loop will matter on runtime efficiency...
-        for cpm_con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for cpm_con in _value + _defining:
             # replace root by conjunction of itself and the con expression
             self.pysdd_root = self.pysdd_manager.conjoin(self.pysdd_root,
                                                 self._pysdd_expr(cpm_con))

--- a/cpmpy/solvers/pysdd.py
+++ b/cpmpy/solvers/pysdd.py
@@ -54,6 +54,7 @@ from ..expressions.globalconstraints import DirectConstraint
 from ..expressions.utils import is_bool, is_int, argvals, is_any_list
 from ..transformations.decompose_global import decompose_in_tree
 from ..transformations.get_variables import get_variables
+from ..transformations.flatten_model import apply_transform
 from ..transformations.normalize import toplevel_list, simplify_boolean
 from ..transformations.safening import no_partial_functions
 
@@ -304,14 +305,14 @@ class CPM_pysdd(SolverInterface):
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
         # works on list of nested expressions
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        cpm_cons = simplify_boolean(cpm_cons)  # for cleaning (BE >= 0) and such
-        return cpm_cons, []
+        value, defining = apply_transform(simplify_boolean, value, defining)  # for cleaning (BE >= 0) and such
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_pysdd":
         """

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -321,11 +321,11 @@ class CPM_scip(SolverInterface):
             Returns:
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons)
-        cpm_cons = push_down_negation(cpm_cons)
-        cpm_cons = decompose_linear(cpm_cons, supported=self.supported_global_constraints, supported_reified=self.supported_reified_global_constraints, csemap=self._csemap)
-        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining)
+        value, defining = apply_transform(push_down_negation, value, defining)
+        value, defining = apply_transform(decompose_linear, value, defining, supported=self.supported_global_constraints, supported_reified=self.supported_reified_global_constraints, csemap=self._csemap)
+        value, defining = apply_transform(flatten_constraint, value, defining, csemap=self._csemap)
         value, defining = apply_transform(reify_rewrite, value, defining,
             supported=frozenset(["sum", "wsum"]), csemap=self._csemap)
         value, defining = apply_transform(only_numexpr_equality, value, defining,

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -41,7 +41,7 @@ from ..expressions.globalfunctions import GlobalFunction, FloatSum
 from ..expressions.utils import is_num, is_int, is_true_cst, is_false_cst
 from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.comparison import only_numexpr_equality
-from ..transformations.flatten_model import flatten_constraint, flatten_objective
+from ..transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from ..transformations.get_variables import get_variables
 from ..transformations.linearize import decompose_linear, decompose_linear_objective, linearize_constraint, linearize_reified_variables, only_positive_bv, only_positive_bv_wsum
 from ..transformations.normalize import toplevel_list
@@ -263,7 +263,8 @@ class CPM_scip(SolverInterface):
             obj = only_positive_bv_wsum(obj)
 
             # transform and add constraints (via `_add_transformed_constraint` as to not pollute `user_vars`)
-            for cpm_expr in self.transform(safe_cons + decomp_cons + flat_cons):
+            _value, _defining = self.transform(safe_cons + decomp_cons + flat_cons)
+            for cpm_expr in _value + _defining:
                 self._add_transformed_constraint(cpm_expr)
 
             scip_obj = self._make_numexpr(obj)
@@ -305,7 +306,7 @@ class CPM_scip(SolverInterface):
         raise NotImplementedError("scip: Not a known supported numexpr {}".format(cpm_expr))
 
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -318,21 +319,23 @@ class CPM_scip(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
         cpm_cons = toplevel_list(cpm_expr)
         cpm_cons = no_partial_functions(cpm_cons)
         cpm_cons = push_down_negation(cpm_cons)
         cpm_cons = decompose_linear(cpm_cons, supported=self.supported_global_constraints, supported_reified=self.supported_reified_global_constraints, csemap=self._csemap)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self._csemap)
-        cpm_cons = reify_rewrite(cpm_cons, supported=frozenset(["sum", "wsum"]), csemap=self._csemap)
-        cpm_cons = only_numexpr_equality(cpm_cons, supported=frozenset(["sum", "wsum"]), csemap=self._csemap)
-        cpm_cons = linearize_reified_variables(cpm_cons, min_values=2, csemap=self._csemap)
-        cpm_cons = only_bv_reifies(cpm_cons, csemap=self._csemap)
-        cpm_cons = only_implies(cpm_cons, csemap=self._csemap)
-        cpm_cons = linearize_constraint(cpm_cons, supported=frozenset({"sum", "wsum", "abs", "->"}) | self.supported_global_constraints, csemap=self._csemap)
-        cpm_cons = only_positive_bv(cpm_cons, csemap=self._csemap)
-        return cpm_cons
+        value, defining = flatten_constraint(cpm_cons, csemap=self._csemap)
+        value, defining = apply_transform(reify_rewrite, value, defining,
+            supported=frozenset(["sum", "wsum"]), csemap=self._csemap)
+        value, defining = apply_transform(only_numexpr_equality, value, defining,
+            supported=frozenset(["sum", "wsum"]), csemap=self._csemap)
+        value, defining = apply_transform(linearize_reified_variables, value, defining, min_values=2, csemap=self._csemap)
+        value, defining = apply_transform(only_bv_reifies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(only_implies, value, defining, csemap=self._csemap)
+        value, defining = apply_transform(linearize_constraint, value, defining, supported=frozenset({"sum", "wsum", "abs", "->"}) | self.supported_global_constraints, csemap=self._csemap)
+        value, defining = apply_transform(only_positive_bv, value, defining, csemap=self._csemap)
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_scip":
         """
@@ -357,7 +360,9 @@ class CPM_scip(SolverInterface):
         # Ensure every user var has a solver variable (so we get values after solve even if the constraint was simplified away and the var never appears in transformed constraints)
         self.solver_vars(list(self.user_vars))
 
-        for con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+
+        for con in _value + _defining:
             self._add_transformed_constraint(con)
 
         return self

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -200,9 +200,14 @@ class SolverInterface(object):
                 res.append(self.solver_var(cpm_var))
         return res
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
-            Transform arbitrary CPMpy expressions to constraints the solver supports
+            Transform arbitrary CPMpy expressions to constraints the solver supports.
+
+            Returns a pair ``(value, defining)``:
+            *value* is the rewritten form of the input constraints;
+            *defining* are CSE / ``get_or_make_var`` side constraints (e.g. ``abs(x) == IV``).
+            Callers that do not need the split can post ``value + defining``.
 
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.
@@ -213,9 +218,9 @@ class SolverInterface(object):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: ``(value, defining)``
         """
-        return toplevel_list(cpm_expr)  # replace by the transformations your solver needs
+        return toplevel_list(cpm_expr), []  # replace by the transformations your solver needs
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "SolverInterface":
         """
@@ -240,7 +245,8 @@ class SolverInterface(object):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for con in self.transform(cpm_expr):
+        value, defining = self.transform(cpm_expr)
+        for con in value + defining:
             raise NotImplementedError("solver add(): abstract function, overwrite")
 
         return self

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -205,8 +205,16 @@ class SolverInterface(object):
             Transform arbitrary CPMpy expressions to constraints the solver supports.
 
             Returns a pair ``(value, defining)``:
-            *value* is the rewritten form of the input constraints;
-            *defining* are CSE / ``get_or_make_var`` side constraints (e.g. ``abs(x) == IV``).
+
+            - *value*: the rewritten form of the input constraints (what the caller
+              asked for, after transformations).
+            - *defining*: constraints that (totally) define auxiliary variables
+              introduced along the way. They can always be posted as top-level
+              hard constraints. Typical examples include CSE /
+              ``get_or_make_var`` equalities (e.g. ``abs(x) == IV``), and
+              encoding/domain constraints that link Boolean literals to integer
+              variables (e.g. exactly-one / channeling from ``int2bool``).
+
             Callers that do not need the split can post ``value + defining``.
 
             Implemented through chaining multiple solver-independent **transformation functions** from

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -215,7 +215,7 @@ class SolverInterface(object):
               encoding/domain constraints that link Boolean literals to integer
               variables (e.g. exactly-one / channeling from ``int2bool``).
 
-            Callers that do not need the split can post ``value + defining``.
+            Callers that do not need the split can concatenate the lists ``value + defining``.
 
             Implemented through chaining multiple solver-independent **transformation functions** from
             the `cpmpy/transformations/` directory.

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -220,7 +220,7 @@ class SolverInterface(object):
             Returns:
                 tuple[list[Expression], list[Expression]]: ``(value, defining)``
         """
-        return toplevel_list(cpm_expr), []  # replace by the transformations your solver needs
+        return toplevel_list(cpm_expr)  # replace by the transformations your solver needs
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "SolverInterface":
         """

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -361,7 +361,7 @@ class CPM_z3(SolverInterface):
             self.obj_handle = self.z3_solver.maximize(z3_obj)
             self._minimize = False # record direction of optimisation
 
-    def transform(self, cpm_expr: NestedBoolExprLike) -> list[Expression]:
+    def transform(self, cpm_expr: NestedBoolExprLike) -> tuple[list[Expression], list[Expression]]:
         """
             Transform arbitrary CPMpy expressions to constraints the solver supports
 
@@ -374,7 +374,7 @@ class CPM_z3(SolverInterface):
                 cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
 
             Returns:
-                list[Expression]: transformed constraints
+                tuple[list[Expression], list[Expression]]: (value, defining)
         """
 
         cpm_cons = toplevel_list(cpm_expr)
@@ -383,7 +383,7 @@ class CPM_z3(SolverInterface):
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        return cpm_cons
+        return cpm_cons, []
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_z3":
         """
@@ -409,7 +409,8 @@ class CPM_z3(SolverInterface):
         get_variables(cpm_expr, collect=self.user_vars)
 
         # transform and post the constraints
-        for cpm_con in self.transform(cpm_expr):
+        _value, _defining = self.transform(cpm_expr)
+        for cpm_con in _value + _defining:
             # translate each expression tree, then post straight away
             z3_con = self._z3_expr(cpm_con)
             self.z3_solver.add(z3_con)

--- a/cpmpy/solvers/z3.py
+++ b/cpmpy/solvers/z3.py
@@ -58,6 +58,7 @@ from ..expressions.globalfunctions import GlobalFunction, FloatSum
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl, _IntVarImpl
 from ..expressions.utils import is_num, is_any_list, is_bool, is_int, is_boolexpr, eval_comparison
 from ..transformations.decompose_global import decompose_in_tree, decompose_objective
+from ..transformations.flatten_model import apply_transform
 from ..transformations.normalize import toplevel_list
 from ..transformations.safening import no_partial_functions, safen_objective
 
@@ -377,13 +378,13 @@ class CPM_z3(SolverInterface):
                 tuple[list[Expression], list[Expression]]: (value, defining)
         """
 
-        cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons, safen_toplevel=frozenset({"div", "mod"}))
-        cpm_cons = decompose_in_tree(cpm_cons,
+        value, defining = toplevel_list(cpm_expr)
+        value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel=frozenset({"div", "mod"}))
+        value, defining = apply_transform(decompose_in_tree, value, defining,
                                      supported=self.supported_global_constraints,
                                      supported_reified=self.supported_reified_global_constraints,
                                      csemap=self._csemap)
-        return cpm_cons, []
+        return value, defining
 
     def add(self, cpm_expr: NestedBoolExprLike) -> "CPM_z3":
         """

--- a/cpmpy/tools/explain/mcs.py
+++ b/cpmpy/tools/explain/mcs.py
@@ -26,7 +26,7 @@ def mcs_opt(soft, hard, weights=1, solver="ortools"):
         :param: weights: weight of each constraint, default is 1
         :param: solver: the SAT-solver to use, must support optimization
     """
-    soft2 = toplevel_list(soft, merge_and=False)
+    soft2, _ = toplevel_list(soft, merge_and=False)
     mymss = mss_opt(soft2, hard, weights, solver=solver)
     return list(set(soft2) - set(mymss))
 
@@ -41,7 +41,7 @@ def mcs_grow(soft, hard, solver="ortools"):
         :param: hard: list of hard constraints, will be added to the model before solving
         :param: solver: the SAT-solver to use, must support assumptions
     """
-    soft2 = toplevel_list(soft, merge_and=False)
+    soft2, _ = toplevel_list(soft, merge_and=False)
     mymss = mss_grow(soft2, hard, solver)
     return list(set(soft2) - set(mymss))
 
@@ -57,6 +57,6 @@ def mcs_grow_naive(soft, hard, solver="ortools"):
         :param: hard: list of hard constraints, will be added to the model before solving
         :param: solver: the SAT-solver to use, ideally incremental such as "gurobi", "exact"
     """
-    soft2 = toplevel_list(soft, merge_and=False)
+    soft2, _ = toplevel_list(soft, merge_and=False)
     mymss = mss_grow_naive(soft2, hard, solver)
     return list(set(soft2) - set(mymss))

--- a/cpmpy/tools/explain/mss.py
+++ b/cpmpy/tools/explain/mss.py
@@ -91,7 +91,7 @@ def mss_grow_naive(soft, hard=[], solver="ortools"):
         :param: solver: the SAT-solver to use, ideally incremental such as "gurobi", "exact"
     """
 
-    soft = toplevel_list(soft, merge_and=False)
+    soft, _ = toplevel_list(soft, merge_and=False)
     if not is_any_list(hard):
         hard = [hard]
     else:

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -234,7 +234,7 @@ def mus_naive(soft, hard=[], solver="ortools"):
         :param solver: name of a solver, see SolverLookup.solvernames()
     """
     # ensure toplevel list
-    soft = toplevel_list(soft, merge_and=False)
+    soft, _ = toplevel_list(soft, merge_and=False)
 
     m = cp.Model(hard + soft)
     assert not m.solve(solver=solver), "MUS: model must be UNSAT"
@@ -268,7 +268,7 @@ def quickxplain_naive(soft, hard=[], solver="ortools"):
             https://cdn.aaai.org/AAAI/2004/AAAI04-027.pdf
     """
 
-    soft = toplevel_list(soft, merge_and=False)
+    soft, _ = toplevel_list(soft, merge_and=False)
     assert cp.Model(hard + soft).solve(solver) is False, "The model should be UNSAT!"
 
     # the recursive call
@@ -299,7 +299,7 @@ def ocus_naive(soft, hard=[], weights=None, meta_constraint=True, solver="ortool
     """
         Naive implementation of `ocus` without assumption variables and incremental solving
     """
-    soft = toplevel_list(soft, merge_and=False)
+    soft, _ = toplevel_list(soft, merge_and=False)
     bvs = cp.boolvar(shape=(len(soft),))
 
     if weights is None:

--- a/cpmpy/tools/explain/utils.py
+++ b/cpmpy/tools/explain/utils.py
@@ -29,13 +29,13 @@ def make_assump_model(soft, hard=[], name=None):
         Provide name for assumption variables with `name` param.
     """
     # ensure toplevel list
-    soft2 = toplevel_list(soft, merge_and=False)
+    soft2, _ = toplevel_list(soft, merge_and=False)
 
     # make assumption variables
     assump = cp.boolvar(shape=(len(soft2),), name=name)
 
     # hard + implied soft constraints
-    hard = toplevel_list(hard)
+    hard, _ = toplevel_list(hard)
     model = cp.Model(hard + [assump.implies(soft2)])  # each assumption variable implies a candidate
 
     return model, soft2, assump

--- a/cpmpy/tools/xcsp3/xcsp3_cpmpy.py
+++ b/cpmpy/tools/xcsp3/xcsp3_cpmpy.py
@@ -660,7 +660,7 @@ def xcsp3_cpmpy(
         # Model.add() may leave nested lists (e.g. element-matrix index bounds); flatten first
         if solver in added_natives:
             from cpmpy.transformations.normalize import toplevel_list
-            model.constraints = toplevel_list(model.constraints)
+            model.constraints, _ = toplevel_list(model.constraints)
             for i, constraint in enumerate(model.constraints):
                 if constraint.name in added_natives[solver]:
                     model.constraints[i] = added_natives[solver][constraint.name](constraint.args)

--- a/cpmpy/transformations/comparison.py
+++ b/cpmpy/transformations/comparison.py
@@ -16,11 +16,11 @@
 
 import copy
 from .flatten_model import get_or_make_var
-from ..expressions.core import Comparison, Operator
+from ..expressions.core import Comparison, Operator, Expression
 from ..expressions.utils import is_boolexpr
 from ..expressions.variables import _NumVarImpl, _BoolVarImpl
 
-def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
+def only_numexpr_equality(constraints, supported=frozenset(), csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
         Transforms ``NumExpr <op> IV`` to ``(NumExpr == A) & (A <op> IV)`` if not supported.
         Also for the reified uses of `NumExpr`
@@ -31,8 +31,8 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
             tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
 
-    value = []
-    defining = []
+    value: list[Expression] = []
+    defining: list[Expression] = []
     for cpm_expr in constraints:
 
         if isinstance(cpm_expr, Operator) and cpm_expr.name == "->":

--- a/cpmpy/transformations/comparison.py
+++ b/cpmpy/transformations/comparison.py
@@ -26,9 +26,13 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
         Also for the reified uses of `NumExpr`
 
         :param supported:  a (frozen)set of expression names that supports all comparisons in the solver
+
+        Returns:
+            tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
 
-    newlist = []
+    value = []
+    defining = []
     for cpm_expr in constraints:
 
         if isinstance(cpm_expr, Operator) and cpm_expr.name == "->":
@@ -38,7 +42,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
             elif not isinstance(subexpr, _BoolVarImpl): # bv -> expr
                 idx = 1
             else: # bv -> bv
-                newlist.append(cpm_expr)
+                value.append(cpm_expr)
                 continue
 
             new_arg, new_cons = _rewrite_comparison(cpm_expr.args[idx], supported=supported,csemap=csemap)
@@ -48,7 +52,8 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
                 args[idx] = new_arg                
                 cpm_expr.update_args(args) # XXX redundant? we know it's flat so no subexprs anyway
             
-            newlist += [cpm_expr] + new_cons
+            value.append(cpm_expr)
+            defining.extend(new_cons)
 
             
         elif isinstance(cpm_expr, Comparison):
@@ -59,7 +64,7 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
                 elif not isinstance(rhs, _BoolVarImpl):  # bv == expr
                     idx = 1
                 else: # bv == bv
-                    newlist.append(cpm_expr)
+                    value.append(cpm_expr)
                     continue
 
                 # identical to the above, but keep for readability?
@@ -70,20 +75,22 @@ def only_numexpr_equality(constraints, supported=frozenset(), csemap=None):
                     args[idx] = new_arg
                     cpm_expr.update_args(args) # XXX redundant? we know it's flat so no subexprs anyway
 
-                newlist += [cpm_expr] + new_cons
+                value.append(cpm_expr)
+                defining.extend(new_cons)
 
             elif cpm_expr.name != "==": # numerical comparison
                 new_expr, new_cons = _rewrite_comparison(cpm_expr, supported=supported,csemap=csemap)
-                newlist += [new_expr] + new_cons
+                value.append(new_expr)
+                defining.extend(new_cons)
             
             else:
-                newlist.append(cpm_expr) # equality constraint, keep
+                value.append(cpm_expr) # equality constraint, keep
 
         else:
             # default, keep original
-            newlist.append(cpm_expr)
-                
-    return newlist
+            value.append(cpm_expr)
+
+    return value, defining
 
 
 def _rewrite_comparison(cpm_expr, supported=frozenset(), csemap=None):

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -46,7 +46,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       csemap: Optional[CSEMap] = None,
                       decompose_custom: Optional[Dict[str, CustomDecomp]] = None,
                       decompose_custom_positive: Optional[Dict[str, CustomDecomp]] = None,
-                      ):
+                      ) -> tuple[list[Expression], list[Expression]]:
     """
     Decomposes global constraint or global function not supported by the solver.
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -26,6 +26,7 @@ import numpy as np
 
 
 from .cse import CSEMap
+from .flatten_model import apply_transform
 from ..expressions.core import Expression, BoolVal, Operator
 from ..expressions.globalconstraints import GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction
@@ -91,7 +92,6 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     todolist: list[Expression] = []  # value constraints that still need to be decomposed
     defining_todo: list[Expression] = []  # defining constraints that still need to be decomposed
     newlist: list[Expression] = []
-    defining: list[Expression] = []
     changed = False
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
@@ -186,15 +186,14 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             newlist.append(expr)
 
     # recurse on newly generated value and defining expressions separately
-    decomp_kwargs = dict(supported=supported, supported_reified=supported_reified, csemap=csemap,
-                         decompose_custom=decompose_custom, decompose_custom_positive=decompose_custom_positive)
     if len(todolist) > 0 or len(defining_todo) > 0:
-        v, d_from_v = decompose_in_tree(todolist, **decomp_kwargs) if todolist else ([], [])
-        # rewritten defining stay defining (same merge rule as apply_transform)
-        dv, d_from_d = decompose_in_tree(defining_todo, **decomp_kwargs) if defining_todo else ([], [])
-        return newlist + list(v), list(defining) + list(d_from_v) + list(dv) + list(d_from_d)
+        v, d = apply_transform(decompose_in_tree, todolist, defining_todo,
+                               supported=supported, supported_reified=supported_reified, csemap=csemap,
+                               decompose_custom=decompose_custom,
+                               decompose_custom_positive=decompose_custom_positive)
+        return newlist + v, d
     elif changed:
-        return newlist, defining
+        return newlist, []
     else:  # not changed
         return lst_of_expr, []
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -62,7 +62,9 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :param decompose_custom_positive: a dictionary mapping names of global constraints to their custom decompositions, which are valid only in positive context.
 
     Returns:
-        tuple[list[Expression], list[Expression]]: ``(value, defining)``
+        tuple[list[Expression], list[Expression]]: ``(value, defining)``.
+        Defining are the second lists from ``decompose()`` / ``decompose_positive()``
+        (and from nested global/function decompositions); they stay on the defining stream.
 
     To decompose a global constraint in positive context:
     1. Check `decompose_positive_custom`
@@ -86,8 +88,10 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     if supported_reified is None:
         supported_reified = frozenset[str]()
 
-    todolist: list[Expression] = []  # these still need to be decomposed
+    todolist: list[Expression] = []  # value constraints that still need to be decomposed
+    defining_todo: list[Expression] = []  # defining constraints that still need to be decomposed
     newlist: list[Expression] = []
+    defining: list[Expression] = []
     changed = False
     for expr in lst_of_expr:
         if isinstance(expr, GlobalConstraint) and expr.name not in supported:
@@ -110,10 +114,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                 exprs, toplevel_exprs = decompose_custom[expr.name](expr)
             else:
                 exprs, toplevel_exprs = expr.decompose_positive()
-            # we merge the list toplevel rather than create an 'and'
-            # we add them to todolist because both might contain globals
-            if len(toplevel_exprs) > 0:
-                todolist.extend(toplevel_exprs)
+            # value side may still contain globals; defining side too (recurse separately)
             if len(exprs) > 0:
                 todolist.extend(exprs)
                 # don't save toplevel decompositions to the csemap, 
@@ -123,6 +124,8 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                 #         csemap.save_decomposition(expr, exprs[0])
                 #     else:
                 #         csemap.save_decomposition(expr, Operator("and", exprs))
+            if len(toplevel_exprs) > 0:
+                defining_todo.extend(toplevel_exprs)
         
         elif isinstance(expr, (bool, np.bool_)):
             # TODO: violates type!!! from `.decompose()` functions that are not cleaned yet
@@ -132,7 +135,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
         elif expr.name == "not":  # not(global) or negation left by a decomposition
             args_changed, expr_newargs, expr_toplevel = _decompose_in_tree_args(expr.args, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
             if len(expr_toplevel) > 0:
-                todolist.extend(expr_toplevel)
+                defining_todo.extend(expr_toplevel)
             if not args_changed:
                 expr_newargs = expr.args  # lets be sure its set
 
@@ -162,7 +165,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                 else:
                     exprs, toplevel_exprs = subexpr.decompose_positive()
                 if len(toplevel_exprs) > 0:
-                    todolist.extend(toplevel_exprs)
+                    defining_todo.extend(toplevel_exprs)
                 expr = Operator("->", [expr.args[0], cpm_all(exprs)])   
                 decomposed_positive = True
 
@@ -171,7 +174,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             if args_changed:
                 changed = True
                 if len(expr_toplevel) > 0:
-                    todolist.extend(expr_toplevel)
+                    defining_todo.extend(expr_toplevel)
 
                 # if decompose_positive: we know 'expr' is a fresh expression
                 if not decomposed_positive:
@@ -182,12 +185,16 @@ def decompose_in_tree(lst_of_expr: list[Expression],
         else:
             newlist.append(expr)
 
-    # recurse on any newly generated toplevel expressions
-    if len(todolist) > 0:
-        v, d = decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-        return newlist + v, d
+    # recurse on newly generated value and defining expressions separately
+    decomp_kwargs = dict(supported=supported, supported_reified=supported_reified, csemap=csemap,
+                         decompose_custom=decompose_custom, decompose_custom_positive=decompose_custom_positive)
+    if len(todolist) > 0 or len(defining_todo) > 0:
+        v, d_from_v = decompose_in_tree(todolist, **decomp_kwargs) if todolist else ([], [])
+        # rewritten defining stay defining (same merge rule as apply_transform)
+        dv, d_from_d = decompose_in_tree(defining_todo, **decomp_kwargs) if defining_todo else ([], [])
+        return newlist + list(v), list(defining) + list(d_from_v) + list(dv) + list(d_from_d)
     elif changed:
-        return newlist, []
+        return newlist, defining
     else:  # not changed
         return lst_of_expr, []
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -62,7 +62,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :param decompose_custom_positive: a dictionary mapping names of global constraints to their custom decompositions, which are valid only in positive context.
 
     Returns:
-        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
+        tuple[list[Expression], list[Expression]]: ``(value, defining)``
 
     To decompose a global constraint in positive context:
     1. Check `decompose_positive_custom`
@@ -185,7 +185,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     # recurse on any newly generated toplevel expressions
     if len(todolist) > 0:
         v, d = decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
-        return newlist + v + d, []
+        return newlist + v, d
     elif changed:
         return newlist, []
     else:  # not changed

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -46,7 +46,7 @@ def decompose_in_tree(lst_of_expr: list[Expression],
                       csemap: Optional[CSEMap] = None,
                       decompose_custom: Optional[Dict[str, CustomDecomp]] = None,
                       decompose_custom_positive: Optional[Dict[str, CustomDecomp]] = None,
-                      ) -> list[Expression]:
+                      ):
     """
     Decomposes global constraint or global function not supported by the solver.
 
@@ -60,6 +60,9 @@ def decompose_in_tree(lst_of_expr: list[Expression],
     :param csemap: CSEMap object used to avoid decomposing the same global constraint twice
     :param decompose_custom: a dictionary mapping names of global constraints to their custom decompositions.
     :param decompose_custom_positive: a dictionary mapping names of global constraints to their custom decompositions, which are valid only in positive context.
+
+    Returns:
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
 
     To decompose a global constraint in positive context:
     1. Check `decompose_positive_custom`
@@ -181,11 +184,12 @@ def decompose_in_tree(lst_of_expr: list[Expression],
 
     # recurse on any newly generated toplevel expressions
     if len(todolist) > 0:
-        return newlist + decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+        v, d = decompose_in_tree(todolist, supported=supported, supported_reified=supported_reified, csemap=csemap, decompose_custom=decompose_custom)
+        return newlist + v + d, []
     elif changed:
-        return newlist
+        return newlist, []
     else:  # not changed
-        return lst_of_expr
+        return lst_of_expr, []
 
 
 def decompose_objective(expr: Expression,

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -151,9 +151,9 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
     # for backwards compatibility reasons, we now consider it a meta-
     # transformation, that calls (preceding) transformations itself
     # e.g. `toplevel_list()` ensures it is a list
-    lst_of_expr = toplevel_list(expr)               # ensure it is a list
+    lst_of_expr, _ = toplevel_list(expr)               # ensure it is a list
     if do_simplify:
-        lst_of_expr = simplify_boolean(lst_of_expr)     # simplify boolean expressions, and ensure types are correct
+        lst_of_expr, _ = simplify_boolean(lst_of_expr)     # simplify boolean expressions, and ensure types are correct
     for expr in lst_of_expr:
 
         if not expr.has_subexpr():
@@ -337,7 +337,8 @@ def flatten_objective(expr, supported=frozenset(["sum", "wsum"]), csemap=None):
         # one source of errors is sum(v) where v is a matrix, use v.sum() instead
         raise Exception(f"Objective expects a single variable/expression, not a list of expressions: {expr}")
 
-    expr = simplify_boolean([expr])[0]
+    expr, _ = simplify_boolean([expr])
+    expr = expr[0]
     (flatexpr, flatcons) = normalized_numexpr(expr, csemap=csemap)  # might rewrite expr into a (w)sum
     if isinstance(flatexpr, Expression) and flatexpr.name in supported:
         return (flatexpr, flatcons)

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -311,27 +311,22 @@ def flatten_constraint(expr, csemap=None, do_simplify=True) -> tuple[list[Expres
     return value, defining
 
 
-def apply_transform(transform, value, defining, **kwargs):
+def apply_transform(transform, value, defining, **kwargs)-> tuple[list[Expression], list[Expression]]:
     """
         Apply a ``(list) -> (value, defining)`` transform to both streams and merge.
 
-        ``transform`` is run on ``value`` and on ``defining`` separately. New defining
-        constraints from either call are appended to the defining stream; rewritten
-        defining constraints stay defining.
+        ``transform`` is run on ``value`` and on ``defining`` separately. Only the new value
+        constraints from ``value`` are returned as value constraints. All other constraints are returned 
+        as defining constraints.
     """
-    v2, d_from_v = transform(value, **kwargs)
-    d2, d_from_d = transform(defining, **kwargs)
-    return list(v2), list(d2) + list(d_from_v) + list(d_from_d)
+    vv, dv = transform(value, **kwargs)
+    vd, dd = transform(defining, **kwargs)
+    return list(vv), list(vd) + list(dv) + list(dd)
 
 
-def flatten_objective(expr, supported=frozenset(["sum", "wsum"]), csemap=None):
+def flatten_objective(expr, supported=frozenset(["sum", "wsum"]), csemap=None) -> tuple[Expression, list[Expression]]:
     """
-    - Decision variable: Var
-    - Linear: 
-        ======================                       ========
-        sum([Var])                                   (CPMpy class 'Operator', name 'sum')
-        wsum([Const],[Var])                          (CPMpy class 'Operator', name 'wsum')
-        ======================                       ========
+        Returns the flattened objective expression and the defining constraints.
     """
     # lets be very explicit here
     if is_any_list(expr):

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -123,7 +123,7 @@ def flatten_model(orig_model, csemap=None):
             return cp.Model(*basecons, maximize=newobj)
 
 
-def flatten_constraint(expr, csemap=None, do_simplify=True):
+def flatten_constraint(expr, csemap=None, do_simplify=True) -> tuple[list[Expression], list[Expression]]:
     """
         input is any expression; except is_num(), pure _NumVarImpl,
         or Operator/GlobalConstraint with not is_bool()

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -136,8 +136,9 @@ def flatten_constraint(expr, csemap=None, do_simplify=True) -> tuple[list[Expres
         Returns:
             tuple[list[Expression], list[Expression]]:
                 ``(value, defining)``. *value* is the flattened form of the input;
-                *defining* are CSE / ``get_or_make_var`` side constraints
-                (e.g. ``abs(x) == IV``). Callers that do not need the split can use
+                *defining* are constraints that define auxiliary variables created
+                while flattening (e.g. CSE / ``get_or_make_var`` equalities such as
+                ``abs(x) == IV``). Callers that do not need the split can use
                 ``value + defining``.
 
         it will return 'Exception' if something is not supported

--- a/cpmpy/transformations/flatten_model.py
+++ b/cpmpy/transformations/flatten_model.py
@@ -108,7 +108,8 @@ def flatten_model(orig_model, csemap=None):
     """
 
     # the top-level constraints
-    basecons = flatten_constraint(orig_model.constraints, csemap=csemap)
+    value, defining = flatten_constraint(orig_model.constraints, csemap=csemap)
+    basecons = value + defining
 
     # the objective
     if orig_model.objective_ is None:
@@ -132,7 +133,12 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
             csemap: a CSEMap object to store the flattened expressions
             do_simplify: whether to simplify -> operators during flattening, might remove variables
         
-        output: see definition of 'flat normal form' above.
+        Returns:
+            tuple[list[Expression], list[Expression]]:
+                ``(value, defining)``. *value* is the flattened form of the input;
+                *defining* are CSE / ``get_or_make_var`` side constraints
+                (e.g. ``abs(x) == IV``). Callers that do not need the split can use
+                ``value + defining``.
 
         it will return 'Exception' if something is not supported
 
@@ -140,8 +146,8 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
             TODO, what built-in python error is best?
             RE TODO: we now have custom NotImpl/NotSupported
     """
-
-    newlist = []
+    value = []
+    defining = []
     # for backwards compatibility reasons, we now consider it a meta-
     # transformation, that calls (preceding) transformations itself
     # e.g. `toplevel_list()` ensures it is a list
@@ -151,7 +157,7 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
     for expr in lst_of_expr:
 
         if not expr.has_subexpr():
-            newlist.append(expr)  # no need to do anything
+            value.append(expr)  # no need to do anything
             continue
 
         elif isinstance(expr, Operator):
@@ -171,7 +177,9 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
                         if isinstance(a, Operator) and a.name == '->':
                             newargs[i:i+1] = [recurse_negation(a.args[0]),a.args[1]]
                     # there could be nested implications
-                    newlist.extend(flatten_constraint(Operator('or', newargs), csemap=csemap, do_simplify=False))
+                    v, d = flatten_constraint(Operator('or', newargs), csemap=csemap, do_simplify=False)
+                    value.extend(v)
+                    defining.extend(d)
                     continue
                 # conjunctions in disjunctions could be split out by applying distributivity,
                 # but this would explode the number of constraints in favour of having less auxiliary variables.
@@ -182,20 +190,27 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
                 if expr.args[1].name == 'and':
                     a1s = expr.args[1].args
                     a0 = expr.args[0]
-                    newlist.extend(flatten_constraint([a0.implies(a1) for a1 in a1s], csemap=csemap, do_simplify=False))
+                    v, d = flatten_constraint([a0.implies(a1) for a1 in a1s], csemap=csemap, do_simplify=False)
+                    value.extend(v)
+                    defining.extend(d)
                     continue
                 # 2) if lhs is 'or' then or([a01..a0n])->a1 :: ~a1->and([~a01..~a0n] and split
                 elif expr.args[0].name == 'or':
                     a0s = expr.args[0].args
                     a1 = expr.args[1]
-                    newlist.extend(flatten_constraint([recurse_negation(a1).implies(recurse_negation(a0)) for a0 in a0s], csemap=csemap, do_simplify=False))
+                    v, d = flatten_constraint([recurse_negation(a1).implies(recurse_negation(a0)) for a0 in a0s], csemap=csemap, do_simplify=False)
+                    value.extend(v)
+                    defining.extend(d)
                     continue
                 # 2b) if lhs is ->, like 'or': a01->a02->a1 :: (~a01|a02)->a1 :: ~a1->a01,~a1->~a02
                 elif expr.args[0].name == '->':
                     a01,a02 = expr.args[0].args
                     a1 = expr.args[1]
-                    newlist.extend(flatten_constraint([recurse_negation(a1).implies(a01), 
-                                                       recurse_negation(a1).implies(recurse_negation(a02))], csemap=csemap, do_simplify=False))
+                    v, d = flatten_constraint([recurse_negation(a1).implies(a01),
+                                                     recurse_negation(a1).implies(recurse_negation(a02))],
+                                                    csemap=csemap, do_simplify=False)
+                    value.extend(v)
+                    defining.extend(d)
                     continue
 
                 # ->, allows a boolexpr on one side
@@ -208,9 +223,9 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
                     lhs,lcons = normalized_boolexpr(expr.args[0], csemap=csemap)
                     rhs,rcons = get_or_make_var(expr.args[1], csemap=csemap)
 
-                newlist.append(Operator(expr.name, (lhs,rhs)))
-                newlist.extend(lcons)
-                newlist.extend(rcons)
+                value.append(Operator(expr.name, (lhs,rhs)))
+                defining.extend(lcons)
+                defining.extend(rcons)
                 continue
 
 
@@ -218,8 +233,8 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
             # if none of the above cases + continue matched:
             # a normalizable boolexpr
             (con, flatcons) = normalized_boolexpr(expr, csemap=csemap)
-            newlist.append(con)
-            newlist.extend(flatcons)
+            value.append(con)
+            defining.extend(flatcons)
 
         elif isinstance(expr, Comparison):
             """
@@ -255,9 +270,9 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
             # already flat?
             if not expr.has_subexpr():
                 if not rewritten:
-                    newlist.append(expr)  # original
+                    value.append(expr)  # original
                 else:
-                    newlist.append(Comparison(exprname, lexpr, rexpr))
+                    value.append(Comparison(exprname, lexpr, rexpr))
                 continue
 
             # ensure rhs is var
@@ -276,23 +291,36 @@ def flatten_constraint(expr, csemap=None, do_simplify=True):
             else:
                 (lhs, lcons) = normalized_numexpr(lexpr, csemap=csemap)
 
-            newlist.append(Comparison(exprname, lhs, rvar))
-            newlist.extend(lcons)
-            newlist.extend(rcons)
+            value.append(Comparison(exprname, lhs, rvar))
+            defining.extend(lcons)
+            defining.extend(rcons)
 
         elif isinstance(expr, cp.expressions.globalconstraints.GlobalConstraint):
             """
     - Global constraint: global([Var]*)          (CPMpy class 'GlobalConstraint')
             """
             (con, flatcons) = normalized_boolexpr(expr, csemap=csemap)
-            newlist.append(con)
-            newlist.extend(flatcons)
+            value.append(con)
+            defining.extend(flatcons)
 
         else:
             # any other case (e.g. DirectConstraint), pass as is
-            newlist.append(expr)
+            value.append(expr)
 
-    return newlist
+    return value, defining
+
+
+def apply_transform(transform, value, defining, **kwargs):
+    """
+        Apply a ``(list) -> (value, defining)`` transform to both streams and merge.
+
+        ``transform`` is run on ``value`` and on ``defining`` separately. New defining
+        constraints from either call are appended to the defining stream; rewritten
+        defining constraints stay defining.
+    """
+    v2, d_from_v = transform(value, **kwargs)
+    d2, d_from_d = transform(defining, **kwargs)
+    return list(v2), list(d2) + list(d_from_v) + list(d_from_d)
 
 
 def flatten_objective(expr, supported=frozenset(["sum", "wsum"]), csemap=None):

--- a/cpmpy/transformations/int2bool.py
+++ b/cpmpy/transformations/int2bool.py
@@ -22,6 +22,10 @@ def int2bool(cpm_lst: List[Expression], ivarmap, encoding="auto", csemap=None):
     :param: ivarmap: dictionary mapping integer variables to their encoding
     :param: encoding: choice of encoding: "direct", "order", "binary", or "auto", which makes encoding choices based on constraint comparator and domain size
     :param: csemap: To enable CSE
+
+    Returns:
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` where defining holds
+        encoding domain constraints (e.g. exactly-one).
     """
     assert encoding in (
         "auto",
@@ -30,11 +34,13 @@ def int2bool(cpm_lst: List[Expression], ivarmap, encoding="auto", csemap=None):
         "binary",
     ), "Only auto, direct, order, and binary encoding are supported"
 
-    cpm_out = []
+    value = []
+    defining = []
     for expr in cpm_lst:
         constraints, domain_constraints = _encode_expr(ivarmap, expr, encoding, csemap=csemap)
-        cpm_out += domain_constraints + constraints
-    return cpm_out
+        value.extend(constraints)
+        defining.extend(domain_constraints)
+    return value, defining
 
 
 def _encode_expr(ivarmap, expr, encoding, csemap=None):

--- a/cpmpy/transformations/int2bool.py
+++ b/cpmpy/transformations/int2bool.py
@@ -15,7 +15,7 @@ from ..expressions.utils import is_int
 UNKNOWN_COMPARATOR_ERROR = ValueError("Comparator is not known or should have been simplified by linearize.")
 
 
-def int2bool(cpm_lst: List[Expression], ivarmap, encoding="auto", csemap=None):
+def int2bool(cpm_lst: List[Expression], ivarmap, encoding="auto", csemap=None) -> tuple[list[Expression], list[Expression]]:
     """Convert integer linear constraints to pseudo-boolean constraints. Requires `linearize` transformation.
 
     :param: cpm_lst: list of constraints to transform

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -674,7 +674,7 @@ def get_linear_positive_decompositions():
 def linearize_reified_variables(constraints:list[Expression], 
                                 min_values:int=3,
                                 csemap:Optional[CSEMap]=None,
-                                ivarmap:Optional[dict[str, IntVarEnc]] = None) -> list[Expression]:
+                                ivarmap:Optional[dict[str, IntVarEnc]] = None) -> tuple[list[Expression], list[Expression]]:
     """
     Replace reified (BV <-> (x == val)) implications with direct encoding and
     reified (BV <-> (x >= val)) implications with order encoding when a variable
@@ -691,6 +691,9 @@ def linearize_reified_variables(constraints:list[Expression],
     (TODO: add both encodings and channel between them?)
 
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
+
+    Returns:
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
     """
     assert min_values > 0
     

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -219,7 +219,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
 
             if lhs.name == "sum" and len(lhs.args) == 1 and isinstance(lhs.args[0], _BoolVarImpl) and "or" in supported:
                 # very special case, avoid writing as sum of 1 argument; write as disjunction of 1 arg instead
-                new_expr = simplify_boolean([eval_comparison(cpm_expr.name,lhs.args[0], rhs)])
+                new_expr, _ = simplify_boolean([eval_comparison(cpm_expr.name,lhs.args[0], rhs)])
                 assert len(new_expr) == 1
                 if isinstance(new_expr[0], BoolVal):
                     if new_expr[0].value() is True:
@@ -612,7 +612,7 @@ def decompose_linear(lst_of_expr: Sequence[Expression],
             csemap: map of expressions to an auxiliary variable
 
         returns:
-            list of expressions
+            tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
     """
     if supported is None:
         supported = frozenset[str]()

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -64,7 +64,7 @@ Optional post-linearisation transformations:
 """
 
 import copy
-from typing import AbstractSet, Sequence, Optional
+from typing import AbstractSet, Sequence, Optional, cast
 
 import cpmpy as cp
 from cpmpy.transformations.get_variables import get_variables
@@ -97,7 +97,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
         reified: whether the constraint is fully reified
     """
 
-    newlist = []
+    newlist: list[Expression] = []
     for cpm_expr in lst_of_expr:
         # Boolean literals are handled as trivial linears or unit clauses depending on `supported`
         if isinstance(cpm_expr, _BoolVarImpl):
@@ -106,9 +106,9 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 newlist.append(Operator("or", [cpm_expr]))
             elif isinstance(cpm_expr, NegBoolView):
                 # might as well remove the negation
-                newlist.append(sum([~cpm_expr]) <= 0)
+                newlist.append(cast(Expression, sum([~cpm_expr]) <= 0))
             else: # positive literal
-                newlist.append(sum([cpm_expr]) >= 1)
+                newlist.append(cast(Expression, sum([cpm_expr]) >= 1))
 
         # Boolean operators
         elif isinstance(cpm_expr, Operator) and cpm_expr.is_bool():
@@ -136,12 +136,12 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 elif isinstance(cond, _BoolVarImpl):
                     lin_sub, _ = linearize_constraint([sub_expr], supported=supported, reified=True, csemap=csemap)
                     # BV -> (C1 and ... and Cn) == (BV -> C1) and ... and (BV -> Cn)
-                    indicator_constraints=[]
+                    indicator_constraints: list[Expression] = []
                     for lin in lin_sub:
                         if is_true_cst(lin):
                             continue
                         elif is_false_cst(lin):
-                            indicator_constraints=[] # do not add any constraints
+                            indicator_constraints = list[Expression]() # do not add any constraints
                             v, d = linearize_constraint([~cond], supported=supported, csemap=csemap, reified=reified)
                             newlist += v + d # post linear version of unary constraint
                             break # do not need to add other
@@ -310,7 +310,7 @@ def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[E
 
         Resulting expression is linear if the original expression was linear.
     """
-    newlist = []
+    newlist: list[Expression] = []
     for cpm_expr in lst_of_expr:
 
         if isinstance(cpm_expr, Comparison):
@@ -456,7 +456,7 @@ def canonical_comparison(lst_of_expr: ListLike[Expression]) -> tuple[list[Expres
         Expects the input constraints to be flat. Only apply after applying :func:`flatten_constraint`
     """
 
-    newlist = []
+    newlist: list[Expression] = []
     for cpm_expr in lst_of_expr:
 
         if isinstance(cpm_expr, Operator) and cpm_expr.name == '->':    # half reification of comparison
@@ -562,7 +562,7 @@ def only_positive_coefficients(lst_of_expr) -> tuple[list[Expression], list[Expr
 
         Resulting expression is linear.
     """
-    newlist = []
+    newlist: list[Expression] = []
     for cpm_expr in lst_of_expr:
         if isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -134,7 +134,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
 
                 # BV -> LinExpr
                 elif isinstance(cond, _BoolVarImpl):
-                    lin_sub = linearize_constraint([sub_expr], supported=supported, reified=True, csemap=csemap)
+                    lin_sub, _ = linearize_constraint([sub_expr], supported=supported, reified=True, csemap=csemap)
                     # BV -> (C1 and ... and Cn) == (BV -> C1) and ... and (BV -> Cn)
                     indicator_constraints=[]
                     for lin in lin_sub:
@@ -142,7 +142,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                             continue
                         elif is_false_cst(lin):
                             indicator_constraints=[] # do not add any constraints
-                            newlist += linearize_constraint([~cond], supported=supported, csemap=csemap, reified=reified) # post linear version of unary constraint
+                            v, d = linearize_constraint([~cond], supported=supported, csemap=csemap, reified=reified)
+                            newlist += v + d # post linear version of unary constraint
                             break # do not need to add other
                         elif "->" in supported and not reified:
                             indicator_constraints.append(cond.implies(lin)) # Add indicator constraint
@@ -168,16 +169,18 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                                 lin_lhs += M * ~cond
                                 indicator_constraints.append(Comparison(lin.name, lin_lhs, lin_rhs))
                             elif lin.name == "==":
-                                indicator_constraints += linearize_constraint([cond.implies(lin_lhs <= lin_rhs),
-                                                                               cond.implies(lin_lhs >= lin_rhs)],
-                                                                              supported=supported, reified=reified, csemap=csemap)
+                                v, d = linearize_constraint([cond.implies(lin_lhs <= lin_rhs),
+                                                       cond.implies(lin_lhs >= lin_rhs)],
+                                                      supported=supported, reified=reified, csemap=csemap)
+                                indicator_constraints += v + d
                             else:
                                 raise ValueError(f"Unexpected linearized rhs of implication {lin} in {cpm_expr}")
                     newlist+=indicator_constraints
 
                     # ensure no new solutions are created
                     new_vars = set(get_variables(lin_sub)) - set(get_variables(sub_expr)) - {cond, ~cond}
-                    newlist += linearize_constraint([(~cond).implies(nv == nv.lb) for nv in new_vars], supported=supported, reified=reified, csemap=csemap)
+                    v, d = linearize_constraint([(~cond).implies(nv == nv.lb) for nv in new_vars], supported=supported, reified=reified, csemap=csemap)
+                    newlist += v + d
 
             else: # supported operator
                 newlist.append(cpm_expr)
@@ -206,7 +209,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 raise ValueError(f"Linearization of `lhs` ({lhs}) not supported, run "
                                  "`cpmpy.transformations.decompose_global.decompose_in_tree() first")
 
-            (cpm_expr,) = canonical_comparison((cpm_expr,))  # just transforms the constraint, not introducing new ones
+            (cpm_expr,), _ = canonical_comparison((cpm_expr,))  # just transforms the constraint, not introducing new ones
             if isinstance(cpm_expr, BoolVal):
                 # it was a trivial comparison
                 newlist.append(cpm_expr)
@@ -221,7 +224,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 if isinstance(new_expr[0], BoolVal):
                     if new_expr[0].value() is True:
                         continue # skip or([BoolVal(True)])
-                    newlist += linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap)  # don't wrap in or(BoolVal(False))
+                    v, d = linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap)  # don't wrap in or(BoolVal(False))
+                    newlist += v + d
                     continue
                 newlist.append(Operator("or", new_expr))
                 continue
@@ -236,18 +240,21 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 if t_lb and t_ub:
                     continue
                 elif not t_lb and not t_ub:
-                    newlist += linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap) # post the linear version of False
+                    v, d = linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap) # post the linear version of False
+                    newlist += v + d
                     break
 
             # now fix the comparisons themselves
             if cpm_expr.name == "<":
                 new_rhs, cons = get_or_make_var(rhs - 1, csemap=csemap) # if rhs is constant, will return new constant
                 newlist.append(lhs <= new_rhs)
-                newlist += linearize_constraint(cons, csemap=csemap)
+                v, d = linearize_constraint(cons, csemap=csemap)
+                newlist += v + d
             elif cpm_expr.name == ">":
                 new_rhs, cons = get_or_make_var(rhs + 1, csemap=csemap) # if rhs is constant, will return new constant
                 newlist.append(lhs >= new_rhs)
-                newlist += linearize_constraint(cons, csemap=csemap)
+                v, d = linearize_constraint(cons, csemap=csemap)
+                newlist += v + d
             elif cpm_expr.name == "!=":
                 # Special case: BV != BV
                 if isinstance(lhs, _BoolVarImpl) and isinstance(rhs, _BoolVarImpl):
@@ -268,13 +275,16 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                     _, M1 = (lhs - rhs + 1).get_bounds()
                     _, M2 = (rhs - lhs + 1).get_bounds()
                     cons = [lhs + -M1*z <= rhs-1, lhs  + -M2*z >= rhs-M2+1]
-                    newlist += linearize_constraint(flatten_constraint(cons, csemap=csemap), supported=supported, reified=reified, csemap=csemap)
+                    v, d = flatten_constraint(cons, csemap=csemap)
+                    lv, ld = linearize_constraint(v + d, supported=supported, reified=reified, csemap=csemap)
+                    newlist += lv + ld
 
                 else:
                     # introduce new indicator constraints
                     z = boolvar()
                     constraints = [z.implies(lhs < rhs), (~z).implies(lhs > rhs)]
-                    newlist += linearize_constraint(constraints, supported=supported, reified=reified, csemap=csemap)
+                    v, d = linearize_constraint(constraints, supported=supported, reified=reified, csemap=csemap)
+                    newlist += v + d
             else:
                 # supported comparison
                 newlist.append(eval_comparison(cpm_expr.name, lhs, rhs))
@@ -291,7 +301,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
         else:
             raise ValueError(f"Unexpected expression {cpm_expr}, if you reach this, please report on github.")
 
-    return newlist
+    return newlist, []
 
 def only_positive_bv(lst_of_expr, csemap=None):
     """
@@ -339,7 +349,7 @@ def only_positive_bv(lst_of_expr, csemap=None):
             assert isinstance(cond, _BoolVarImpl), f"{cpm_expr} is not a supported linear expression. Apply " \
                                                    f"`linearize_constraint` before calling `only_positive_bv` "
             # BV -> Expr
-            subexpr = only_positive_bv([subexpr], csemap=csemap)
+            subexpr, _ = only_positive_bv([subexpr], csemap=csemap)
             newlist += [cond.implies(expr) for expr in subexpr]
 
         elif isinstance(cpm_expr, _BoolVarImpl):
@@ -349,7 +359,7 @@ def only_positive_bv(lst_of_expr, csemap=None):
         else:
             raise Exception(f"{cpm_expr} is not linear or is not supported. Please report on github")
 
-    return newlist
+    return newlist, []
 
 def only_positive_bv_wsum(expr):
     """
@@ -436,7 +446,7 @@ def only_positive_bv_wsum_const(cpm_expr):
         raise ValueError(f"unexpected expression, should be sum, wsum or var but got {cpm_expr}")
 
 
-def canonical_comparison(lst_of_expr: ListLike[Expression]) -> list[Expression]:
+def canonical_comparison(lst_of_expr: ListLike[Expression]):
     """
         Canonicalize a comparison expression.
         Transforms linear expressions, or a reification thereof into canonical form by:
@@ -452,10 +462,10 @@ def canonical_comparison(lst_of_expr: ListLike[Expression]) -> list[Expression]:
         if isinstance(cpm_expr, Operator) and cpm_expr.name == '->':    # half reification of comparison
             lhs, rhs = cpm_expr.args
             if isinstance(rhs, Comparison):
-                (rhs,) = canonical_comparison((rhs,))
+                (rhs,), _ = canonical_comparison((rhs,))
                 newlist.append(lhs.implies(rhs))
             elif isinstance(lhs, Comparison):
-                (lhs,) = canonical_comparison((lhs,))
+                (lhs,), _ = canonical_comparison((lhs,))
                 newlist.append(lhs.implies(rhs))
             else:
                 newlist.append(cpm_expr)
@@ -464,7 +474,7 @@ def canonical_comparison(lst_of_expr: ListLike[Expression]) -> list[Expression]:
             lhs, rhs = cpm_expr.args
             if isinstance(lhs, Comparison) and is_boolexpr(rhs):
                 assert cpm_expr.name == "==", "Expected a reification of a comparison here, but got {}".format(cpm_expr.name)
-                (lhs,) = canonical_comparison((lhs,))
+                (lhs,), _ = canonical_comparison((lhs,))
             elif is_num(lhs) or isinstance(lhs, _NumVarImpl) or (isinstance(lhs, Operator) and lhs.name in {"sum", "wsum", "sub"}):
                 if lhs.name == "sub":
                     lhs = Operator("wsum", [[1,-1],lhs.args])
@@ -532,7 +542,7 @@ def canonical_comparison(lst_of_expr: ListLike[Expression]) -> list[Expression]:
         else:   # rest of expressions
             newlist.append(cpm_expr)
 
-    return newlist
+    return newlist, []
 
 def only_positive_coefficients_(ws, xs):
     """
@@ -579,13 +589,13 @@ def only_positive_coefficients(lst_of_expr):
             cond, subexpr = cpm_expr.args
             assert isinstance(cond, _BoolVarImpl), f"{cpm_expr} is not a supported linear expression. Apply " \
                                                    f"`linearize_constraint` before calling `only_positive_coefficients` "
-            subexpr = only_positive_coefficients([subexpr])
+            subexpr, _ = only_positive_coefficients([subexpr])
             newlist += [cond.implies(expr) for expr in subexpr]
 
         else:
             newlist.append(cpm_expr)
 
-    return newlist
+    return newlist, []
 
 
 def decompose_linear(lst_of_expr: Sequence[Expression],
@@ -686,7 +696,7 @@ def linearize_reified_variables(constraints:list[Expression],
     
     # this transformation can only be done if there is a csemap
     if csemap is None:
-        return constraints
+        return constraints, []
 
     # Make the integer encodings in integer linear friendly way
     my_ivarmap = ivarmap if ivarmap is not None else {}
@@ -756,10 +766,10 @@ def linearize_reified_variables(constraints:list[Expression],
                         continue  # do not keep
             newcons.append(con)
         
-        return newcons + toplevel
+        return newcons + toplevel, []
     
     assert len(toplevel) == 0, "cannot have toplevel constraints if len(bv_map) == 0"
-    return constraints
+    return constraints, []
 
 
 def _extract_var_from_lhs(lhs):

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -84,7 +84,7 @@ from .int2bool import IntVarEnc, _encode_int_var
 
 
 
-def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=False, csemap=None):
+def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=False, csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
     Transforms all constraints to a linear form.
     This function assumes all constraints are in 'flat normal form' with only boolean variables on the lhs of an implication.
@@ -303,7 +303,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
 
     return newlist, []
 
-def only_positive_bv(lst_of_expr, csemap=None):
+def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
         Replaces :class:`~cpmpy.expressions.comparison.Comparison` containing :class:`~cpmpy.expressions.variables.NegBoolView` with equivalent expression using only :class:`~cpmpy.expressions.variables.BoolVar`.
         Comparisons are expected to be linearized. Only apply after applying :func:`linearize_constraint(cpm_expr) <linearize_constraint>`.
@@ -446,7 +446,7 @@ def only_positive_bv_wsum_const(cpm_expr):
         raise ValueError(f"unexpected expression, should be sum, wsum or var but got {cpm_expr}")
 
 
-def canonical_comparison(lst_of_expr: ListLike[Expression]):
+def canonical_comparison(lst_of_expr: ListLike[Expression]) -> tuple[list[Expression], list[Expression]]:
     """
         Canonicalize a comparison expression.
         Transforms linear expressions, or a reification thereof into canonical form by:
@@ -553,7 +553,7 @@ def only_positive_coefficients_(ws, xs):
     constant = sum(ws[i] for i in indices)
     return nw, na, constant
 
-def only_positive_coefficients(lst_of_expr):
+def only_positive_coefficients(lst_of_expr) -> tuple[list[Expression], list[Expression]]:
     """
         Replaces Boolean terms with negative coefficients in linear constraints with terms with positive coefficients (including 0) by negating its literal.
         This can simplify a `wsum` into `sum`.
@@ -601,7 +601,7 @@ def only_positive_coefficients(lst_of_expr):
 def decompose_linear(lst_of_expr: Sequence[Expression],
                      supported: Optional[AbstractSet[str]] = None,
                      supported_reified: Optional[AbstractSet[str]] = None,
-                     csemap: Optional[CSEMap] = None):
+                     csemap: Optional[CSEMap] = None) -> tuple[list[Expression], list[Expression]]:
     """
         Decompose unsupported global constraints in a linear-friendly way using (var == val) in sums.
 

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -70,7 +70,7 @@ import cpmpy as cp
 from cpmpy.transformations.get_variables import get_variables
 from .cse import CSEMap
 
-from .flatten_model import flatten_constraint, get_or_make_var
+from .flatten_model import flatten_constraint, get_or_make_var, apply_transform
 from .decompose_global import decompose_in_tree, decompose_objective
 from .normalize import simplify_boolean
 from ..exceptions import TransformationNotImplementedError
@@ -98,6 +98,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
     """
 
     newlist: list[Expression] = []
+    defining: list[Expression] = []
     for cpm_expr in lst_of_expr:
         # Boolean literals are handled as trivial linears or unit clauses depending on `supported`
         if isinstance(cpm_expr, _BoolVarImpl):
@@ -134,7 +135,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
 
                 # BV -> LinExpr
                 elif isinstance(cond, _BoolVarImpl):
-                    lin_sub, _ = linearize_constraint([sub_expr], supported=supported, reified=True, csemap=csemap)
+                    lin_sub, lin_def = linearize_constraint([sub_expr], supported=supported, reified=True, csemap=csemap)
+                    defining.extend(lin_def)
                     # BV -> (C1 and ... and Cn) == (BV -> C1) and ... and (BV -> Cn)
                     indicator_constraints: list[Expression] = []
                     for lin in lin_sub:
@@ -143,7 +145,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                         elif is_false_cst(lin):
                             indicator_constraints = list[Expression]() # do not add any constraints
                             v, d = linearize_constraint([~cond], supported=supported, csemap=csemap, reified=reified)
-                            newlist += v + d # post linear version of unary constraint
+                            newlist.extend(v)
+                            defining.extend(d) # post linear version of unary constraint
                             break # do not need to add other
                         elif "->" in supported and not reified:
                             indicator_constraints.append(cond.implies(lin)) # Add indicator constraint
@@ -172,7 +175,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                                 v, d = linearize_constraint([cond.implies(lin_lhs <= lin_rhs),
                                                        cond.implies(lin_lhs >= lin_rhs)],
                                                       supported=supported, reified=reified, csemap=csemap)
-                                indicator_constraints += v + d
+                                indicator_constraints.extend(v)
+                                defining.extend(d)
                             else:
                                 raise ValueError(f"Unexpected linearized rhs of implication {lin} in {cpm_expr}")
                     newlist+=indicator_constraints
@@ -180,7 +184,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                     # ensure no new solutions are created
                     new_vars = set(get_variables(lin_sub)) - set(get_variables(sub_expr)) - {cond, ~cond}
                     v, d = linearize_constraint([(~cond).implies(nv == nv.lb) for nv in new_vars], supported=supported, reified=reified, csemap=csemap)
-                    newlist += v + d
+                    newlist.extend(v)
+                    defining.extend(d)
 
             else: # supported operator
                 newlist.append(cpm_expr)
@@ -225,7 +230,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                     if new_expr[0].value() is True:
                         continue # skip or([BoolVal(True)])
                     v, d = linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap)  # don't wrap in or(BoolVal(False))
-                    newlist += v + d
+                    newlist.extend(v)
+                    defining.extend(d)
                     continue
                 newlist.append(Operator("or", new_expr))
                 continue
@@ -241,7 +247,8 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                     continue
                 elif not t_lb and not t_ub:
                     v, d = linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap) # post the linear version of False
-                    newlist += v + d
+                    newlist.extend(v)
+                    defining.extend(d)
                     break
 
             # now fix the comparisons themselves
@@ -249,12 +256,15 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 new_rhs, cons = get_or_make_var(rhs - 1, csemap=csemap) # if rhs is constant, will return new constant
                 newlist.append(lhs <= new_rhs)
                 v, d = linearize_constraint(cons, csemap=csemap)
-                newlist += v + d
+                # cons are defining; linearized form stays defining
+                defining.extend(v)
+                defining.extend(d)
             elif cpm_expr.name == ">":
                 new_rhs, cons = get_or_make_var(rhs + 1, csemap=csemap) # if rhs is constant, will return new constant
                 newlist.append(lhs >= new_rhs)
                 v, d = linearize_constraint(cons, csemap=csemap)
-                newlist += v + d
+                defining.extend(v)
+                defining.extend(d)
             elif cpm_expr.name == "!=":
                 # Special case: BV != BV
                 if isinstance(lhs, _BoolVarImpl) and isinstance(rhs, _BoolVarImpl):
@@ -276,15 +286,18 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                     _, M2 = (rhs - lhs + 1).get_bounds()
                     cons = [lhs + -M1*z <= rhs-1, lhs  + -M2*z >= rhs-M2+1]
                     v, d = flatten_constraint(cons, csemap=csemap)
-                    lv, ld = linearize_constraint(v + d, supported=supported, reified=reified, csemap=csemap)
-                    newlist += lv + ld
+                    lv, ld = apply_transform(linearize_constraint, v, d,
+                                            supported=supported, reified=reified, csemap=csemap)
+                    newlist.extend(lv)
+                    defining.extend(ld)
 
                 else:
                     # introduce new indicator constraints
                     z = boolvar()
                     constraints = [z.implies(lhs < rhs), (~z).implies(lhs > rhs)]
                     v, d = linearize_constraint(constraints, supported=supported, reified=reified, csemap=csemap)
-                    newlist += v + d
+                    newlist.extend(v)
+                    defining.extend(d)
             else:
                 # supported comparison
                 newlist.append(eval_comparison(cpm_expr.name, lhs, rhs))
@@ -301,7 +314,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
         else:
             raise ValueError(f"Unexpected expression {cpm_expr}, if you reach this, please report on github.")
 
-    return newlist, []
+    return newlist, defining
 
 def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
@@ -311,6 +324,7 @@ def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[E
         Resulting expression is linear if the original expression was linear.
     """
     newlist: list[Expression] = []
+    defining: list[Expression] = []
     for cpm_expr in lst_of_expr:
 
         if isinstance(cpm_expr, Comparison):
@@ -339,7 +353,7 @@ def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[E
 
             if new_lhs is not lhs:
                 newlist.append(eval_comparison(cpm_expr.name, new_lhs, rhs))
-                newlist += new_cons  # already linear
+                defining.extend(new_cons)  # already linear
             else:
                 newlist.append(cpm_expr)
 
@@ -349,8 +363,9 @@ def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[E
             assert isinstance(cond, _BoolVarImpl), f"{cpm_expr} is not a supported linear expression. Apply " \
                                                    f"`linearize_constraint` before calling `only_positive_bv` "
             # BV -> Expr
-            subexpr, _ = only_positive_bv([subexpr], csemap=csemap)
+            subexpr, sub_def = only_positive_bv([subexpr], csemap=csemap)
             newlist += [cond.implies(expr) for expr in subexpr]
+            defining.extend(sub_def)
 
         elif isinstance(cpm_expr, _BoolVarImpl):
             raise ValueError(f"Unreachable: unexpected Boolean literal (`_BoolVarImpl`) in expression {cpm_expr}, perhaps `linearize_constraint` was not called before this `only_positive_bv `call")
@@ -359,7 +374,7 @@ def only_positive_bv(lst_of_expr, csemap=None) -> tuple[list[Expression], list[E
         else:
             raise Exception(f"{cpm_expr} is not linear or is not supported. Please report on github")
 
-    return newlist, []
+    return newlist, defining
 
 def only_positive_bv_wsum(expr):
     """
@@ -563,6 +578,7 @@ def only_positive_coefficients(lst_of_expr) -> tuple[list[Expression], list[Expr
         Resulting expression is linear.
     """
     newlist: list[Expression] = []
+    defining: list[Expression] = []
     for cpm_expr in lst_of_expr:
         if isinstance(cpm_expr, Comparison):
             lhs, rhs = cpm_expr.args
@@ -589,13 +605,14 @@ def only_positive_coefficients(lst_of_expr) -> tuple[list[Expression], list[Expr
             cond, subexpr = cpm_expr.args
             assert isinstance(cond, _BoolVarImpl), f"{cpm_expr} is not a supported linear expression. Apply " \
                                                    f"`linearize_constraint` before calling `only_positive_coefficients` "
-            subexpr, _ = only_positive_coefficients([subexpr])
+            subexpr, sub_def = only_positive_coefficients([subexpr])
             newlist += [cond.implies(expr) for expr in subexpr]
+            defining.extend(sub_def)
 
         else:
             newlist.append(cpm_expr)
 
-    return newlist, []
+    return newlist, defining
 
 
 def decompose_linear(lst_of_expr: Sequence[Expression],
@@ -693,7 +710,8 @@ def linearize_reified_variables(constraints:list[Expression],
     Apply AFTER flatten_constraint and BEFORE only_implies and linearize_constraint.
 
     Returns:
-        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` where defining holds
+        domain/channeling constraints introduced for the encoding
     """
     assert min_values > 0
     
@@ -769,7 +787,7 @@ def linearize_reified_variables(constraints:list[Expression],
                         continue  # do not keep
             newcons.append(con)
         
-        return newcons + toplevel, []
+        return newcons, toplevel
     
     assert len(toplevel) == 0, "cannot have toplevel constraints if len(bv_map) == 0"
     return constraints, []

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -64,7 +64,7 @@ Optional post-linearisation transformations:
 """
 
 import copy
-from typing import AbstractSet, Sequence, Optional, cast
+from typing import AbstractSet, Sequence, Optional
 
 import cpmpy as cp
 from cpmpy.transformations.get_variables import get_variables
@@ -106,9 +106,9 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                 newlist.append(Operator("or", [cpm_expr]))
             elif isinstance(cpm_expr, NegBoolView):
                 # might as well remove the negation
-                newlist.append(cast(Expression, sum([~cpm_expr]) <= 0))
+                newlist.append((~cpm_expr) <= 0)
             else: # positive literal
-                newlist.append(cast(Expression, sum([cpm_expr]) >= 1))
+                newlist.append(cpm_expr >= 1)
 
         # Boolean operators
         elif isinstance(cpm_expr, Operator) and cpm_expr.is_bool():

--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -629,7 +629,7 @@ def decompose_linear(lst_of_expr: Sequence[Expression],
             csemap: map of expressions to an auxiliary variable
 
         returns:
-            tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
+            tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
     if supported is None:
         supported = frozenset[str]()

--- a/cpmpy/transformations/negation.py
+++ b/cpmpy/transformations/negation.py
@@ -17,7 +17,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.variables import _BoolVarImpl, NDVarArray, cpm_array
 from ..expressions.utils import is_boolexpr
 
-def push_down_negation(lst_of_expr: list[Expression], toplevel=True) -> list[Expression]:
+def push_down_negation(lst_of_expr: list[Expression], toplevel=True):
     """
         Recursively simplifies expressions by pushing down negation into the arguments.
         E.g., not(x >= 3 | y == 2) is simplified to (x < 3) & (y != 2).
@@ -27,8 +27,8 @@ def push_down_negation(lst_of_expr: list[Expression], toplevel=True) -> list[Exp
           then the 'and' will not be added to the toplevel list, but all its arguments will be merged in.
           (actually only Expressions, and if a constant 'False' is found it adds BoolVal(False) and stops merging)
 
-        Return:
-            list of Expressions
+        Returns:
+            tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
     """
     newlist: list[Expression] = []
     changed = False
@@ -49,8 +49,8 @@ def push_down_negation(lst_of_expr: list[Expression], toplevel=True) -> list[Exp
             newlist.append(expr)
     
     if not changed:
-        return lst_of_expr
-    return newlist
+        return lst_of_expr, []
+    return newlist, []
 
 def push_down_negation_objective(expr: Expression) -> Expression:
     """

--- a/cpmpy/transformations/negation.py
+++ b/cpmpy/transformations/negation.py
@@ -17,7 +17,7 @@ from ..expressions.core import Expression, Comparison, Operator, BoolVal
 from ..expressions.variables import _BoolVarImpl, NDVarArray, cpm_array
 from ..expressions.utils import is_boolexpr
 
-def push_down_negation(lst_of_expr: list[Expression], toplevel=True):
+def push_down_negation(lst_of_expr: list[Expression], toplevel=True) -> tuple[list[Expression], list[Expression]]:
     """
         Recursively simplifies expressions by pushing down negation into the arguments.
         E.g., not(x >= 3 | y == 2) is simplified to (x < 3) & (y != 2).

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -16,13 +16,16 @@ from ..expressions.globalconstraints import GlobalConstraint
 from .negation import recurse_negation
 
 
-def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True) -> list[Expression]:
+def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True):
     """
     Unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with :func:`~cpmpy.expressions.core.Expression.is_bool()` true.
 
     Arguments:
         cpm_expr (NestedBoolExprLike): CPMpy expression, or list thereof
         merge_and (bool):  if True then a toplevel 'and' will have its arguments merged at top level
+
+    Returns:
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
     """
 
     # very efficient version with limited function lookups and list operations
@@ -47,10 +50,10 @@ def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True) -> list[
     append = newlist.append
     unravel((cpm_expr,), append)
 
-    return newlist
+    return newlist, []
 
 
-def simplify_boolean(lst_of_expr: list[Expression], num_context=False) -> list[Expression]:
+def simplify_boolean(lst_of_expr: list[Expression], num_context=False):
     """
     Removes Boolean constants from CPMpy expressions, except inside global constraints/functions.
 
@@ -67,7 +70,8 @@ def simplify_boolean(lst_of_expr: list[Expression], num_context=False) -> list[E
         num_context (bool): whether the expressions are used as numeric arguments (default: False)
 
     Returns:
-        list[Expression]: simplified expressions; returns ``lst_of_expr`` unchanged if nothing changed
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining;
+        value is ``lst_of_expr`` unchanged if nothing changed
     """
 
     newlist: list[Expression] = []
@@ -82,8 +86,8 @@ def simplify_boolean(lst_of_expr: list[Expression], num_context=False) -> list[E
             newlist.append(expr)
     
     if not changed:
-        return lst_of_expr
-    return newlist
+        return lst_of_expr, []
+    return newlist, []
 
 
 def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, Expression|int]:

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -16,7 +16,7 @@ from ..expressions.globalconstraints import GlobalConstraint
 from .negation import recurse_negation
 
 
-def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True):
+def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True) -> tuple[list[Expression], list[Expression]]:
     """
     Unravels nested lists and top-level AND's and ensures every element returned is a CPMpy Expression with :func:`~cpmpy.expressions.core.Expression.is_bool()` true.
 
@@ -53,7 +53,7 @@ def toplevel_list(cpm_expr: NestedBoolExprLike, merge_and: bool = True):
     return newlist, []
 
 
-def simplify_boolean(lst_of_expr: list[Expression], num_context=False):
+def simplify_boolean(lst_of_expr: list[Expression], num_context=False) -> tuple[list[Expression], list[Expression]]:
     """
     Removes Boolean constants from CPMpy expressions, except inside global constraints/functions.
 

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -30,7 +30,12 @@ from .flatten_model import flatten_constraint, get_or_make_var
 from .negation import recurse_negation
 
 def only_bv_reifies(constraints, csemap=None):
+    """
+        Ensure reifications have a BoolVar on the left-hand side.
 
+        Returns:
+            tuple[list[Expression], list[Expression]]: ``(value, defining)``
+    """
     newcons = []
     for cpm_expr in constraints:
         if cpm_expr.name in ['->', "=="]:
@@ -40,17 +45,20 @@ def only_bv_reifies(constraints, csemap=None):
                 # BE -> BV :: ~BV -> ~BE
                 if cpm_expr.name == '->':
                     newexpr = (~a1).implies(recurse_negation(a0))
-                    newexpr = only_bv_reifies(flatten_constraint(newexpr, csemap=csemap), csemap=csemap)
+                    v, d = flatten_constraint(newexpr, csemap=csemap)
+                    rv, rd = only_bv_reifies(v + d, csemap=csemap)
+                    newexpr = rv + rd
                 else:
                     newexpr = [a1 == a0]  # BE == BV :: BV == BE
                     if not a0.is_bool():
-                        newexpr = flatten_constraint(newexpr, csemap=csemap)
+                        v, d = flatten_constraint(newexpr, csemap=csemap)
+                        newexpr = v + d
                 newcons.extend(newexpr)
             else:
                 newcons.append(cpm_expr)
         else:
             newcons.append(cpm_expr)
-    return newcons
+    return newcons, []
 
 def only_implies(constraints, csemap=None):
     """
@@ -123,9 +131,12 @@ def only_implies(constraints, csemap=None):
             newcons.append(cpm_expr)
     
     if len(retransform) != 0:
-        newcons.extend(only_implies(only_bv_reifies(flatten_constraint(retransform, csemap=csemap), csemap=csemap), csemap=csemap))
+        v, d = flatten_constraint(retransform, csemap=csemap)
+        bv, bd = only_bv_reifies(v + d, csemap=csemap)
+        iv, id_ = only_implies(bv + bd, csemap=csemap)
+        newcons.extend(iv + id_)
 
-    return newcons
+    return newcons, []
 
 
 def reify_rewrite(constraints, supported=frozenset(), csemap=None):
@@ -143,12 +154,16 @@ def reify_rewrite(constraints, supported=frozenset(), csemap=None):
 
         :param supported: a (frozen)set of expression names that support reification in the solver, including
                           supported 'Left Hand Side (LHS)' expressions in reified comparisons, e.g. ``BV -> (LHS == V)``
+
+        Returns:
+            tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
     if not is_any_list(constraints):
         # assume list, so make list
         constraints = [constraints]
 
-    newcons = []
+    value = []
+    defining = []
     for cpm_expr in constraints:
         assert isinstance(cpm_expr, Expression), f"Expected CPMpy Expression but got {cpm_expr}, " \
                                                  f"run transformations.normalize.make_cpm_expr first!"
@@ -168,19 +183,19 @@ def reify_rewrite(constraints, supported=frozenset(), csemap=None):
             boolexpr_index = 0
 
         if boolexpr_index is None:  # non-reified or variable-only reification
-            newcons.append(cpm_expr)
+            value.append(cpm_expr)
         else:  # reification, check for rewrite
             boolexpr = cpm_expr.args[boolexpr_index]
             if isinstance(boolexpr, Operator):
                 # Case 1, BE is Operator (and, or, ->)
                 #   assume supported, return as is
-                newcons.append(cpm_expr)
+                value.append(cpm_expr)
                 #   could actually rewrite into list of clauses like to_cnf() does... not for here
             elif isinstance(boolexpr, GlobalConstraint):
                 # Case 2, BE is a GlobalConstraint
                 # replace BE by its decomposition, then flatten
                 if boolexpr.name in supported:
-                    newcons.append(cpm_expr)
+                    value.append(cpm_expr)
                 else:
                     raise ValueError(f"Unsupported boolexpr {boolexpr} in reification, run a suitable decomposition "
                                      f"transformation from `cpmpy.transformations.decompose_global` to decompose "
@@ -191,20 +206,20 @@ def reify_rewrite(constraints, supported=frozenset(), csemap=None):
                 #   have list of supported lhs's such as sum and wsum...
                 #   at the very least, (iv1 == iv2) == bv has to be supported
                 if isinstance(lhs, _NumVarImpl) or lhs.name in supported:
-                    newcons.append(cpm_expr)
+                    value.append(cpm_expr)
                 else:  # other cases, LHS is a total function
                     #     introduce aux var and bring function to toplevel
                     #     (AUX,c) = get_or_make_var(LHS)
                     #     return c+[Comp(OP,AUX,RHS) == BV] or +[Comp(OP,AUX,RHS) -> BV] or +[Comp(OP,AUX,RHS) <- BV]
                     (auxvar, cons) = get_or_make_var(lhs, csemap=csemap)
-                    newcons += cons
+                    defining.extend(cons)
                     reifexpr = copy.copy(cpm_expr)
                     args = list(reifexpr.args)
                     args[boolexpr_index] = Comparison(op, auxvar, rhs)  # Comp(OP,AUX,RHS)
                     reifexpr.update_args(tuple(args))
-                    newcons.append(reifexpr)
+                    value.append(reifexpr)
             else:
                 # don't think this will be reached
-                newcons.append(cpm_expr)
+                value.append(cpm_expr)
 
-    return newcons
+    return value, defining

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -26,7 +26,7 @@ from ..expressions.globalfunctions import Element
 from ..expressions.variables import _BoolVarImpl, _NumVarImpl
 from ..expressions.python_builtins import all
 from ..expressions.utils import is_any_list
-from .flatten_model import flatten_constraint, get_or_make_var
+from .flatten_model import flatten_constraint, get_or_make_var, apply_transform
 from .negation import recurse_negation
 
 def only_bv_reifies(constraints, csemap=None) -> tuple[list[Expression], list[Expression]]:
@@ -37,6 +37,7 @@ def only_bv_reifies(constraints, csemap=None) -> tuple[list[Expression], list[Ex
             tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
     newcons: list[Expression] = []
+    defining: list[Expression] = []
     for cpm_expr in constraints:
         if cpm_expr.name in ['->', "=="]:
             a0, a1 = cpm_expr.args
@@ -46,19 +47,22 @@ def only_bv_reifies(constraints, csemap=None) -> tuple[list[Expression], list[Ex
                 if cpm_expr.name == '->':
                     newexpr = (~a1).implies(recurse_negation(a0))
                     v, d = flatten_constraint(newexpr, csemap=csemap)
-                    rv, rd = only_bv_reifies(v + d, csemap=csemap)
-                    newcons.extend(rv + rd)
+                    rv, rd = apply_transform(only_bv_reifies, v, d, csemap=csemap)
+                    newcons.extend(rv)
+                    defining.extend(rd)
                 else:
-                    newexpr = [a1 == a0]  # BE == BV :: BV == BE
+                    swapped = [a1 == a0]  # BE == BV :: BV == BE
                     if not a0.is_bool():
-                        v, d = flatten_constraint(newexpr, csemap=csemap)
-                        newexpr = v + d
-                    newcons.extend(newexpr)
+                        v, d = flatten_constraint(swapped, csemap=csemap)
+                        newcons.extend(v)
+                        defining.extend(d)
+                    else:
+                        newcons.extend(swapped)
             else:
                 newcons.append(cpm_expr)
         else:
             newcons.append(cpm_expr)
-    return newcons, []
+    return newcons, defining
 
 def only_implies(constraints, csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
@@ -77,6 +81,7 @@ def only_implies(constraints, csemap=None) -> tuple[list[Expression], list[Expre
         AFTER :func:`~cpmpy.transformations.flatten_model.flatten_constraint()` and :func:`only_bv_reifies()`.
     """
     newcons: list[Expression] = []
+    defining: list[Expression] = []
     retransform: list[Expression] = []
 
     for cpm_expr in constraints:
@@ -132,11 +137,12 @@ def only_implies(constraints, csemap=None) -> tuple[list[Expression], list[Expre
     
     if len(retransform) != 0:
         v, d = flatten_constraint(retransform, csemap=csemap)
-        bv, bd = only_bv_reifies(v + d, csemap=csemap)
-        iv, id_ = only_implies(bv + bd, csemap=csemap)
-        newcons.extend(iv + id_)
+        bv, bd = apply_transform(only_bv_reifies, v, d, csemap=csemap)
+        iv, id_ = apply_transform(only_implies, bv, bd, csemap=csemap)
+        newcons.extend(iv)
+        defining.extend(id_)
 
-    return newcons, []
+    return newcons, defining
 
 
 def reify_rewrite(constraints, supported=frozenset(), csemap=None) -> tuple[list[Expression], list[Expression]]:

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -49,11 +49,11 @@ def only_bv_reifies(constraints, csemap=None) -> tuple[list[Expression], list[Ex
                     rv, rd = only_bv_reifies(v + d, csemap=csemap)
                     newcons.extend(rv + rd)
                 else:
-                    swapped = [a1 == a0]  # BE == BV :: BV == BE
+                    newexpr = [a1 == a0]  # BE == BV :: BV == BE
                     if not a0.is_bool():
-                        v, d = flatten_constraint(swapped, csemap=csemap)
-                        swapped = v + d
-                    newcons.extend(swapped)
+                        v, d = flatten_constraint(newexpr, csemap=csemap)
+                        newexpr = v + d
+                    newcons.extend(newexpr)
             else:
                 newcons.append(cpm_expr)
         else:

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -29,14 +29,14 @@ from ..expressions.utils import is_any_list
 from .flatten_model import flatten_constraint, get_or_make_var
 from .negation import recurse_negation
 
-def only_bv_reifies(constraints, csemap=None):
+def only_bv_reifies(constraints, csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
         Ensure reifications have a BoolVar on the left-hand side.
 
         Returns:
             tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
-    newcons = []
+    newcons: list[Expression] = []
     for cpm_expr in constraints:
         if cpm_expr.name in ['->', "=="]:
             a0, a1 = cpm_expr.args
@@ -44,23 +44,23 @@ def only_bv_reifies(constraints, csemap=None):
                     isinstance(a1, _BoolVarImpl):
                 # BE -> BV :: ~BV -> ~BE
                 if cpm_expr.name == '->':
-                    newexpr = (~a1).implies(recurse_negation(a0))
-                    v, d = flatten_constraint(newexpr, csemap=csemap)
+                    flat_new = (~a1).implies(recurse_negation(a0))
+                    v, d = flatten_constraint(flat_new, csemap=csemap)
                     rv, rd = only_bv_reifies(v + d, csemap=csemap)
-                    newexpr = rv + rd
+                    newcons.extend(rv + rd)
                 else:
-                    newexpr = [a1 == a0]  # BE == BV :: BV == BE
+                    swapped = [a1 == a0]  # BE == BV :: BV == BE
                     if not a0.is_bool():
-                        v, d = flatten_constraint(newexpr, csemap=csemap)
-                        newexpr = v + d
-                newcons.extend(newexpr)
+                        v, d = flatten_constraint(swapped, csemap=csemap)
+                        swapped = v + d
+                    newcons.extend(swapped)
             else:
                 newcons.append(cpm_expr)
         else:
             newcons.append(cpm_expr)
     return newcons, []
 
-def only_implies(constraints, csemap=None):
+def only_implies(constraints, csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
         Transforms all reifications to ``BV -> BE`` form
 
@@ -76,8 +76,8 @@ def only_implies(constraints, csemap=None):
         Assumes all constraints are in 'flat normal form' and all reifications have a variable in lhs. Hence, only apply
         AFTER :func:`~cpmpy.transformations.flatten_model.flatten_constraint()` and :func:`only_bv_reifies()`.
     """
-    newcons = []
-    retransform = []
+    newcons: list[Expression] = []
+    retransform: list[Expression] = []
 
     for cpm_expr in constraints:
         # Operators: check BE -> BV
@@ -139,7 +139,7 @@ def only_implies(constraints, csemap=None):
     return newcons, []
 
 
-def reify_rewrite(constraints, supported=frozenset(), csemap=None):
+def reify_rewrite(constraints, supported=frozenset(), csemap=None) -> tuple[list[Expression], list[Expression]]:
     """
         Rewrites reified constraints not natively supported by a solver,
         to a version that uses standard constraints and reification over equalities between variables.

--- a/cpmpy/transformations/reification.py
+++ b/cpmpy/transformations/reification.py
@@ -44,8 +44,8 @@ def only_bv_reifies(constraints, csemap=None) -> tuple[list[Expression], list[Ex
                     isinstance(a1, _BoolVarImpl):
                 # BE -> BV :: ~BV -> ~BE
                 if cpm_expr.name == '->':
-                    flat_new = (~a1).implies(recurse_negation(a0))
-                    v, d = flatten_constraint(flat_new, csemap=csemap)
+                    newexpr = (~a1).implies(recurse_negation(a0))
+                    v, d = flatten_constraint(newexpr, csemap=csemap)
                     rv, rd = only_bv_reifies(v + d, csemap=csemap)
                     newcons.extend(rv + rd)
                 else:

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -16,7 +16,7 @@ from typing import Optional, AbstractSet, Any, Sequence
 def no_partial_functions(lst_of_expr: list[Expression],
                         _toplevel: Optional[Any]=None, 
                         _nbc: Optional[Any] = None, 
-                        safen_toplevel: Optional[AbstractSet[str]] = None) -> list[Expression]:
+                        safen_toplevel: Optional[AbstractSet[str]] = None):
     """
     A partial function is a function whose output is not defined for all possible inputs.
 
@@ -70,6 +70,9 @@ def no_partial_functions(lst_of_expr: list[Expression],
         safen_toplevel (set[str]): list of expression types that need to be safened, even when toplevel. Used when
                                     a solver supports the global function natively (not decomposed) but does not accept
                                     unsafe values in its API (e.g., OR-Tools for `div`).
+
+    Returns:
+        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
     """
 
     if _toplevel is not None:
@@ -100,11 +103,12 @@ def no_partial_functions(lst_of_expr: list[Expression],
         newlist.append(expr)
         
     if len(todolist) > 0:
-        return newlist + no_partial_functions(todolist, safen_toplevel=safen_toplevel)
+        v, d = no_partial_functions(todolist, safen_toplevel=safen_toplevel)
+        return newlist + v + d, []
     elif changed:
-        return newlist
+        return newlist, []
     else:
-        return lst_of_expr
+        return lst_of_expr, []
 
 def _no_partial_functions(lst_of_expr: ListLike[Any], is_toplevel: bool, safen_toplevel: AbstractSet[str]) -> tuple[bool, list[Expression], list[Expression], list[Expression]]:
     """

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -72,7 +72,7 @@ def no_partial_functions(lst_of_expr: list[Expression],
                                     unsafe values in its API (e.g., OR-Tools for `div`).
 
     Returns:
-        tuple[list[Expression], list[Expression]]: ``(value, defining)`` with empty defining
+        tuple[list[Expression], list[Expression]]: ``(value, defining)``
     """
 
     if _toplevel is not None:
@@ -104,7 +104,7 @@ def no_partial_functions(lst_of_expr: list[Expression],
         
     if len(todolist) > 0:
         v, d = no_partial_functions(todolist, safen_toplevel=safen_toplevel)
-        return newlist + v + d, []
+        return newlist + v, d
     elif changed:
         return newlist, []
     else:

--- a/cpmpy/transformations/safening.py
+++ b/cpmpy/transformations/safening.py
@@ -16,7 +16,7 @@ from typing import Optional, AbstractSet, Any, Sequence
 def no_partial_functions(lst_of_expr: list[Expression],
                         _toplevel: Optional[Any]=None, 
                         _nbc: Optional[Any] = None, 
-                        safen_toplevel: Optional[AbstractSet[str]] = None):
+                        safen_toplevel: Optional[AbstractSet[str]] = None) -> tuple[list[Expression], list[Expression]]:
     """
     A partial function is a function whose output is not defined for all possible inputs.
 

--- a/cpmpy/transformations/to_opb.py
+++ b/cpmpy/transformations/to_opb.py
@@ -15,7 +15,7 @@ List of functions
 import cpmpy as cp
 from cpmpy.transformations.normalize import toplevel_list,simplify_boolean
 from cpmpy.transformations.safening import no_partial_functions, safen_objective
-from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective
+from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective, apply_transform
 from cpmpy.transformations.reification import only_implies, only_bv_reifies
 from cpmpy.transformations.linearize import (
     decompose_linear,
@@ -122,31 +122,28 @@ def to_opb(cpm_expr, csemap, ivarmap, encoding="auto"):
         Transform a list of CPMpy expressions into a list of Pseudo-Boolean constraints.
     """
 
-    cpm_cons = toplevel_list(cpm_expr)
-    cpm_cons = no_partial_functions(cpm_cons, safen_toplevel={"div", "mod", "element"})
+    value, defining = toplevel_list(cpm_expr)
+    value, defining = apply_transform(no_partial_functions, value, defining, safen_toplevel={"div", "mod", "element"})
     # Use linear-specific decompositions (e.g. AllDifferent.decompose_linear)
     # before linearization, consistent with MIP backends.
-    cpm_cons = decompose_linear(
-        cpm_cons,
+    value, defining = apply_transform(
+        decompose_linear,
+        value,
+        defining,
         supported=frozenset(),
         supported_reified=frozenset(),
         csemap=csemap,
     )
-    cpm_cons = simplify_boolean(cpm_cons)
-    v, d = flatten_constraint(cpm_cons, csemap=csemap)  # flat normal form
-    cpm_cons = v + d
-    v, d = only_bv_reifies(cpm_cons, csemap=csemap)
-    cpm_cons = v + d
-    v, d = only_implies(cpm_cons, csemap=csemap)
-    cpm_cons = v + d
-    v, d = linearize_constraint(
-        cpm_cons, supported=frozenset({"sum", "wsum"}), csemap=csemap
+    value, defining = apply_transform(simplify_boolean, value, defining)
+    value, defining = apply_transform(flatten_constraint, value, defining, csemap=csemap)  # flat normal form
+    value, defining = apply_transform(only_bv_reifies, value, defining, csemap=csemap)
+    value, defining = apply_transform(only_implies, value, defining, csemap=csemap)
+    value, defining = apply_transform(
+        linearize_constraint, value, defining, supported=frozenset({"sum", "wsum"}), csemap=csemap
     )
-    cpm_cons = v + d
-    v, d = int2bool(cpm_cons, ivarmap, encoding=encoding)
-    cpm_cons = v + d
+    value, defining = apply_transform(int2bool, value, defining, ivarmap=ivarmap, encoding=encoding)
 
-    return _normalized_comparison(cpm_cons)
+    return _normalized_comparison(value + defining)
 
 
 def to_opb_objective(expr, csemap, ivarmap, encoding="auto"):

--- a/cpmpy/transformations/to_opb.py
+++ b/cpmpy/transformations/to_opb.py
@@ -133,13 +133,18 @@ def to_opb(cpm_expr, csemap, ivarmap, encoding="auto"):
         csemap=csemap,
     )
     cpm_cons = simplify_boolean(cpm_cons)
-    cpm_cons = flatten_constraint(cpm_cons, csemap=csemap)  # flat normal form
-    cpm_cons = only_bv_reifies(cpm_cons, csemap=csemap)
-    cpm_cons = only_implies(cpm_cons, csemap=csemap)
-    cpm_cons = linearize_constraint(
+    v, d = flatten_constraint(cpm_cons, csemap=csemap)  # flat normal form
+    cpm_cons = v + d
+    v, d = only_bv_reifies(cpm_cons, csemap=csemap)
+    cpm_cons = v + d
+    v, d = only_implies(cpm_cons, csemap=csemap)
+    cpm_cons = v + d
+    v, d = linearize_constraint(
         cpm_cons, supported=frozenset({"sum", "wsum"}), csemap=csemap
     )
-    cpm_cons = int2bool(cpm_cons, ivarmap, encoding=encoding)
+    cpm_cons = v + d
+    v, d = int2bool(cpm_cons, ivarmap, encoding=encoding)
+    cpm_cons = v + d
 
     return _normalized_comparison(cpm_cons)
 

--- a/dev/time_ortools.py
+++ b/dev/time_ortools.py
@@ -114,39 +114,45 @@ def _process_instance(args):
 
         step = "flatten_constraint"
         t0 = time.perf_counter()
-        cpm_expr = flatten_constraint(cpm_expr, csemap=solver._csemap)
+        _v, _d = flatten_constraint(cpm_expr, csemap=solver._csemap)
+
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "reify_rewrite"
         t0 = time.perf_counter()
-        cpm_expr = reify_rewrite(cpm_expr, supported=frozenset({"sum", "wsum"}), csemap=solver._csemap)
+        _v, _d = reify_rewrite(cpm_expr, supported=frozenset({"sum", "wsum"}), csemap=solver._csemap)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "only_numexpr_equality"
         t0 = time.perf_counter()
-        cpm_expr = only_numexpr_equality(
+        _v, _d = only_numexpr_equality(
             cpm_expr,
             supported=frozenset({"sum", "wsum", "sub"}),
             csemap=solver._csemap,
         )
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "only_bv_reifies"
         t0 = time.perf_counter()
-        cpm_expr = only_bv_reifies(cpm_expr, csemap=solver._csemap)
+        _v, _d = only_bv_reifies(cpm_expr, csemap=solver._csemap)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "only_implies"
         t0 = time.perf_counter()
-        cpm_expr = only_implies(cpm_expr, csemap=solver._csemap)
+        _v, _d = only_implies(cpm_expr, csemap=solver._csemap)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)

--- a/dev/time_ortools.py
+++ b/dev/time_ortools.py
@@ -81,21 +81,21 @@ def _process_instance(args):
     try:
         step = "toplevel_list"
         t0 = time.perf_counter()
-        cpm_expr = toplevel_list(cpm_expr)
+        cpm_expr, _ = toplevel_list(cpm_expr)
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "no_partial_functions"
         t0 = time.perf_counter()
-        cpm_expr = no_partial_functions(cpm_expr, safen_toplevel=frozenset({"div", "mod"}))
+        cpm_expr, _ = no_partial_functions(cpm_expr, safen_toplevel=frozenset({"div", "mod"}))
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "decompose_in_tree"
         t0 = time.perf_counter()
-        cpm_expr = decompose_in_tree(
+        cpm_expr, _ = decompose_in_tree(
             cpm_expr,
             supported=solver.supported_global_constraints,
             supported_reified=solver.supported_reified_global_constraints,
@@ -107,7 +107,7 @@ def _process_instance(args):
 
         step = "push_down_negation"
         t0 = time.perf_counter()
-        cpm_expr = push_down_negation(cpm_expr)
+        cpm_expr, _ = push_down_negation(cpm_expr)
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)

--- a/dev/time_transformations.py
+++ b/dev/time_transformations.py
@@ -89,21 +89,21 @@ def _process_instance(args):
     try:
         step = "toplevel_list"
         t0 = time.perf_counter()
-        cpm_expr = toplevel_list(cpm_expr)
+        cpm_expr, _ = toplevel_list(cpm_expr)
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "no_partial_functions"
         t0 = time.perf_counter()
-        cpm_expr = no_partial_functions(cpm_expr, safen_toplevel={"div", "mod", "element"})
+        cpm_expr, _ = no_partial_functions(cpm_expr, safen_toplevel={"div", "mod", "element"})
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "decompose_linear"
         t0 = time.perf_counter()
-        cpm_expr = decompose_linear(
+        cpm_expr, _ = decompose_linear(
             cpm_expr,
             supported=solver.supported_global_constraints,
             supported_reified=solver.supported_reified_global_constraints,
@@ -115,7 +115,7 @@ def _process_instance(args):
 
         step = "push_down_negation"
         t0 = time.perf_counter()
-        cpm_expr = push_down_negation(cpm_expr)
+        cpm_expr, _ = push_down_negation(cpm_expr)
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)

--- a/dev/time_transformations.py
+++ b/dev/time_transformations.py
@@ -122,46 +122,53 @@ def _process_instance(args):
 
         step = "flatten_constraint"
         t0 = time.perf_counter()
-        cpm_expr = flatten_constraint(cpm_expr, csemap=solver._csemap)
+        _v, _d = flatten_constraint(cpm_expr, csemap=solver._csemap)
+
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "only_bv_reifies"
         t0 = time.perf_counter()
-        cpm_expr = only_bv_reifies(cpm_expr, csemap=solver._csemap)
+        _v, _d = only_bv_reifies(cpm_expr, csemap=solver._csemap)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "only_implies"
         t0 = time.perf_counter()
-        cpm_expr = only_implies(cpm_expr, csemap=solver._csemap)
+        _v, _d = only_implies(cpm_expr, csemap=solver._csemap)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "linearize_constraint"
         t0 = time.perf_counter()
-        cpm_expr = linearize_constraint(
+        _v, _d = linearize_constraint(
             cpm_expr,
             supported=frozenset({"sum", "wsum", "->", "and", "or"}),
             csemap=solver._csemap,
         )
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)
 
         step = "int2bool"
         t0 = time.perf_counter()
-        cpm_expr = int2bool(cpm_expr, solver.ivarmap, encoding=solver.encoding)
+        _v, _d = int2bool(cpm_expr, solver.ivarmap, encoding=solver.encoding)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records
 
         step = "only_positive_coefficients"
         t0 = time.perf_counter()
-        cpm_expr = only_positive_coefficients(cpm_expr)
+        _v, _d = only_positive_coefficients(cpm_expr)
+        cpm_expr = _v + _d
         records.append((instance_id, step, time.perf_counter() - t0))
         if stop_after and step == stop_after:
             return records, _calc_stats(start_time, cpm_expr)

--- a/examples/advanced/cp_explanations.py
+++ b/examples/advanced/cp_explanations.py
@@ -91,8 +91,9 @@ def omus(soft_constraints, soft_weights, hard_constraints=[], solver='ortools', 
 def omus_pure(soft_constraints, soft_weights, hard_constraints=[], solver='ortools', verbose=1):
     # small optimisation: pre-flatten all constraints once
     # so it needs not be done over-and-over in solving
-    hard = flatten_constraint(hard_constraints) # batch flatten
-    soft = [flatten_constraint(c) for c in soft_constraints]
+    hv, hd = flatten_constraint(hard_constraints) # batch flatten
+    hard = hv + hd
+    soft = [(lambda vd: vd[0]+vd[1])(flatten_constraint(c)) for c in soft_constraints]
 
     ## Mip model
     if cp.Model(hard+soft).solve():

--- a/examples/advanced/quickxplain.py
+++ b/examples/advanced/quickxplain.py
@@ -21,7 +21,7 @@ def quickXplain(soft, hard=[], solver="ortools"):
             "z3", "pysat" and "gurobi" are incremental, "ortools" restarts the solver
     """
 
-    soft = toplevel_list(soft, merge_and=False)
+    soft, _ = toplevel_list(soft, merge_and=False)
     assump = cp.boolvar(shape=len(soft))
     solver = cp.SolverLookup.get(solver, cp.Model(hard))
     solver += assump.implies(soft)

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -28,7 +28,8 @@ class TestCSE:
        
         nested_alldiff = cp.AllDifferent(x,y+y,z)      
 
-        _v, _d = flatten_constraint(nested_alldiff, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(nested_alldiff, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 2
         fc = flat_cons[0]
@@ -40,7 +41,8 @@ class TestCSE:
 
         # next time we use y + y, it should replace it IV0
         nested_cons2 = (y + y) % 3 == 0
-        _v, _d = flatten_constraint(nested_cons2, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(nested_cons2, csemap=self.csemap)
+        flat_cons = _v + _d
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(IV0) mod 3 == 0"
         assert len(self.csemap) == 1
@@ -48,7 +50,8 @@ class TestCSE:
 
         # should also work for Boolean variables (introduce reification)
         nested_cons = (x + y + z >= 11) | (cp.AllDifferent(x,y,z))
-        _v, _d = flatten_constraint(nested_cons, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(nested_cons, csemap=self.csemap)
+        flat_cons = _v + _d
         
         assert len(flat_cons) == 3
         
@@ -58,7 +61,8 @@ class TestCSE:
         
         # next time we use x + y + z <= 10, it should replace it with BV0
         nested_cons2 = ((x + y + z >= 11) ^ cp.boolvar(name="a"))
-        _v, _d = flatten_constraint(nested_cons2, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(nested_cons2, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "BV0 xor a"
@@ -67,7 +71,8 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x > 5) | (y + z > 7)
-        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(cons, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert [str(con) for con in flat_cons] == [
@@ -85,7 +90,8 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x >= 6) | (y + z >= 8)
-        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(cons, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert {str(con) for con in flat_cons} == {
@@ -102,7 +108,8 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x < 6) | (y + z < 8)
-        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(cons, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert {str(con) for con in flat_cons} == {
@@ -120,7 +127,8 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x <= 5) | (y + z <= 7)
-        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
+        _v, _d = flatten_constraint(cons, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert {str(con) for con in flat_cons} == {
@@ -242,11 +250,12 @@ class TestCSE:
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
         
         cons = cp.max(x,y) < z
-        lin_cons, _ = linearize_constraint([cons], supported={"max"}, csemap=self.csemap)
-        
-        assert len(lin_cons) == 2
+        lin_cons, def_cons = linearize_constraint([cons], supported={"max"}, csemap=self.csemap)
+        all_cons = lin_cons + def_cons
+
+        assert len(all_cons) == 2
         assert str(lin_cons[0]) == "(max(x,y)) <= (IV0)"
-        assert str(lin_cons[1]) == "sum([1, -1] * [z, IV0]) == 1"
+        assert str(def_cons[0]) == "sum([1, -1] * [z, IV0]) == 1"
         
         # next time we use z - 1 it should replace it with IV0
         # ... not sure how to find a test for this...

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -24,7 +24,7 @@ class TestCSE:
        
         nested_alldiff = cp.AllDifferent(x,y+y,z)      
 
-        flat_cons = flatten_constraint(nested_alldiff, csemap=self.csemap)
+        _v, _d = flatten_constraint(nested_alldiff, csemap=self.csemap); flat_cons = _v + _d
 
         assert len(flat_cons) == 2
         fc = flat_cons[0]
@@ -36,7 +36,7 @@ class TestCSE:
 
         # next time we use y + y, it should replace it IV0
         nested_cons2 = (y + y) % 3 == 0
-        flat_cons = flatten_constraint(nested_cons2, csemap=self.csemap)
+        _v, _d = flatten_constraint(nested_cons2, csemap=self.csemap); flat_cons = _v + _d
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(IV0) mod 3 == 0"
         assert len(self.csemap) == 1
@@ -44,7 +44,7 @@ class TestCSE:
 
         # should also work for Boolean variables (introduce reification)
         nested_cons = (x + y + z >= 11) | (cp.AllDifferent(x,y,z))
-        flat_cons = flatten_constraint(nested_cons, csemap=self.csemap)
+        _v, _d = flatten_constraint(nested_cons, csemap=self.csemap); flat_cons = _v + _d
         
         assert len(flat_cons) == 3
         
@@ -54,7 +54,7 @@ class TestCSE:
         
         # next time we use x + y + z <= 10, it should replace it with BV0
         nested_cons2 = ((x + y + z >= 11) ^ cp.boolvar(name="a"))
-        flat_cons = flatten_constraint(nested_cons2, csemap=self.csemap)
+        _v, _d = flatten_constraint(nested_cons2, csemap=self.csemap); flat_cons = _v + _d
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "BV0 xor a"
@@ -63,7 +63,7 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x > 5) | (y + z > 7)
-        flat_cons = flatten_constraint(cons, csemap=self.csemap)
+        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert [str(con) for con in flat_cons] == [
@@ -81,7 +81,7 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x >= 6) | (y + z >= 8)
-        flat_cons = flatten_constraint(cons, csemap=self.csemap)
+        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert {str(con) for con in flat_cons} == {
@@ -98,7 +98,7 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x < 6) | (y + z < 8)
-        flat_cons = flatten_constraint(cons, csemap=self.csemap)
+        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert {str(con) for con in flat_cons} == {
@@ -116,7 +116,7 @@ class TestCSE:
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
 
         cons = (x <= 5) | (y + z <= 7)
-        flat_cons = flatten_constraint(cons, csemap=self.csemap)
+        _v, _d = flatten_constraint(cons, csemap=self.csemap); flat_cons = _v + _d
 
         assert len(flat_cons) == 3
         assert {str(con) for con in flat_cons} == {
@@ -134,7 +134,8 @@ class TestCSE:
         x = cp.intvar(0,10, name="x")
         b = cp.boolvar(name="b")
 
-        flat_cons = flatten_constraint((x > 5) == b, csemap=self.csemap)
+        _v, _d = flatten_constraint((x > 5) == b, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(x > 5) == (b)"
@@ -144,7 +145,8 @@ class TestCSE:
         x = cp.intvar(0,10,name="x")
         b = cp.boolvar(name="b")
 
-        flat_cons = flatten_constraint((x == 5) == b, csemap=self.csemap)
+        _v, _d = flatten_constraint((x == 5) == b, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(x == 5) == (b)"
@@ -158,7 +160,8 @@ class TestCSE:
         x = cp.intvar(0,10,name="x")
         b = cp.boolvar(name="b")
 
-        flat_cons = flatten_constraint((x != 5) == b, csemap=self.csemap)
+        _v, _d = flatten_constraint((x != 5) == b, csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 1
         assert str(flat_cons[0]) == "(x != 5) == (b)"
@@ -172,7 +175,8 @@ class TestCSE:
         y = cp.intvar(0,10,name="y")
         b = cp.boolvar(name="b")
 
-        flat_cons = flatten_constraint((x == 5) == (y == 10), csemap=self.csemap)
+        _v, _d = flatten_constraint((x == 5) == (y == 10), csemap=self.csemap)
+        flat_cons = _v + _d
 
         assert len(flat_cons) == 2
         assert str(flat_cons[0]) == "(x == 5) == (BV0)"
@@ -218,23 +222,23 @@ class TestCSE:
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
 
         cons = cp.max([x,y,z]) <= 42
-        eq_cons = only_numexpr_equality([cons], csemap=self.csemap)
+        eq_cons, def_cons = only_numexpr_equality([cons], csemap=self.csemap)
         
-        assert set([str(c) for c in eq_cons]) == {"(max(x,y,z)) == (IV0)", "IV0 <= 42"}
+        assert set([str(c) for c in eq_cons + def_cons]) == {"(max(x,y,z)) == (IV0)", "IV0 <= 42"}
         assert len(self.csemap) == 1
         
         # next time we use max([x,y,z]) it should replace it with IV0
         non_eq_cons = cp.max([x,y,z]) != 1337
-        eq_cons = only_numexpr_equality([non_eq_cons], csemap=self.csemap)
-        assert len(eq_cons) == 1
-        assert str(eq_cons[0]) == "IV0 != 1337"
+        eq_cons, def_cons = only_numexpr_equality([non_eq_cons], csemap=self.csemap)
+        assert len(eq_cons + def_cons) == 1
+        assert str((eq_cons + def_cons)[0]) == "IV0 != 1337"
         assert len(self.csemap) == 1
 
     def test_linearize(self):
         x,y,z = cp.intvar(0,10, shape=3, name=tuple("xyz"))
         
         cons = cp.max(x,y) < z
-        lin_cons = linearize_constraint([cons], supported={"max"}, csemap=self.csemap)
+        lin_cons, _ = linearize_constraint([cons], supported={"max"}, csemap=self.csemap)
         
         assert len(lin_cons) == 2
         assert str(lin_cons[0]) == "(max(x,y)) <= (IV0)"

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -3,7 +3,11 @@ import cpmpy as cp
 from cpmpy.transformations.comparison import only_numexpr_equality
 from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective
-from cpmpy.transformations.decompose_global import decompose_in_tree
+from cpmpy.transformations.decompose_global import decompose_in_tree as _raw_decompose_in_tree
+def decompose_in_tree(*a, **k):
+    v, d = _raw_decompose_in_tree(*a, **k)
+    return v + d
+
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
 from cpmpy.transformations.linearize import linearize_constraint
 from cpmpy.transformations.reification import only_bv_reifies

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,5 +1,11 @@
 import cpmpy as cp
 from cpmpy.transformations.flatten_model import flatten_model, flatten_constraint, get_or_make_var, flatten_objective, normalized_boolexpr
+from cpmpy.transformations.cse import CSEMap
+
+def _flat(expr, **kw):
+    v, d = flatten_constraint(expr, **kw)
+    return v + d
+
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
 from cpmpy.expressions.core import Operator
 
@@ -49,34 +55,53 @@ class TestFlattenConstraint:
         (x,y,z) = self.bvars[:3]
 
         e = (x == y) 
-        assert str([e]) == str(flatten_constraint(e))
+        assert str([e]) == str(_flat(e))
         e = (x == ~y) 
-        assert str([e]) == str(flatten_constraint(e))
+        assert str([e]) == str(_flat(e))
         e = (a == b) 
-        assert str([e]) == str(flatten_constraint(e))
+        assert str([e]) == str(_flat(e))
 
     def test_nq(self):
         (a,b,c,d,e) = self.ivars[:5]
         (x,y,z) = self.bvars[:3]
 
         e = (x != y) 
-        # assert "[(~BV1) == (BV0)]" == str(flatten_constraint(e)) -> part of push_down_negation now
+        # assert "[(~BV1) == (BV0)]" == str(_flat(e)) -> part of push_down_negation now
         e = (x != ~y) 
-        # assert "[(~BV1) == (~BV0)]" == str(flatten_constraint(e)) -> part of push_down_negation now
+        # assert "[(~BV1) == (~BV0)]" == str(_flat(e)) -> part of push_down_negation now
         e = (a != b) 
-        assert "[(IV0) != (IV1)]" == str(flatten_constraint(e))
+        assert "[(IV0) != (IV1)]" == str(_flat(e))
 
     def test_eq_comp(self):
         (a,b,c,d,e) = self.ivars[:5]
         (x,y,z) = self.bvars[:3]
 
         e = ((a > 5) == x)
-        assert "[(IV0 > 5) == (BV0)]" == str(flatten_constraint(e))
+        assert "[(IV0 > 5) == (BV0)]" == str(_flat(e))
         e = (x == (b < 3))
-        assert "[(IV1 < 3) == (BV0)]" == str(flatten_constraint(e))
+        assert "[(IV1 < 3) == (BV0)]" == str(_flat(e))
         e = ((a > 5) == (b < 3))
-        assert len(flatten_constraint(e)) == 2
-    
+        v, d = flatten_constraint(e)
+        assert len(v) + len(d) == 2
+
+    def test_value_defining_split(self):
+        # CSE defining constraints should be separable from the value constraint
+        x = cp.intvar(-10, 10, name="x")
+        y = cp.intvar(-10, 10, name="y")
+        csemap = CSEMap()
+        v0, d0 = flatten_constraint(cp.abs(x) + y <= 15, csemap=csemap)
+        v1, d1 = flatten_constraint(cp.abs(x) + y >= 11, csemap=csemap)
+
+        assert len(v0) == 1
+        assert len(d0) == 1
+        assert "abs" in str(d0[0])
+        assert len(v1) == 1
+        assert d1 == []  # defining reused via CSE
+        # value + defining covers the full flattened form
+        v, d = flatten_constraint(cp.abs(x) + y <= 15, csemap=CSEMap())
+        assert len(v) + len(d) == 2
+
+
 class TestFlattenExpr:
     def setup_method(self):
         _IntVarImpl.counter = 0
@@ -275,50 +300,50 @@ class TestFlattenExpr:
         (a,b,c,d,e) = self.ivars[:5]
         (x,y,z) = self.bvars[:3]
 
-        assert  str(flatten_constraint( x )) == "[BV0]"
-        assert  str(flatten_constraint( ~x )) == "[~BV0]"
-        assert  str(flatten_constraint( [x,y] )) == "[BV0, BV1]"
-        assert  str(flatten_constraint( x&y )) == "[BV0, BV1]"
-        assert  str(flatten_constraint( x&y&~z )) == "[BV0, BV1, ~BV2]"
-        assert  str(flatten_constraint( x.implies(y) )) == "[(BV0) -> (BV1)]"
-        assert  str(flatten_constraint( x|(y.implies(z)) )) == "[or(BV0, ~BV1, BV2)]"
-        assert  str(flatten_constraint( (a > 10)&x )) == "[IV0 > 10, BV0]"
+        assert  str(_flat( x )) == "[BV0]"
+        assert  str(_flat( ~x )) == "[~BV0]"
+        assert  str(_flat( [x,y] )) == "[BV0, BV1]"
+        assert  str(_flat( x&y )) == "[BV0, BV1]"
+        assert  str(_flat( x&y&~z )) == "[BV0, BV1, ~BV2]"
+        assert  str(_flat( x.implies(y) )) == "[(BV0) -> (BV1)]"
+        assert  str(_flat( x|(y.implies(z)) )) == "[or(BV0, ~BV1, BV2)]"
+        assert  str(_flat( (a > 10)&x )) == "[IV0 > 10, BV0]"
         cp.boolvar() # increase counter
-        assert  str(flatten_constraint( (a > 10).implies(x) )) == "[(IV0 > 10) -> (BV0)]"
+        assert  str(_flat( (a > 10).implies(x) )) == "[(IV0 > 10) -> (BV0)]"
         cp.boolvar() # increase counter
-        assert  str(flatten_constraint( (a > 10) )) == "[IV0 > 10]"
-        assert  str(flatten_constraint( (a > 10) == 1 )) == "[IV0 > 10]"
-        # assert  str(flatten_constraint( (a > 10) == 0 )) == "[IV0 <= 10]" -> part of push_down_negation now
-        assert  str(flatten_constraint( (a > 10) == x )) == "[(IV0 > 10) == (BV0)]"
-        #self.assertEqual( str(flatten_constraint( x == (a > 10) )), "[(IV0 > 10) == (BV0)]" ) # TODO, make it do the swap (again)
-        assert  str(flatten_constraint( (a >= 10) | (b + c >= 2) )) == "[(BV5) or (BV6), (IV0 >= 10) == (BV5), ((IV1) + (IV2) >= 2) == (BV6)]"
-        assert  str(flatten_constraint( a > 10 )) == "[IV0 > 10]"
-        assert  str(flatten_constraint( 10 > a )) == "[IV0 < 10]"# surprising
-        assert  str(flatten_constraint( a+b > c )) == "[((IV0) + (IV1)) > (IV2)]"
-        #self.assertEqual( str(flatten_constraint( c < a+b )), "[((IV0) + (IV1)) > (IV2)]" ) # TODO, make it do the swap (again)
-        assert  str(flatten_constraint( (a+b > c) == x|y )) == "[(((IV0) + (IV1)) > (IV2)) == (BV7), ((BV0) or (BV1)) == (BV7)]"
+        assert  str(_flat( (a > 10) )) == "[IV0 > 10]"
+        assert  str(_flat( (a > 10) == 1 )) == "[IV0 > 10]"
+        # assert  str(_flat( (a > 10) == 0 )) == "[IV0 <= 10]" -> part of push_down_negation now
+        assert  str(_flat( (a > 10) == x )) == "[(IV0 > 10) == (BV0)]"
+        #self.assertEqual( str(_flat( x == (a > 10) )), "[(IV0 > 10) == (BV0)]" ) # TODO, make it do the swap (again)
+        assert  str(_flat( (a >= 10) | (b + c >= 2) )) == "[(BV5) or (BV6), (IV0 >= 10) == (BV5), ((IV1) + (IV2) >= 2) == (BV6)]"
+        assert  str(_flat( a > 10 )) == "[IV0 > 10]"
+        assert  str(_flat( 10 > a )) == "[IV0 < 10]"# surprising
+        assert  str(_flat( a+b > c )) == "[((IV0) + (IV1)) > (IV2)]"
+        #self.assertEqual( str(_flat( c < a+b )), "[((IV0) + (IV1)) > (IV2)]" ) # TODO, make it do the swap (again)
+        assert  str(_flat( (a+b > c) == x|y )) == "[(((IV0) + (IV1)) > (IV2)) == (BV7), ((BV0) or (BV1)) == (BV7)]"
 
-        assert  str(flatten_constraint( a + b == c )) == "[((IV0) + (IV1)) == (IV2)]"
-        #self.assertEqual( str(flatten_constraint( c != a + b )), "[((IV0) + (IV1)) != (IV2)]" ) # TODO, make it do the swap (again)
-        assert  str(flatten_constraint( ((a > 5) == (b >= 3)) )) == "[(IV0 > 5) == (BV8), (IV1 >= 3) == (BV8)]"
+        assert  str(_flat( a + b == c )) == "[((IV0) + (IV1)) == (IV2)]"
+        #self.assertEqual( str(_flat( c != a + b )), "[((IV0) + (IV1)) != (IV2)]" ) # TODO, make it do the swap (again)
+        assert  str(_flat( ((a > 5) == (b >= 3)) )) == "[(IV0 > 5) == (BV8), (IV1 >= 3) == (BV8)]"
 
-        assert  str(flatten_constraint( cp.cpm_array([1,2,3])[a] == b )) == "[([1 2 3][IV0]) == (IV1)]"
-        assert  str(flatten_constraint( cp.cpm_array([1,2,3])[a] > b )) == "[([1 2 3][IV0]) > (IV1)]"
+        assert  str(_flat( cp.cpm_array([1,2,3])[a] == b )) == "[([1 2 3][IV0]) == (IV1)]"
+        assert  str(_flat( cp.cpm_array([1,2,3])[a] > b )) == "[([1 2 3][IV0]) > (IV1)]"
         cp.intvar(0,2, 4) # increase counter
-        assert  str(flatten_constraint( cp.cpm_array([1,2,3])[a] <= b )) == "[([1 2 3][IV0]) <= (IV1)]"
-        assert  str(flatten_constraint( cp.AllDifferent([a+b,b+c,c+3]) )) == "[alldifferent(IV9,IV10,IV11), ((IV0) + (IV1)) == (IV9), ((IV1) + (IV2)) == (IV10), ((IV2) + 3) == (IV11)]"
+        assert  str(_flat( cp.cpm_array([1,2,3])[a] <= b )) == "[([1 2 3][IV0]) <= (IV1)]"
+        assert  str(_flat( cp.AllDifferent([a+b,b+c,c+3]) )) == "[alldifferent(IV9,IV10,IV11), ((IV0) + (IV1)) == (IV9), ((IV1) + (IV2)) == (IV10), ((IV2) + 3) == (IV11)]"
 
         # issue #27
-        assert  str(flatten_constraint( (a == 10).implies(b == c+d) )) == "[(IV0 == 10) -> (BV9), (((IV2) + (IV3)) == (IV1)) == (BV9)]"
+        assert  str(_flat( (a == 10).implies(b == c+d) )) == "[(IV0 == 10) -> (BV9), (((IV2) + (IV3)) == (IV1)) == (BV9)]"
         # different order should not create more tempvars
-        assert  str(flatten_constraint( (a == 10).implies(c+d == b) )) == "[(IV0 == 10) -> (BV10), (((IV2) + (IV3)) == (IV1)) == (BV10)]"
-        assert  str(flatten_constraint( a // b == c )) == "[((IV0) div (IV1)) == (IV2)]"
-        assert  str(flatten_constraint( c == a // b )) == "[((IV0) div (IV1)) == (IV2)]"
+        assert  str(_flat( (a == 10).implies(c+d == b) )) == "[(IV0 == 10) -> (BV10), (((IV2) + (IV3)) == (IV1)) == (BV10)]"
+        assert  str(_flat( a // b == c )) == "[((IV0) div (IV1)) == (IV2)]"
+        assert  str(_flat( c == a // b )) == "[((IV0) div (IV1)) == (IV2)]"
 
         assert  str(a % 1 == 0) == "(IV0) mod 1 == 0"
 
         # boolexpr as numexpr
-        assert  str(flatten_constraint((a + b == 2) <= c)) == "[(BV11) <= (IV2), ((IV0) + (IV1) == 2) == (BV11)]"
+        assert  str(_flat((a + b == 2) <= c)) == "[(BV11) <= (IV2), ((IV0) + (IV1) == 2) == (BV11)]"
 
         # != in boolexpr, bug #170
         assert  str(normalized_boolexpr(x != (a == 1))) == "((BV12) == (~BV0), [(IV0 == 1) == (BV12)])"
@@ -330,7 +355,7 @@ class TestFlattenExpr:
         pos_wsum = Operator('wsum', ([1, -2, -1], vars_list))
         neg_wsum = Operator('wsum', ([-1, 2, 1], vars_list))
         impl = (pos_wsum < 0).implies(neg_wsum == c)
-        flat = flatten_constraint([impl])
+        flat = _flat([impl])
         for con in flat:
             if isinstance(con, Operator) and con.name == 'wsum':
                 w, v = con.args

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -10,8 +10,16 @@ from cpmpy.expressions.globalfunctions import GlobalFunction
 from cpmpy.exceptions import TypeError, NotSupportedError, IncompleteFunctionError
 from cpmpy.expressions.utils import STAR, argvals, argval
 from cpmpy.solvers import CPM_minizinc
-from cpmpy.transformations.decompose_global import decompose_in_tree
-from cpmpy.transformations.safening import no_partial_functions
+from cpmpy.transformations.decompose_global import decompose_in_tree as _raw_decompose_in_tree
+def decompose_in_tree(*a, **k):
+    v, d = _raw_decompose_in_tree(*a, **k)
+    return v + d
+
+from cpmpy.transformations.safening import no_partial_functions as _raw_no_partial_functions
+def no_partial_functions(*a, **k):
+    v, d = _raw_no_partial_functions(*a, **k)
+    return v + d
+
 
 from utils import skip_on_missing_pblib, inclusive_range, lambda_assert
 
@@ -793,7 +801,6 @@ class TestGlobal:
                     pass
 
     def test_abs(self):
-        from cpmpy.transformations.decompose_global import decompose_in_tree
         iv = cp.intvar(-8, 8, name="x")
         constraints = [cp.Abs(iv) + 9 <= 8]
         model = cp.Model(constraints)

--- a/tests/test_int2bool.py
+++ b/tests/test_int2bool.py
@@ -105,7 +105,9 @@ class TestTransInt2Bool:
         user_vars = tuple(get_variables(constraint))
         ivarmap = dict()
         csemap = CSEMap()
-        flat = int2bool(flatten_constraint(constraint), ivarmap=ivarmap, encoding=encoding, csemap=csemap)
+        v, d = flatten_constraint(constraint)
+        _v, _d = int2bool(v + d, ivarmap=ivarmap, encoding=encoding, csemap=csemap)
+        flat = _v + _d
 
         cons_sols = []
         flat_sols = []

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -101,6 +101,22 @@ class TestNativeMus(TestMus):
         self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 
+    def test_cse_defining_not_in_soft_group(self, solver):
+        """
+        Defining CSE constraints must be treated as hard for native MUS.
+        Otherwise the soft that first creates `abs(x)==IV` is spuriously required
+        when another soft reuses `IV` (Ignace, PR #986).
+        """
+        x = cp.intvar(-10, 10, name="x")
+        y = cp.intvar(-10, 10, name="y")
+        soft = [
+            cp.abs(x) + y <= 15,  # not needed for the conflict
+            cp.abs(x) + y >= 11,  # alone unsat with hard + domains
+        ]
+        hard = [x == 0]
+        mus = self.mus_func(soft, hard=hard, solver=solver)
+        assert set(mus) == {soft[1]}
+
 
 @pytest.mark.requires_solver("exact")
 class TestQuickXplain(TestMus):

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -101,22 +101,6 @@ class TestNativeMus(TestMus):
         self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
         self.naive_func = mus_naive
 
-    def test_cse_defining_not_in_soft_group(self, solver):
-        """
-        Defining CSE constraints must be treated as hard for native MUS.
-        Otherwise the soft that first creates `abs(x)==IV` is spuriously required
-        when another soft reuses `IV` (Ignace, PR #986).
-        """
-        x = cp.intvar(-10, 10, name="x")
-        y = cp.intvar(-10, 10, name="y")
-        soft = [
-            cp.abs(x) + y <= 15,  # not needed for the conflict
-            cp.abs(x) + y >= 11,  # alone unsat with hard + domains
-        ]
-        hard = [x == 0]
-        mus = self.mus_func(soft, hard=hard, solver=solver)
-        assert set(mus) == {soft[1]}
-
 
 @pytest.mark.requires_solver("exact")
 class TestQuickXplain(TestMus):

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -23,7 +23,8 @@ def linearize_reified_variables(*a, **k):
     return v + d
 
 def decompose_linear(*a, **k):
-    return _raw_decompose_linear(*a, **k)
+    v, d = _raw_decompose_linear(*a, **k)
+    return v + d
 
 def canonical_comparison(*a, **k):
     v, d = _raw_canonical_comparison(*a, **k)
@@ -43,11 +44,19 @@ def only_positive_bv_wsum_const(*a, **k):
 def only_positive_bv_wsum(*a, **k):
     return _raw_only_positive_bv_wsum(*a, **k)
 
-from cpmpy.transformations.decompose_global import decompose_in_tree
+from cpmpy.transformations.decompose_global import decompose_in_tree as _raw_decompose_in_tree
 from cpmpy.transformations.int2bool import IntVarEncDirect, IntVarEncOrder
-from cpmpy.transformations.normalize import toplevel_list
+from cpmpy.transformations.normalize import toplevel_list as _raw_toplevel_list
 from cpmpy.transformations.reification import only_bv_reifies, only_implies
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
+
+def decompose_in_tree(*a, **k):
+    v, d = _raw_decompose_in_tree(*a, **k)
+    return v + d
+
+def toplevel_list(*a, **k):
+    v, d = _raw_toplevel_list(*a, **k)
+    return v + d
 
 
 class TestTransLinearize:

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -5,7 +5,44 @@ from cpmpy.expressions import boolvar, intvar
 from cpmpy.expressions.core import Operator
 from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.flatten_model import flatten_constraint, flatten_objective
-from cpmpy.transformations.linearize import linearize_constraint, linearize_reified_variables, decompose_linear, canonical_comparison, only_positive_bv, only_positive_coefficients, only_positive_bv_wsum_const, only_positive_bv_wsum
+from cpmpy.transformations import linearize as _lin_mod
+_raw_linearize_constraint = _lin_mod.linearize_constraint
+_raw_linearize_reified_variables = _lin_mod.linearize_reified_variables
+_raw_decompose_linear = _lin_mod.decompose_linear
+_raw_canonical_comparison = _lin_mod.canonical_comparison
+_raw_only_positive_bv = _lin_mod.only_positive_bv
+_raw_only_positive_coefficients = _lin_mod.only_positive_coefficients
+_raw_only_positive_bv_wsum_const = _lin_mod.only_positive_bv_wsum_const
+_raw_only_positive_bv_wsum = _lin_mod.only_positive_bv_wsum
+def linearize_constraint(*a, **k):
+    v, d = _raw_linearize_constraint(*a, **k)
+    return v + d
+
+def linearize_reified_variables(*a, **k):
+    v, d = _raw_linearize_reified_variables(*a, **k)
+    return v + d
+
+def decompose_linear(*a, **k):
+    return _raw_decompose_linear(*a, **k)
+
+def canonical_comparison(*a, **k):
+    v, d = _raw_canonical_comparison(*a, **k)
+    return v + d
+
+def only_positive_bv(*a, **k):
+    v, d = _raw_only_positive_bv(*a, **k)
+    return v + d
+
+def only_positive_coefficients(*a, **k):
+    v, d = _raw_only_positive_coefficients(*a, **k)
+    return v + d
+
+def only_positive_bv_wsum_const(*a, **k):
+    return _raw_only_positive_bv_wsum_const(*a, **k)
+
+def only_positive_bv_wsum(*a, **k):
+    return _raw_only_positive_bv_wsum(*a, **k)
+
 from cpmpy.transformations.decompose_global import decompose_in_tree
 from cpmpy.transformations.int2bool import IntVarEncDirect, IntVarEncOrder
 from cpmpy.transformations.normalize import toplevel_list
@@ -103,8 +140,9 @@ class TestTransLinearize:
     def test_trivially_false_bool_comparison_not_wrapped_in_or(self):
         b0 = cp.boolvar(name="b0")
         b1 = cp.boolvar(name="b1")  # reifies ((~b0) + -7 <= -6)
-        cons = only_implies(only_bv_reifies([((~b0) + -7 <= -6) == b1]))
-        lin = linearize_constraint(cons, supported={"or", "->", "sum", "wsum", "and"})
+        v, d = only_bv_reifies([((~b0) + -7 <= -6) == b1])
+        v, d = only_implies(v + d)
+        lin = linearize_constraint(v + d, supported={"or", "->", "sum", "wsum", "and"})
         # comparison is trivially true for any b0, so only b1 is forced true
         assert str(lin) == "[or(b1)]"
 
@@ -619,8 +657,8 @@ class TestLinearizeReifiedVariablesThreshold:
 
     def linearize(self, cpm_cons):
         cpm_cons = toplevel_list(cpm_cons)
-        cpm_cons = flatten_constraint(cpm_cons, csemap=self.csemap)
-        return cpm_cons
+        v, d = flatten_constraint(cpm_cons, csemap=self.csemap)
+        return v + d
 
     def test_linearize_reified_variables_below_threshold(self):
         """With min_values=3, (a==1)|(a==2) is not replaced."""

--- a/tests/test_trans_safen.py
+++ b/tests/test_trans_safen.py
@@ -3,6 +3,13 @@ from cpmpy.transformations.safening import no_partial_functions
 from cpmpy.expressions.utils import argval
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl # to reset counters
 
+def _pair_to_list(fn):
+    def _wrapped(*a, **k):
+        v, d = fn(*a, **k)
+        return v + d
+    return _wrapped
+no_partial_functions = _pair_to_list(no_partial_functions)
+
 
 class TestTransSafen:
 

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -1,16 +1,14 @@
 import cpmpy as cp
-from cpmpy.expressions.core import Operator, BoolVal, Comparison
+from cpmpy.expressions.core import Operator, BoolVal, Comparison, Expression
 from cpmpy.transformations.negation import push_down_negation
 from cpmpy.transformations.normalize import simplify_boolean, toplevel_list
 
-def _pair_to_list(fn):
-    def _wrapped(*a, **k):
-        v, d = fn(*a, **k)
-        return v + d
-    return _wrapped
-simplify_boolean = _pair_to_list(simplify_boolean)
-toplevel_list = _pair_to_list(toplevel_list)
-push_down_negation = _pair_to_list(push_down_negation)
+
+def _join_transform(expr):
+    value, defining = toplevel_list(expr)
+    value, defining = push_down_negation(value + defining)
+    value, defining = simplify_boolean(value + defining)
+    return value + defining
 
 
 class TestTransSimplify:
@@ -19,7 +17,7 @@ class TestTransSimplify:
         self.bvs = cp.boolvar(shape=3, name="bv")
         self.ivs = cp.intvar(0, 5, shape=3, name="iv")
 
-        self.transform = lambda x: simplify_boolean(push_down_negation(toplevel_list(x)))
+        self.transform = _join_transform
 
     def test_bool_ops(self):
         expr = Operator("or", self.bvs.tolist() + [False])

--- a/tests/test_trans_simplify.py
+++ b/tests/test_trans_simplify.py
@@ -3,6 +3,15 @@ from cpmpy.expressions.core import Operator, BoolVal, Comparison
 from cpmpy.transformations.negation import push_down_negation
 from cpmpy.transformations.normalize import simplify_boolean, toplevel_list
 
+def _pair_to_list(fn):
+    def _wrapped(*a, **k):
+        v, d = fn(*a, **k)
+        return v + d
+    return _wrapped
+simplify_boolean = _pair_to_list(simplify_boolean)
+toplevel_list = _pair_to_list(toplevel_list)
+push_down_negation = _pair_to_list(push_down_negation)
+
 
 class TestTransSimplify:
 

--- a/tests/test_transf_comp.py
+++ b/tests/test_transf_comp.py
@@ -22,7 +22,9 @@ class TestTransfComp:
                 ]
 
         # test transformation
-        transform = lambda expr: only_numexpr_equality(flatten_constraint(expr))
+        def _join(vd):
+            return vd[0] + vd[1]
+        transform = lambda expr: _join(only_numexpr_equality(_join(flatten_constraint(expr))))
 
         for (expr, strexpr) in cases:
             self.setup_method()  # reset the IV counters

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -7,6 +7,14 @@ from cpmpy.transformations.decompose_global import decompose_in_tree
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl  # to reset counters
 from cpmpy.transformations.linearize import decompose_linear
 
+def _pair_to_list(fn):
+    def _wrapped(*a, **k):
+        v, d = fn(*a, **k)
+        return v + d
+    return _wrapped
+decompose_in_tree = _pair_to_list(decompose_in_tree)
+decompose_linear = _pair_to_list(decompose_linear)
+
 
 class TestTransfDecomp:
 

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -4,6 +4,7 @@ from cpmpy.expressions.globalfunctions import GlobalFunction
 from cpmpy.expressions.utils import flatlist
 from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.decompose_global import decompose_in_tree
+from cpmpy.transformations.decompose_global import decompose_in_tree as decompose_in_tree_raw
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl  # to reset counters
 from cpmpy.transformations.linearize import decompose_linear
 
@@ -253,6 +254,14 @@ class TestTransfDecomp:
         assert set(map(str, decompose_in_tree([bv.implies(cons)]))) == {"(bv) -> (sum(a, b, c) >= 1)", "a == 1"} # decompose positive
         assert set(map(str, decompose_in_tree([cons.implies(bv)]))) == {"(sum(a, b, c) == 1) -> (bv)","a == 1"}  # decompose standard
         assert set(map(str, decompose_in_tree([bv == (cons)]))) == {"(bv) == (sum(a, b, c) == 1)", "a == 1"} # decompose standard
+
+        # defining from decompose() must stay on the defining stream
+        v, d = decompose_in_tree_raw([cons])
+        assert set(map(str, v)) == {"sum(a, b, c) >= 1"}
+        assert set(map(str, d)) == {"a == 1"}
+        v, d = decompose_in_tree_raw([bv.implies(cons)])
+        assert set(map(str, v)) == {"(bv) -> (sum(a, b, c) >= 1)"}
+        assert set(map(str, d)) == {"a == 1"}
 
 
 

--- a/tests/test_transf_negation.py
+++ b/tests/test_transf_negation.py
@@ -1,6 +1,13 @@
 import cpmpy as cp
 from cpmpy.transformations.negation import push_down_negation, recurse_negation
 
+def _pair_to_list(fn):
+    def _wrapped(*a, **k):
+        v, d = fn(*a, **k)
+        return v + d
+    return _wrapped
+push_down_negation = _pair_to_list(push_down_negation)
+
 
 class TestTransfNegation:
 

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -87,7 +87,7 @@ class TestTransfReif:
         def _join(vd):
             return vd[0] + vd[1]
         f = lambda expr: str(_join(reify_rewrite(_join(flatten_constraint(expr)))))
-        fd = lambda expr: str(_join(reify_rewrite(_join(flatten_constraint(decompose_in_tree(expr))))))
+        fd = lambda expr: str(_join(reify_rewrite(_join(flatten_constraint(_join(decompose_in_tree(expr)))))))
 
 
         # various reify_rewrite cases:

--- a/tests/test_transf_reif.py
+++ b/tests/test_transf_reif.py
@@ -30,7 +30,9 @@ class TestTransfReif:
 
         # test transformation
         for (expr, strexpr) in cases:
-            assert  str(only_implies(only_bv_reifies((expr,)))) == strexpr
+            v, d = only_bv_reifies((expr,))
+            v, d = only_implies(v + d)
+            assert str(v + d) == strexpr
             assert cp.Model(expr).solve()
 
     def test_reif_element(self):
@@ -82,8 +84,10 @@ class TestTransfReif:
         rv = cp.boolvar(name="rv")
         arr = cp.cpm_array([0,1,2])
 
-        f = lambda expr : str(reify_rewrite(flatten_constraint(expr)))
-        fd = lambda expr : str(reify_rewrite(flatten_constraint(decompose_in_tree(expr))))
+        def _join(vd):
+            return vd[0] + vd[1]
+        f = lambda expr: str(_join(reify_rewrite(_join(flatten_constraint(expr)))))
+        fd = lambda expr: str(_join(reify_rewrite(_join(flatten_constraint(decompose_in_tree(expr))))))
 
 
         # various reify_rewrite cases:
@@ -93,7 +97,7 @@ class TestTransfReif:
         assert f((bvs[0].implies(bvs[1])).implies(rv)) == "[(~rv) -> (bvs[0]), (~rv) -> (~bvs[1])]"
         pytest.raises(ValueError, lambda : f(rv == cp.AllDifferent(ivs)))
         assert fd([rv.implies(cp.AllDifferent(ivs))]) == "[(rv) -> ((ivs[0]) != (ivs[1])), (rv) -> ((ivs[0]) != (ivs[2])), (rv) -> ((ivs[1]) != (ivs[2]))]"
-        assert f(rv == (arr[cp.intvar(0, 2)] != 1)) == "[([0 1 2][IV0]) == (IV1), (IV1 != 1) == (rv)]"
-        assert f(rv == (cp.max(ivs) > 5)) == "[(max(ivs[0],ivs[1],ivs[2])) == (IV2), (IV2 > 5) == (rv)]"
-        assert f(rv.implies(cp.min(ivs) != 0)) == "[(min(ivs[0],ivs[1],ivs[2])) == (IV3), (rv) -> (IV3 != 0)]"
-        assert f((cp.min(ivs) != 0).implies(rv)) == "[(min(ivs[0],ivs[1],ivs[2])) == (IV4), (IV4 != 0) -> (rv)]"
+        assert f(rv == (arr[cp.intvar(0, 2)] != 1)) == "[(IV1 != 1) == (rv), ([0 1 2][IV0]) == (IV1)]"
+        assert f(rv == (cp.max(ivs) > 5)) == "[(IV2 > 5) == (rv), (max(ivs[0],ivs[1],ivs[2])) == (IV2)]"
+        assert f(rv.implies(cp.min(ivs) != 0)) == "[(rv) -> (IV3 != 0), (min(ivs[0],ivs[1],ivs[2])) == (IV3)]"
+        assert f((cp.min(ivs) != 0).implies(rv)) == "[(IV4 != 0) -> (rv), (min(ivs[0],ivs[1],ivs[2])) == (IV4)]"

--- a/tests/test_value_defining_split.py
+++ b/tests/test_value_defining_split.py
@@ -3,8 +3,6 @@ Tests that transformations put auxiliary/defining constraints on the defining
 stream (and the rewritten input on the value stream), not the other way around.
 """
 import cpmpy as cp
-from cpmpy.expressions.globalconstraints import GlobalConstraint
-from cpmpy.expressions.utils import flatlist
 from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
 from cpmpy.transformations.cse import CSEMap
 from cpmpy.transformations.comparison import only_numexpr_equality
@@ -66,35 +64,30 @@ class TestValueDefiningSplit:
         assert "max" not in str(v[0])
 
     def test_decompose_in_tree(self):
-        class MyGlobal(GlobalConstraint):
-            def __init__(self, arr):
-                super().__init__("mycustomglobal", tuple(flatlist(arr)))
+        # Globals/functions already return (value, defining) from decompose();
+        # decompose_in_tree must keep that second list on the defining stream.
+        x = cp.intvar(0, 5, shape=3, name="x")
+        b = cp.boolvar(name="b")
 
-            def decompose(self):
-                return [cp.sum(self.args) == 1], [self.args[0] == 1]
+        # Table.decompose_positive: value = any(row selectors), defining = row implications
+        v, d = decompose_in_tree([cp.Table(x, [[0, 1, 2], [1, 2, 3]])])
+        assert str(v) == "[(BV0) or (BV1)]"
+        assert str(d) == ("[(BV0) -> (and(x[0] == 0, x[1] == 1, x[2] == 2)), "
+                          "(BV1) -> (and(x[0] == 1, x[1] == 2, x[2] == 3))]")
 
-            def decompose_positive(self):
-                return [cp.sum(self.args) >= 1], [self.args[0] == 1]
+        # nested Maximum: value keeps the comparison; defining totally defines the aux
+        v, d = decompose_in_tree([b == (cp.max(x) <= 3)], csemap=CSEMap())
+        assert str(v) == "[(b) == (IV0 <= 3)]"
+        assert str(d) == ("[(IV0) >= (x[0]), (IV0) >= (x[1]), (IV0) >= (x[2]), "
+                          "or((IV0) <= (x[0]), (IV0) <= (x[1]), (IV0) <= (x[2]))]")
 
-        a, b, c = cp.intvar(0, 10, shape=3, name=("a", "b", "c"))
-        bv = cp.boolvar(name="bv")
-        cons = MyGlobal([a, b, c])
-
-        v, d = decompose_in_tree([cons])
-        assert str(v) == "[sum(a, b, c) >= 1]"
-        assert str(d) == "[a == 1]"
-
-        v, d = decompose_in_tree([bv.implies(cons)])
-        assert str(v) == "[(bv) -> (sum(a, b, c) >= 1)]"
-        assert str(d) == "[a == 1]"
-
-        # nested global function: max defining stays defining
-        x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
-        q = cp.intvar(0, 2, name="q")
-        v, d = decompose_in_tree([bv == ((cp.max([x, y, z]) + q) <= 10)], csemap=CSEMap())
-        assert str(v) == "[(bv) == ((IV0) + (q) <= 10)]"
-        assert len(d) == 4
-        assert all("IV0" in str(c) for c in d)
+        # Element: value is the comparison on the aux; defining channels index -> arr
+        arr = cp.intvar(0, 5, shape=4, name="a")
+        i = cp.intvar(0, 3, name="i")
+        v, d = decompose_in_tree([arr[i] == 2], csemap=CSEMap())
+        assert str(v) == "[IV1 == 2]"
+        assert str(d) == ("[(i == 0) -> ((IV1) == (a[0])), (i == 1) -> ((IV1) == (a[1])), "
+                          "(i == 2) -> ((IV1) == (a[2])), (i == 3) -> ((IV1) == (a[3]))]")
 
     def test_linearize(self):
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))

--- a/tests/test_value_defining_split.py
+++ b/tests/test_value_defining_split.py
@@ -1,0 +1,130 @@
+"""
+Tests that transformations put auxiliary/defining constraints on the defining
+stream (and the rewritten input on the value stream), not the other way around.
+"""
+import cpmpy as cp
+from cpmpy.expressions.globalconstraints import GlobalConstraint
+from cpmpy.expressions.utils import flatlist
+from cpmpy.expressions.variables import _IntVarImpl, _BoolVarImpl
+from cpmpy.transformations.cse import CSEMap
+from cpmpy.transformations.comparison import only_numexpr_equality
+from cpmpy.transformations.decompose_global import decompose_in_tree
+from cpmpy.transformations.flatten_model import flatten_constraint, apply_transform
+from cpmpy.transformations.int2bool import int2bool
+from cpmpy.transformations.linearize import linearize_constraint
+from cpmpy.transformations.reification import only_bv_reifies, only_implies, reify_rewrite
+
+
+def _strs(exprs):
+    return list(map(str, exprs))
+
+
+class TestValueDefiningSplit:
+    def setup_method(self):
+        _IntVarImpl.counter = 0
+        _BoolVarImpl.counter = 0
+
+    def test_flatten_cse_defining(self):
+        x = cp.intvar(-10, 10, name="x")
+        y = cp.intvar(-10, 10, name="y")
+        csemap = CSEMap()
+
+        v0, d0 = flatten_constraint(cp.abs(x) + y <= 15, csemap=csemap)
+        assert len(v0) == 1 and len(d0) == 1
+        assert "abs" in str(d0[0])
+        assert "abs" not in str(v0[0])
+
+        v1, d1 = flatten_constraint(cp.abs(x) + y >= 11, csemap=csemap)
+        assert len(v1) == 1 and d1 == []  # CSE reuses defining
+
+    def test_only_bv_reifies(self):
+        x = cp.intvar(-10, 10, name="x")
+        b = cp.boolvar(name="b")
+        # BE -> BV rewrite flattens nested abs into a defining equality
+        v, d = only_bv_reifies([((cp.abs(x) + x) >= 3).implies(b)], csemap=CSEMap())
+        assert _strs(v) == ["(~b) -> ((IV0) + (x) < 3)"]
+        assert _strs(d) == ["(abs(x)) == (IV0)"]
+
+    def test_only_implies(self):
+        x = cp.intvar(-10, 10, name="x")
+        b = cp.boolvar(name="b")
+        v, d = only_implies([(b) == ((cp.abs(x) + x) >= 3)], csemap=CSEMap())
+        assert _strs(v) == [
+            "(b) -> ((IV0) + (x) >= 3)",
+            "(~b) -> ((IV0) + (x) < 3)",
+        ]
+        assert _strs(d) == ["(abs(x)) == (IV0)"]
+
+    def test_reify_rewrite(self):
+        ivs = cp.intvar(1, 9, shape=3, name="ivs")
+        rv = cp.boolvar(name="rv")
+        flat_v, flat_d = flatten_constraint(rv == (cp.max(ivs) > 5), csemap=CSEMap())
+        v, d = apply_transform(reify_rewrite, flat_v, flat_d)
+        # value is the reified comparison over an aux; defining defines that aux
+        assert len(v) == 1 and "rv" in str(v[0])
+        assert any("max" in str(c) for c in d)
+        assert all("max" not in str(c) for c in v)
+
+    def test_only_numexpr_equality(self):
+        x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
+        v, d = only_numexpr_equality([cp.max(x, y, z) < 5], supported=frozenset(), csemap=CSEMap())
+        assert len(v) == 1 and len(d) == 1
+        assert "max" in str(d[0]) and "==" in str(d[0])
+        assert "max" not in str(v[0])
+
+    def test_decompose_in_tree(self):
+        class MyGlobal(GlobalConstraint):
+            def __init__(self, arr):
+                super().__init__("mycustomglobal", tuple(flatlist(arr)))
+
+            def decompose(self):
+                return [cp.sum(self.args) == 1], [self.args[0] == 1]
+
+            def decompose_positive(self):
+                return [cp.sum(self.args) >= 1], [self.args[0] == 1]
+
+        a, b, c = cp.intvar(0, 10, shape=3, name=("a", "b", "c"))
+        bv = cp.boolvar(name="bv")
+        cons = MyGlobal([a, b, c])
+
+        v, d = decompose_in_tree([cons])
+        assert _strs(v) == ["sum(a, b, c) >= 1"]
+        assert _strs(d) == ["a == 1"]
+
+        v, d = decompose_in_tree([bv.implies(cons)])
+        assert _strs(v) == ["(bv) -> (sum(a, b, c) >= 1)"]
+        assert _strs(d) == ["a == 1"]
+
+        # nested global function: max defining stays defining
+        x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
+        q = cp.intvar(0, 2, name="q")
+        v, d = decompose_in_tree([bv == ((cp.max([x, y, z]) + q) <= 10)], csemap=CSEMap())
+        assert _strs(v) == ["(bv) == ((IV0) + (q) <= 10)"]
+        assert len(d) == 4
+        assert all("IV0" in s for s in _strs(d))
+
+    def test_linearize(self):
+        x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
+        v, d = linearize_constraint([cp.max(x, y) < z], supported={"max"}, csemap=CSEMap())
+        assert _strs(v) == ["(max(x,y)) <= (IV0)"]
+        assert _strs(d) == ["sum([1, -1] * [z, IV0]) == 1"]
+
+    def test_int2bool_domain_defining(self):
+        x = cp.intvar(0, 2, name="x")
+        v, d = int2bool([cp.sum([x]) >= 1], ivarmap={}, encoding="direct", csemap=CSEMap())
+        assert len(v) == 1
+        assert len(d) == 1
+        # value is the rewritten PB constraint; defining is the domain/exactly-one
+        assert "sum" in str(d[0]) and "== 1" in str(d[0])
+        assert "sum" not in str(v[0]) or str(v[0]).startswith("~")
+
+    def test_apply_transform_preserves_existing_defining(self):
+        x = cp.intvar(-10, 10, name="x")
+        y = cp.intvar(-10, 10, name="y")
+        csemap = CSEMap()
+        v, d = flatten_constraint(cp.abs(x) + y <= 15, csemap=csemap)
+        assert len(d) == 1
+        # a no-op-ish transform on both streams must keep defining as defining
+        v2, d2 = apply_transform(only_bv_reifies, v, d, csemap=csemap)
+        assert any("abs" in str(c) for c in d2)
+        assert all("abs" not in str(c) for c in v2)

--- a/tests/test_value_defining_split.py
+++ b/tests/test_value_defining_split.py
@@ -15,10 +15,6 @@ from cpmpy.transformations.linearize import linearize_constraint
 from cpmpy.transformations.reification import only_bv_reifies, only_implies, reify_rewrite
 
 
-def _strs(exprs):
-    return list(map(str, exprs))
-
-
 class TestValueDefiningSplit:
     def setup_method(self):
         _IntVarImpl.counter = 0
@@ -42,18 +38,15 @@ class TestValueDefiningSplit:
         b = cp.boolvar(name="b")
         # BE -> BV rewrite flattens nested abs into a defining equality
         v, d = only_bv_reifies([((cp.abs(x) + x) >= 3).implies(b)], csemap=CSEMap())
-        assert _strs(v) == ["(~b) -> ((IV0) + (x) < 3)"]
-        assert _strs(d) == ["(abs(x)) == (IV0)"]
+        assert str(v) == "[(~b) -> ((IV0) + (x) < 3)]"
+        assert str(d) == "[(abs(x)) == (IV0)]"
 
     def test_only_implies(self):
         x = cp.intvar(-10, 10, name="x")
         b = cp.boolvar(name="b")
         v, d = only_implies([(b) == ((cp.abs(x) + x) >= 3)], csemap=CSEMap())
-        assert _strs(v) == [
-            "(b) -> ((IV0) + (x) >= 3)",
-            "(~b) -> ((IV0) + (x) < 3)",
-        ]
-        assert _strs(d) == ["(abs(x)) == (IV0)"]
+        assert str(v) == "[(b) -> ((IV0) + (x) >= 3), (~b) -> ((IV0) + (x) < 3)]"
+        assert str(d) == "[(abs(x)) == (IV0)]"
 
     def test_reify_rewrite(self):
         ivs = cp.intvar(1, 9, shape=3, name="ivs")
@@ -88,26 +81,26 @@ class TestValueDefiningSplit:
         cons = MyGlobal([a, b, c])
 
         v, d = decompose_in_tree([cons])
-        assert _strs(v) == ["sum(a, b, c) >= 1"]
-        assert _strs(d) == ["a == 1"]
+        assert str(v) == "[sum(a, b, c) >= 1]"
+        assert str(d) == "[a == 1]"
 
         v, d = decompose_in_tree([bv.implies(cons)])
-        assert _strs(v) == ["(bv) -> (sum(a, b, c) >= 1)"]
-        assert _strs(d) == ["a == 1"]
+        assert str(v) == "[(bv) -> (sum(a, b, c) >= 1)]"
+        assert str(d) == "[a == 1]"
 
         # nested global function: max defining stays defining
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
         q = cp.intvar(0, 2, name="q")
         v, d = decompose_in_tree([bv == ((cp.max([x, y, z]) + q) <= 10)], csemap=CSEMap())
-        assert _strs(v) == ["(bv) == ((IV0) + (q) <= 10)"]
+        assert str(v) == "[(bv) == ((IV0) + (q) <= 10)]"
         assert len(d) == 4
-        assert all("IV0" in s for s in _strs(d))
+        assert all("IV0" in str(c) for c in d)
 
     def test_linearize(self):
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
         v, d = linearize_constraint([cp.max(x, y) < z], supported={"max"}, csemap=CSEMap())
-        assert _strs(v) == ["(max(x,y)) <= (IV0)"]
-        assert _strs(d) == ["sum([1, -1] * [z, IV0]) == 1"]
+        assert str(v) == "[(max(x,y)) <= (IV0)]"
+        assert str(d) == "[sum([1, -1] * [z, IV0]) == 1]"
 
     def test_int2bool_domain_defining(self):
         x = cp.intvar(0, 2, name="x")

--- a/tests/test_value_defining_split.py
+++ b/tests/test_value_defining_split.py
@@ -24,12 +24,12 @@ class TestValueDefiningSplit:
         csemap = CSEMap()
 
         v0, d0 = flatten_constraint(cp.abs(x) + y <= 15, csemap=csemap)
-        assert len(v0) == 1 and len(d0) == 1
-        assert "abs" in str(d0[0])
-        assert "abs" not in str(v0[0])
+        assert str(v0) == "[(IV0) + (y) <= 15]"
+        assert str(d0) == "[(abs(x)) == (IV0)]"
 
         v1, d1 = flatten_constraint(cp.abs(x) + y >= 11, csemap=csemap)
-        assert len(v1) == 1 and d1 == []  # CSE reuses defining
+        assert str(v1) == "[(IV0) + (y) >= 11]"
+        assert str(d1) == "[]"  # CSE reuses defining
 
     def test_only_bv_reifies(self):
         x = cp.intvar(-10, 10, name="x")
@@ -51,17 +51,14 @@ class TestValueDefiningSplit:
         rv = cp.boolvar(name="rv")
         flat_v, flat_d = flatten_constraint(rv == (cp.max(ivs) > 5), csemap=CSEMap())
         v, d = apply_transform(reify_rewrite, flat_v, flat_d)
-        # value is the reified comparison over an aux; defining defines that aux
-        assert len(v) == 1 and "rv" in str(v[0])
-        assert any("max" in str(c) for c in d)
-        assert all("max" not in str(c) for c in v)
+        assert str(v) == "[(IV0 > 5) == (rv)]"
+        assert str(d) == "[(max(ivs[0],ivs[1],ivs[2])) == (IV0)]"
 
     def test_only_numexpr_equality(self):
         x, y, z = cp.intvar(0, 10, shape=3, name=tuple("xyz"))
         v, d = only_numexpr_equality([cp.max(x, y, z) < 5], supported=frozenset(), csemap=CSEMap())
-        assert len(v) == 1 and len(d) == 1
-        assert "max" in str(d[0]) and "==" in str(d[0])
-        assert "max" not in str(v[0])
+        assert str(v) == "[IV0 < 5]"
+        assert str(d) == "[(max(x,y,z)) == (IV0)]"
 
     def test_decompose_in_tree(self):
         # Globals/functions already return (value, defining) from decompose();
@@ -98,19 +95,14 @@ class TestValueDefiningSplit:
     def test_int2bool_domain_defining(self):
         x = cp.intvar(0, 2, name="x")
         v, d = int2bool([cp.sum([x]) >= 1], ivarmap={}, encoding="direct", csemap=CSEMap())
-        assert len(v) == 1
-        assert len(d) == 1
-        # value is the rewritten PB constraint; defining is the domain/exactly-one
-        assert "sum" in str(d[0]) and "== 1" in str(d[0])
-        assert "sum" not in str(v[0]) or str(v[0]).startswith("~")
+        assert str(v) == "[~BV[x == 0]]"
+        assert str(d) == "[sum(BV[x == 0], BV[x == 1], BV[x == 2]) == 1]"
 
     def test_apply_transform_preserves_existing_defining(self):
         x = cp.intvar(-10, 10, name="x")
         y = cp.intvar(-10, 10, name="y")
         csemap = CSEMap()
         v, d = flatten_constraint(cp.abs(x) + y <= 15, csemap=csemap)
-        assert len(d) == 1
-        # a no-op-ish transform on both streams must keep defining as defining
         v2, d2 = apply_transform(only_bv_reifies, v, d, csemap=csemap)
-        assert any("abs" in str(c) for c in d2)
-        assert all("abs" not in str(c) for c in v2)
+        assert str(v2) == "[(IV0) + (y) <= 15]"
+        assert str(d2) == "[(abs(x)) == (IV0)]"


### PR DESCRIPTION
This PR splits up value and defining constraints throughout the whole transformation pipeline. On master it is only done in some parts, e.g. decomposition of globals. This PR allows the split to be used elsewhere as well, specifically it will enable a fix for a bug noticed by @IgnaceBleukx in #986. The diff is quite large and while the core idea is simple it is important to verify that the split is correct for all transformations.