### PR TITLE
Fix MUS tests

### DIFF
--- a/cpmpy/tools/explain/marco.py
+++ b/cpmpy/tools/explain/marco.py
@@ -3,6 +3,7 @@
 """
 
 import cpmpy as cp
+from cpmpy.exceptions import NotSupportedError
 from cpmpy.transformations.get_variables import get_variables
 
 from .utils import make_assump_model
@@ -40,12 +41,14 @@ def marco(soft, hard=[], solver="ortools", map_solver="ortools", return_mus=True
 
     # map solver for computing hitting sets
     map_solver = cp.SolverLookup.get(map_solver)
-    do_solution_hint = do_solution_hint and hasattr(map_solver, 'solution_hint')  # solver may not support solution hinting...
-
     map_solver += cp.any(assump)
+    
     if do_solution_hint:
         hint = [1]*len(assump)
-        map_solver.solution_hint(assump, hint) # we want large subsets, more likely to be a MUS
+        try:
+            map_solver.solution_hint(assump, hint) # we want large subsets, more likely to be a MUS
+        except NotSupportedError: # not all solvers support solution hinting
+            do_solution_hint = False
 
     deletion_order = {a : -len(get_variables(dmap[a])) for a in assump} # avoid recomputing
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -12,6 +12,7 @@
 import warnings
 import numpy as np
 import cpmpy as cp
+from cpmpy.exceptions import NotSupportedError
 from cpmpy.solvers.solver_interface import ExitStatus
 from cpmpy.transformations.get_variables import get_variables
 from cpmpy.transformations.normalize import toplevel_list
@@ -164,8 +165,11 @@ def ocus(soft, hard=[], weights=None, meta_constraint=True, solver="ortools", hs
     dmap = dict(zip(assump, soft)) # map assumption variables to constraints
 
     s = cp.SolverLookup.get(solver, model)
-    if do_solution_hint and hasattr(s, 'solution_hint'): # algo is constructive, so favor large subsets
-        s.solution_hint(assump, [1]*len(assump))
+    if do_solution_hint:
+        try:
+            s.solution_hint(assump, [1]*len(assump)) # algo is constructive, so favor large subsets
+        except NotSupportedError: # not all solvers support solution hinting
+            pass
 
     assert s.solve(assumptions=assump) is False
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -1,31 +1,61 @@
+import inspect
 import pytest
 
 import cpmpy as cp
 from cpmpy.tools import mss_opt, marco, OCUSException
 from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, optimal_mus, optimal_mus_naive, mss, mcs, ocus, ocus_naive, mus_native
 
-@pytest.mark.requires_solver("exact")
+
+# Each shared case runs twice: assumption-based (or native) MUS, and the naive variant.
+# Unsupported solvers skip only the non-naive case; naive still runs.
+mus_or_naive = pytest.mark.parametrize("naive", [False, True], ids=["mus", "naive"])
+
+
 class TestMus:
     def setup_method(self):
         self.mus_func = mus
         self.naive_func = mus_naive
 
-    def test_circular(self, solver):
+    def _supported_solver(self, solver):
+        s = cp.SolverLookup.get(solver)
+        solve_arguments = inspect.signature(s.solve).parameters
+        return solve_arguments.get("assumptions") is not None
+
+    def _unsupported_reason(self, solver):
+        return f"Solver {solver} does not support assumption-based MUS"
+
+    def _test_mus(self, cons, hard, solver, verify_func, naive=False, **kwargs):
+        if solver == "hexaly":
+            pytest.skip("Hexaly is too slow on UNSAT problems.")
+        if naive:
+            mus_cons = self.naive_func(soft=cons, hard=hard, solver=solver, **kwargs)
+        else:
+            if not self._supported_solver(solver):
+                pytest.skip(self._unsupported_reason(solver))
+            mus_cons = self.mus_func(soft=cons, hard=hard, solver=solver, **kwargs)
+        assert verify_func(mus_cons)
+
+
+    # test cases
+
+    @mus_or_naive
+    def test_circular(self, solver, naive):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
         cons = [
-            x[0] > x[1], 
+            x[0] > x[1],
             x[1] > x[2],
             x[2] > x[0],
-    
+
             x[3] > x[0],
             (x[3] > x[1]).implies((x[3] > x[2]) & ((x[3] == 3) | (x[1] == x[2])))
         ]
 
-        assert set(self.mus_func(cons, hard=[], solver=solver)) == set(cons[:3])
-        assert set(self.naive_func(cons)) == set(cons[:3])
+        self._test_mus(cons, hard=[], solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == set(cons[:3]))
 
-    def test_bug_191(self, solver):
+    @mus_or_naive
+    def test_bug_191(self, solver, naive):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
@@ -34,12 +64,11 @@ class TestMus:
         hard = [~bv]
         soft = [bv]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver) # crashes
-        assert set(mus_cons) == set(soft)
-        mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
-        assert set(mus_naive_cons) == set(soft)
+        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == set(soft))
 
-    def test_bug_191_many_soft(self, solver):
+    @mus_or_naive
+    def test_bug_191_many_soft(self, solver, naive):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
         when the number of soft constraints > 1.
@@ -52,12 +81,11 @@ class TestMus:
             y == 4
         ]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver) # crashes
-        assert set(mus_cons) == set(soft)
-        mus_naive_cons = self.naive_func(soft=soft, hard=hard) # crashes
-        assert set(mus_naive_cons) == set(soft)
+        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == set(soft))
 
-    def test_wglobal(self, solver):
+    @mus_or_naive
+    def test_wglobal(self, solver, naive):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
 
@@ -66,7 +94,7 @@ class TestMus:
             x > 2,
             x < 1,
             y > 0,
-            y == 4, 
+            y == 4,
             (x + y > 0) | (y < 0),
             (y >= 0) | (x >= 0),
             (y < 0) | (x < 0),
@@ -75,26 +103,20 @@ class TestMus:
         ]
 
         # non-determinstic
-        #self.assertEqual(set(mus(cons)), set(cons[1:3]))
-        ms = self.mus_func(cons, solver=solver)
-        assert len(ms) < len(cons)
-        assert not cp.Model(ms).solve()
-        ms = self.naive_func(cons)
-        assert len(ms) < len(cons)
-        assert not cp.Model(ms).solve()
-        # self.assertEqual(set(self.naive_func(cons)), set(cons[:2]))
-        
-    def test_decomposed_global(self, solver):
+        self._test_mus(cons, hard=[], solver=solver, naive=naive,
+                       verify_func=lambda ms: len(ms) < len(cons) and not cp.Model(ms).solve())
+
+    @mus_or_naive
+    def test_decomposed_global(self, solver, naive):
         x = cp.intvar(1, 5, shape=3, name="x")
         soft = [x[0] == x[1], x[1] == x[2]]
         hard = [cp.AllDifferent(x)]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver)
-        assert len(set(mus_cons)) == 1
-        mus_naive_cons = self.naive_func(soft=soft, hard=hard)
-        assert len(set(mus_naive_cons)) == 1
+        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: len(set(ms)) == 1)
 
-    def test_cse_shared_subexpr(self, solver):
+    @mus_or_naive
+    def test_cse_shared_subexpr(self, solver, naive):
         """Example with CSE in the defining constraints.
 
         Reproducer from https://github.com/CPMpy/cpmpy/pull/986
@@ -107,103 +129,99 @@ class TestMus:
         ]
         hard = [x == 0]
 
-        mus_cons = self.mus_func(soft=soft, hard=hard, solver=solver)
-        assert set(mus_cons) == {soft[1]}
-        mus_naive_cons = self.naive_func(soft=soft, hard=hard)
-        assert set(mus_naive_cons) == {soft[1]}
+        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == {soft[1]})
+
 
 @pytest.mark.requires_solver("exact", "gurobi", "cplex")
 class TestNativeMus(TestMus):
     def setup_method(self):
-        solver = None
-        self.mus_func = lambda soft, hard=[], solver=solver: mus_native(soft, hard=hard, solver=solver)
+        self.mus_func = mus_native
         self.naive_func = mus_naive
 
+    def _supported_solver(self, solver):
+        # True only if the concrete solver class overrides mus_native
+        return "mus_native" in cp.SolverLookup.lookup(solver).__dict__
+
+    def _unsupported_reason(self, solver):
+        return f"Solver {solver} does not support native MUS"
 
 
-
-@pytest.mark.requires_solver("exact")
 class TestQuickXplain(TestMus):
     def setup_method(self):
         self.mus_func = quickxplain
         self.naive_func = quickxplain_naive
 
-    def test_prefered(self):
-
+    @mus_or_naive
+    def test_prefered(self, solver, naive):
         a,b,c,d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b,d]
         mus2 = [a,b,c]
 
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        subset = self.mus_func([a,b,c,d],hard)
-        assert set(subset) == {a,b,c}
-        subset2 = self.mus_func([d,c,b,a], hard)
-        assert set(subset2) == {b,d}
+        self._test_mus([a,b,c,d], hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == {a,b,c})
+        self._test_mus([d,c,b,a], hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == {b,d})
 
-        subset = self.naive_func([a, b, c, d], hard)
-        assert set(subset) == {a, b, c}
-        subset2 = self.naive_func([d, c, b, a], hard)
-        assert set(subset2) == {b, d}
 
-@pytest.mark.requires_solver("exact")
 class TestOptimalMUS(TestMus):
 
     def setup_method(self):
         self.mus_func = optimal_mus
         self.naive_func = optimal_mus_naive
 
-    def test_weighted(self):
+    @mus_or_naive
+    def test_weighted(self, solver, naive):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b, d]
         mus2 = [a, b, c]
 
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        subset = self.mus_func([a, b, c, d], hard, weights = [1,1,2,4])
-        assert set(subset) == {a, b, c}
-        subset2 = self.mus_func([a,b,c,d], hard, weights= [2,3,4,2])
-        assert set(subset2) == {b, d}
-        subset3 = self.mus_func([a,b,c,d], hard)
-        assert set(subset3) == {b,d}
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+                       weights=[1, 1, 2, 4], verify_func=lambda ms: set(ms) == {a, b, c})
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+                       weights=[2, 3, 4, 2], verify_func=lambda ms: set(ms) == {b, d})
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+                       verify_func=lambda ms: set(ms) == {b, d})
 
-        subset = self.naive_func([a, b, c, d], hard, weights=[1, 1, 2, 4])
-        assert set(subset) == {a, b, c}
-        subset2 = self.naive_func([a, b, c, d], hard, weights=[2, 3, 4, 2])
-        assert set(subset2) == {b, d}
-        subset3 = self.naive_func([a, b, c, d], hard)
-        assert set(subset3) == {b, d}
 
-@pytest.mark.requires_solver("exact")
 class TestOCUS(TestOptimalMUS):
 
     def setup_method(self):
         self.mus_func = ocus
         self.naive_func = ocus_naive
 
-    def test_constrained(self):
+    @mus_or_naive
+    def test_constrained(self, solver, naive):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b, d]
         mus2 = [a, b, c]
 
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        subset = self.mus_func([a, b, c, d], hard=hard, meta_constraint = ~b | d)
-        assert set(subset) == {b,d}
-        subset2 = self.mus_func([a,b,c,d], hard, meta_constraint = a & d)
-        assert set(subset2) == {a,b,d}# not subset-minimal
-        pytest.raises(OCUSException, lambda: self.mus_func([a,b,c,d], hard, meta_constraint = ~b)) # does not exist
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+                       meta_constraint=~b | d, verify_func=lambda ms: set(ms) == {b, d})
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+                       meta_constraint=a & d, verify_func=lambda ms: set(ms) == {a, b, d})  # not subset-minimal
 
+    @mus_or_naive
+    def test_no_such_mus(self, solver, naive):
+        a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
+
+        mus1 = [b, d]
+        mus2 = [a, b, c]
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        subset = self.naive_func([a, b, c, d], hard=hard, meta_constraint = ~b | d)
-        assert set(subset) == {b,d}
-        subset2 = self.naive_func([a,b,c,d], hard, meta_constraint = a & d)
-        assert set(subset2) == {a,b,d}# not subset-minimal
-        pytest.raises(OCUSException, lambda: self.naive_func([a,b,c,d], hard, meta_constraint = ~b)) # does not exist
+
+        mus_func = self.naive_func if naive else self.mus_func
+        if not naive and not self._supported_solver(solver):
+            pytest.skip(self._unsupported_reason(solver))
+        pytest.raises(OCUSException, lambda: mus_func([a, b, c, d], hard, meta_constraint=~b, solver=solver))
 
 
-@pytest.mark.requires_solver("exact")
-class TestMARCOMUS(TestMus):
+class TestMARCOMUS:
 
     def test_php(self):
         x = cp.boolvar(shape=(5,3), name="x")

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -6,9 +6,8 @@ from cpmpy.tools import mss_opt, marco, OCUSException
 from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, optimal_mus, optimal_mus_naive, mss, mcs, ocus, ocus_naive, mus_native
 
 
-# Each shared case runs twice: assumption-based (or native) MUS, and the naive variant.
-# Unsupported solvers skip only the non-naive case; naive still runs.
-mus_or_naive = pytest.mark.parametrize("naive", [False, True], ids=["mus", "naive"])
+# annotation to run both MUS and naive varaint for the test
+run_mus_and_naive = pytest.mark.parametrize("naive", [False, True], ids=["mus", "naive"])
 
 
 class TestMus:
@@ -38,7 +37,7 @@ class TestMus:
 
     # test cases
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_circular(self, solver, naive):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
@@ -54,7 +53,7 @@ class TestMus:
         self._test_mus(cons, hard=[], solver=solver, naive=naive,
                        verify_func=lambda ms: set(ms) == set(cons[:3]))
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_bug_191(self, solver, naive):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
@@ -67,7 +66,7 @@ class TestMus:
         self._test_mus(soft, hard=hard, solver=solver, naive=naive,
                        verify_func=lambda ms: set(ms) == set(soft))
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_bug_191_many_soft(self, solver, naive):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
@@ -84,7 +83,7 @@ class TestMus:
         self._test_mus(soft, hard=hard, solver=solver, naive=naive,
                        verify_func=lambda ms: set(ms) == set(soft))
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_wglobal(self, solver, naive):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
@@ -106,7 +105,7 @@ class TestMus:
         self._test_mus(cons, hard=[], solver=solver, naive=naive,
                        verify_func=lambda ms: len(ms) < len(cons) and not cp.Model(ms).solve())
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_decomposed_global(self, solver, naive):
         x = cp.intvar(1, 5, shape=3, name="x")
         soft = [x[0] == x[1], x[1] == x[2]]
@@ -115,7 +114,7 @@ class TestMus:
         self._test_mus(soft, hard=hard, solver=solver, naive=naive,
                        verify_func=lambda ms: len(set(ms)) == 1)
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_cse_shared_subexpr(self, solver, naive):
         """Example with CSE in the defining constraints.
 
@@ -152,7 +151,7 @@ class TestQuickXplain(TestMus):
         self.mus_func = quickxplain
         self.naive_func = quickxplain_naive
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_prefered(self, solver, naive):
         a,b,c,d = [cp.boolvar(name=n) for n in "abcd"]
 
@@ -172,7 +171,7 @@ class TestOptimalMUS(TestMus):
         self.mus_func = optimal_mus
         self.naive_func = optimal_mus_naive
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_weighted(self, solver, naive):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
@@ -194,7 +193,7 @@ class TestOCUS(TestOptimalMUS):
         self.mus_func = ocus
         self.naive_func = ocus_naive
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_constrained(self, solver, naive):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
@@ -207,7 +206,7 @@ class TestOCUS(TestOptimalMUS):
         self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
                        meta_constraint=a & d, verify_func=lambda ms: set(ms) == {a, b, d})  # not subset-minimal
 
-    @mus_or_naive
+    @run_mus_and_naive
     def test_no_such_mus(self, solver, naive):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 

--- a/tests/test_tools_mus.py
+++ b/tests/test_tools_mus.py
@@ -6,39 +6,54 @@ from cpmpy.tools import mss_opt, marco, OCUSException
 from cpmpy.tools.explain import mus, mus_naive, quickxplain, quickxplain_naive, optimal_mus, optimal_mus_naive, mss, mcs, ocus, ocus_naive, mus_native
 
 
-# annotation to run both MUS and naive varaint for the test
-run_mus_and_naive = pytest.mark.parametrize("naive", [False, True], ids=["mus", "naive"])
+ALL = [
+    "mus", "mus_naive", "mus_native",
+    "quickxplain", "quickxplain_naive",
+    "optimal_mus", "optimal_mus_naive",
+    "ocus", "ocus_naive",
+]
+
+MUS_FUNCS = dict(
+    mus = mus,
+    mus_naive = mus_naive,
+    mus_native = mus_native,
+    quickxplain = quickxplain,
+    quickxplain_naive = quickxplain_naive,
+    optimal_mus = optimal_mus,
+    optimal_mus_naive = optimal_mus_naive,
+    ocus = ocus,
+    ocus_naive = ocus_naive,
+)
 
 
-class TestMus:
-    def setup_method(self):
-        self.mus_func = mus
-        self.naive_func = mus_naive
 
-    def _supported_solver(self, solver):
+class TestMUS:
+
+    def _supported_solver(self, solver, variant):
+        if variant.endswith("_naive"):
+            return True
+        if variant == "mus_native":
+            return "mus_native" in cp.SolverLookup.lookup(solver).__dict__
+        # assumption-based algorithms
         s = cp.SolverLookup.get(solver)
-        solve_arguments = inspect.signature(s.solve).parameters
-        return solve_arguments.get("assumptions") is not None
+        return inspect.signature(s.solve).parameters.get("assumptions") is not None
 
-    def _unsupported_reason(self, solver):
+    def _unsupported_reason(self, solver, variant):
+        if variant == "mus_native":
+            return f"Solver {solver} does not support native MUS"
         return f"Solver {solver} does not support assumption-based MUS"
 
-    def _test_mus(self, cons, hard, solver, verify_func, naive=False, **kwargs):
+    def _test_mus(self, cons, hard, solver, verify_func, variant, **kwargs):
         if solver == "hexaly":
             pytest.skip("Hexaly is too slow on UNSAT problems.")
-        if naive:
-            mus_cons = self.naive_func(soft=cons, hard=hard, solver=solver, **kwargs)
-        else:
-            if not self._supported_solver(solver):
-                pytest.skip(self._unsupported_reason(solver))
-            mus_cons = self.mus_func(soft=cons, hard=hard, solver=solver, **kwargs)
+        if not self._supported_solver(solver, variant):
+            pytest.skip(self._unsupported_reason(solver, variant))
+        mus_cons = MUS_FUNCS[variant](soft=cons, hard=hard, solver=solver, **kwargs)
         assert verify_func(mus_cons)
 
-
-    # test cases
-
-    @run_mus_and_naive
-    def test_circular(self, solver, naive):
+    # shared test cases
+    @pytest.mark.parametrize("variant", ALL)
+    def test_circular(self, solver, variant):
         x = cp.intvar(0, 3, shape=4, name="x")
         # circular "bigger then", UNSAT
         cons = [
@@ -50,11 +65,11 @@ class TestMus:
             (x[3] > x[1]).implies((x[3] > x[2]) & ((x[3] == 3) | (x[1] == x[2])))
         ]
 
-        self._test_mus(cons, hard=[], solver=solver, naive=naive,
+        self._test_mus(cons, hard=[], solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == set(cons[:3]))
 
-    @run_mus_and_naive
-    def test_bug_191(self, solver, naive):
+    @pytest.mark.parametrize("variant", ALL)
+    def test_bug_191(self, solver, variant):
         """
         Original Bug request: https://github.com/CPMpy/cpmpy/issues/191
         When assum is a single boolvar and candidates is a list (of length 1), it fails.
@@ -63,11 +78,11 @@ class TestMus:
         hard = [~bv]
         soft = [bv]
 
-        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+        self._test_mus(soft, hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == set(soft))
 
-    @run_mus_and_naive
-    def test_bug_191_many_soft(self, solver, naive):
+    @pytest.mark.parametrize("variant", ALL)
+    def test_bug_191_many_soft(self, solver, variant):
         """
         Checking whether bugfix 191  doesn't break anything in the MUS tool chain,
         when the number of soft constraints > 1.
@@ -80,11 +95,11 @@ class TestMus:
             y == 4
         ]
 
-        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+        self._test_mus(soft, hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == set(soft))
 
-    @run_mus_and_naive
-    def test_wglobal(self, solver, naive):
+    @pytest.mark.parametrize("variant", ALL)
+    def test_wglobal(self, solver, variant):
         x = cp.intvar(-9, 9, name="x")
         y = cp.intvar(-9, 9, name="y")
 
@@ -102,20 +117,20 @@ class TestMus:
         ]
 
         # non-determinstic
-        self._test_mus(cons, hard=[], solver=solver, naive=naive,
+        self._test_mus(cons, hard=[], solver=solver, variant=variant,
                        verify_func=lambda ms: len(ms) < len(cons) and not cp.Model(ms).solve())
 
-    @run_mus_and_naive
-    def test_decomposed_global(self, solver, naive):
+    @pytest.mark.parametrize("variant", ALL)
+    def test_decomposed_global(self, solver, variant):
         x = cp.intvar(1, 5, shape=3, name="x")
         soft = [x[0] == x[1], x[1] == x[2]]
         hard = [cp.AllDifferent(x)]
 
-        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+        self._test_mus(soft, hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: len(set(ms)) == 1)
 
-    @run_mus_and_naive
-    def test_cse_shared_subexpr(self, solver, naive):
+    @pytest.mark.parametrize("variant", ALL)
+    def test_cse_shared_subexpr(self, solver, variant):
         """Example with CSE in the defining constraints.
 
         Reproducer from https://github.com/CPMpy/cpmpy/pull/986
@@ -128,96 +143,67 @@ class TestMus:
         ]
         hard = [x == 0]
 
-        self._test_mus(soft, hard=hard, solver=solver, naive=naive,
+        self._test_mus(soft, hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == {soft[1]})
 
-
-@pytest.mark.requires_solver("exact", "gurobi", "cplex")
-class TestNativeMus(TestMus):
-    def setup_method(self):
-        self.mus_func = mus_native
-        self.naive_func = mus_naive
-
-    def _supported_solver(self, solver):
-        # True only if the concrete solver class overrides mus_native
-        return "mus_native" in cp.SolverLookup.lookup(solver).__dict__
-
-    def _unsupported_reason(self, solver):
-        return f"Solver {solver} does not support native MUS"
-
-
-class TestQuickXplain(TestMus):
-    def setup_method(self):
-        self.mus_func = quickxplain
-        self.naive_func = quickxplain_naive
-
-    @run_mus_and_naive
-    def test_prefered(self, solver, naive):
+    # quickxplain-specific
+    @pytest.mark.parametrize("variant", ["quickxplain", "quickxplain_naive"])
+    def test_prefered(self, solver, variant):
         a,b,c,d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b,d]
         mus2 = [a,b,c]
 
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        self._test_mus([a,b,c,d], hard=hard, solver=solver, naive=naive,
+        self._test_mus([a,b,c,d], hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == {a,b,c})
-        self._test_mus([d,c,b,a], hard=hard, solver=solver, naive=naive,
+        self._test_mus([d,c,b,a], hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == {b,d})
 
-
-class TestOptimalMUS(TestMus):
-
-    def setup_method(self):
-        self.mus_func = optimal_mus
-        self.naive_func = optimal_mus_naive
-
-    @run_mus_and_naive
-    def test_weighted(self, solver, naive):
+    # optimal MUS-specific
+    @pytest.mark.parametrize("variant", ["optimal_mus", "optimal_mus_naive"])
+    def test_weighted(self, solver, variant):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b, d]
         mus2 = [a, b, c]
 
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, variant=variant,
                        weights=[1, 1, 2, 4], verify_func=lambda ms: set(ms) == {a, b, c})
-        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, variant=variant,
                        weights=[2, 3, 4, 2], verify_func=lambda ms: set(ms) == {b, d})
-        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, variant=variant,
                        verify_func=lambda ms: set(ms) == {b, d})
 
-
-class TestOCUS(TestOptimalMUS):
-
-    def setup_method(self):
-        self.mus_func = ocus
-        self.naive_func = ocus_naive
-
-    @run_mus_and_naive
-    def test_constrained(self, solver, naive):
+    # OCUS-specific
+    @pytest.mark.parametrize("variant", ["ocus", "ocus_naive"])
+    def test_constrained(self, solver, variant):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b, d]
         mus2 = [a, b, c]
 
         hard = [~cp.all(mus1), ~cp.all(mus2)]
-        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, variant=variant,
                        meta_constraint=~b | d, verify_func=lambda ms: set(ms) == {b, d})
-        self._test_mus([a, b, c, d], hard=hard, solver=solver, naive=naive,
+        self._test_mus([a, b, c, d], hard=hard, solver=solver, variant=variant,
                        meta_constraint=a & d, verify_func=lambda ms: set(ms) == {a, b, d})  # not subset-minimal
 
-    @run_mus_and_naive
-    def test_no_such_mus(self, solver, naive):
+    @pytest.mark.parametrize("variant", ["ocus", "ocus_naive"])
+    def test_no_such_mus(self, solver, variant):
         a, b, c, d = [cp.boolvar(name=n) for n in "abcd"]
 
         mus1 = [b, d]
         mus2 = [a, b, c]
         hard = [~cp.all(mus1), ~cp.all(mus2)]
 
-        mus_func = self.naive_func if naive else self.mus_func
-        if not naive and not self._supported_solver(solver):
-            pytest.skip(self._unsupported_reason(solver))
-        pytest.raises(OCUSException, lambda: mus_func([a, b, c, d], hard, meta_constraint=~b, solver=solver))
+        if solver == "hexaly":
+            pytest.skip("Hexaly is too slow on UNSAT problems.")
+        if not self._supported_solver(solver, variant):
+            pytest.skip(self._unsupported_reason(solver, variant))
+        pytest.raises(OCUSException, lambda: MUS_FUNCS[variant](
+            [a, b, c, d], hard, meta_constraint=~b, solver=solver))
 
 
 class TestMARCOMUS:


### PR DESCRIPTION
Now runs each mus test really on every solver:
- Previously it required exact to be installed for some reason
- For solvers that do not support assumptions, there is an explicit pytest.skip now
- Native MUS solvers are still parametrized manually (we could change that but will result in lots of skips)

