### PR TITLE
Halfreified global constraints

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -258,6 +258,23 @@ class AllDifferent(GlobalConstraint):
         lb, ub = min(lbs), max(ubs)
         return [cp.sum((arg_i == val) for arg_i in self.args) <= 1 for val in range(lb, ub + 1)], []
 
+    def reformulate_toplevel(self) -> tuple[list[Expression], list[Expression]]:
+        """
+        Post constraint to top-level with auxiliary variables and replace original global with channeling constraint
+        Based on:
+            Ignace Bleukx, Hélène Verhaeghe, Dimos Tsouros, and Tias Guns. 2026. 
+            Efficient Reformulations of Half-reified GlobalConstraints using Auxiliary Variables. 
+            Journal of Artificial Intelligence Research 86, Article 52 (August 2026).
+        """
+
+        has_sol = cp.Model(self).solve(solver='ortools', num_workers=1)
+        if not has_sol:
+            return [cp.BoolVal(False)], []
+
+        new_args = [cp.intvar(lb, ub) for lb, ub in zip(*get_bounds(self.args))]
+        return [new_arg == arg for new_arg, arg in zip(new_args, self.args)], [cp.AllDifferent(new_args)]
+
+
     def value(self) -> Optional[bool]:
         """
         Returns:

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -152,7 +152,9 @@ def decompose_in_tree(lst_of_expr: list[Expression],
             if expr.name == "->" and isinstance(expr.args[1], GlobalConstraint) and expr.args[1].name not in supported_reified:
                 changed = True
                 subexpr = expr.args[1]
-                if decompose_custom_positive is not None and subexpr.name in decompose_custom_positive:
+                if subexpr.name in supported and hasattr(subexpr, "reformulate_toplevel"):
+                    exprs, toplevel_exprs = subexpr.reformulate_toplevel()
+                elif decompose_custom_positive is not None and subexpr.name in decompose_custom_positive:
                     exprs, toplevel_exprs = decompose_custom_positive[subexpr.name](subexpr)
                 elif decompose_custom is not None and subexpr.name in decompose_custom:
                     exprs, toplevel_exprs = decompose_custom[subexpr.name](subexpr)

--- a/tests/test_transf_decompose.py
+++ b/tests/test_transf_decompose.py
@@ -26,8 +26,8 @@ class TestTransfDecomp:
         cons = [bv.implies(cp.AllDifferent(ivs))]
         assert str(decompose_in_tree(cons)) == \
                          "[(bv) -> (and((x) != (y), (x) != (z), (y) != (z)))]"
-        assert str(decompose_in_tree(cons, supported={"alldifferent"})) == \
-                         "[(bv) -> (and((x) != (y), (x) != (z), (y) != (z)))]"
+        # assert str(decompose_in_tree(cons, supported={"alldifferent"})) == \
+        #                  "[(bv) -> (and((x) != (y), (x) != (z), (y) != (z)))]" # reformulated to toplevel
         assert str(decompose_in_tree(cons, supported={"alldifferent"}, supported_reified={"alldifferent"})) ==str(cons)
 
         cons = [cp.AllDifferent(ivs).implies(bv)]
@@ -387,3 +387,23 @@ class TestTransfDecomp:
         assert str(decomposed) == "[(boolval(True)) or (boolval(True))]"
 
         assert cp.Model(cons).solve(solver="ortools")
+
+
+    def test_decompose_reformulate_toplevel(self):
+        x = cp.intvar(1,3, shape=3, name="x")
+        bv = cp.boolvar(name="bv")
+        cons = [bv.implies(cp.AllDifferent(x))]
+
+        decomposed = decompose_in_tree(cons, supported={"alldifferent"}, supported_reified=set())
+        assert set(map(str, decomposed)) == {
+            "(bv) -> (and((IV0) == (x[0]), (IV1) == (x[1]), (IV2) == (x[2])))",
+            "alldifferent(IV0,IV1,IV2)",
+        }
+
+        x_small = cp.intvar(1,2, shape=3, name="x")
+        cons = [bv.implies(cp.AllDifferent(x_small))]
+
+        decomposed = decompose_in_tree(cons, supported={"alldifferent"}, supported_reified=set())
+        assert set(map(str, decomposed)) == {
+            "(bv) -> (boolval(False))",
+        }


### PR DESCRIPTION
Prototype for avoiding decompositions of half-reified global constraints, for now just for AllDifferent, but easily generalizable to the other globals too.

The main open question for me is which solver to use for checking if `self` has a solution? For now I just use ortools (with one thread) but there is an argument to be made to use the solver we are doing the transorm for.