### PR TITLE
Fix typos in docstrings, comments, and error messages

### DIFF
--- a/cpmpy/__init__.py
+++ b/cpmpy/__init__.py
@@ -9,7 +9,7 @@ Source code and bug reports at https://github.com/CPMpy/cpmpy
 The package consists of 4 modules:
 - `model`: a generic container for expressions (constraints and an objective), it can also search for an available solver and call it
 - `expressions`: all forms of expression objects that allow you to specify constraints and objectives over variables
-- `solvers`: CPMpy classes that translate a model into approriate calls of a solver's API
+- `solvers`: CPMpy classes that translate a model into appropriate calls of a solver's API
 - `transformations`: common methods for transforming expressions into other expressions, used by `solvers` modules to simplify/rewrite expressions
 """
 # Tias Guns, 2019-2026

--- a/cpmpy/expressions/__init__.py
+++ b/cpmpy/expressions/__init__.py
@@ -18,7 +18,7 @@ List of submodules
 """
 
 # we only import methods/classes that are used for modelling
-# others need to be imported by the developer explicitely
+# others need to be imported by the developer explicitly
 from .variables import boolvar, intvar, cpm_array
 from .globalconstraints import (
     AllDifferent,

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -656,7 +656,7 @@ class BoolVal(Expression):
 
         Args:
             other (BoolExprLike): the right-hand-side of the implication
-            simplify (bool): simplify the implication, even if it means `other` dissappears from user-view
+            simplify (bool): simplify the implication, even if it means `other` disappears from user-view
 
         Simplification rule:
             - BoolVal(False) -> other :: BoolVal(True)

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -421,8 +421,8 @@ class Circuit(GlobalConstraint):
 
     def decompose(self) -> tuple[list[Expression], list[Expression]]:
         """
-            Decomposition of the Circuit global constraint using auxiliary variables to reprsent the order in which we visit all the nodes.
-            Auxiliary variables are defined in the defining part of the decomposition, which is alwasy enforced top-level.
+            Decomposition of the Circuit global constraint using auxiliary variables to represent the order in which we visit all the nodes.
+            Auxiliary variables are defined in the defining part of the decomposition, which is always enforced top-level.
 
         Returns:
             tuple[list[Expression], list[Expression]]: A tuple containing the constraints representing the constraint value and the defining constraints
@@ -1751,7 +1751,7 @@ class Cumulative(GlobalConstraint):
 class CumulativeOptional(GlobalConstraint):
     """
         Generalization of the Cumulative constraint which allows for optional tasks.
-        A task is only scheduled if the corresponing is_present variable is set to True.
+        A task is only scheduled if the corresponding is_present variable is set to True.
 
         If the task is present, the constraint enforces that:
         - duration >= 0
@@ -2035,7 +2035,7 @@ class NoOverlap(GlobalConstraint):
 class NoOverlapOptional(GlobalConstraint):
     """
         Generalization of the NoOverlap constraint which allows for optional tasks.
-        A task is only scheduled if the corresponing is_present variable is set to True.
+        A task is only scheduled if the corresponding is_present variable is set to True.
 
         The constraint enforces that all present tasks are scheduled without overlapping, and for each present task, the constraint enforces that:
         - duration >= 0

--- a/cpmpy/expressions/globalfunctions.py
+++ b/cpmpy/expressions/globalfunctions.py
@@ -1051,7 +1051,7 @@ class Count(GlobalFunction):
         """
         Arguments:
             arr (ListLike[ExprLike]): List of expressions or constants to count in
-            val (ExprLike): 'Value' to count occurences of (can also be an expression)
+            val (ExprLike): 'Value' to count occurrences of (can also be an expression)
         """
         if not is_any_list(arr):
             raise TypeError(f"Count(arr, val) takes an array of expressions as first argument, not: {arr}")

--- a/cpmpy/expressions/variables.py
+++ b/cpmpy/expressions/variables.py
@@ -148,7 +148,7 @@ def boolvar(shape: int|np.integer|tuple[int|np.integer, ...] = 1,
     data = np.array([_BoolVarImpl(name=n) for n in names])
     # insert into custom ndarray
     r = NDVarArray(shape, dtype=object, buffer=data)
-    r._has_subexpr = False # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
+    r._has_subexpr = False # A bit ugly (access to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
     return r
 
 
@@ -234,7 +234,7 @@ def intvar(lb: int, ub: int, shape: int|np.integer|tuple[int|np.integer, ...] = 
     data = np.array([_IntVarImpl(lb, ub, name=n) for n in names]) # repeat new instances
     # insert into custom ndarray
     r = NDVarArray(shape, dtype=object, buffer=data)
-    r._has_subexpr = False # A bit ugly (acces to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
+    r._has_subexpr = False # A bit ugly (access to private field) but otherwise np.ndarray constructor complains if we pass it as an argument to NDVarArray
     return r
 
 
@@ -635,7 +635,7 @@ class NDVarArray(np.ndarray):
         return cpm_array(np.apply_along_axis(cp.all, axis=axis, arr=self))
 
     def get_bounds(self) -> tuple[np.ndarray, np.ndarray]:
-        if self.size == 0:  # believe it or not, this does happen... e.g. in test_int2bool and an exmaple
+        if self.size == 0:  # believe it or not, this does happen... e.g. in test_int2bool and an example
             z = np.empty(self.shape, dtype=np.int64)
             return z, z
 

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -11,7 +11,7 @@
     to it. Processing only starts when :meth:`solve() <cpmpy.model.Model.solve>` is called, and this does not modify
     the constraints or objective stored in the model.
 
-    A model can be solved multiple times, and constraints can be added inbetween solve calls.
+    A model can be solved multiple times, and constraints can be added in between solve calls.
     Note that constraints are added using :meth:`.add(...) <cpmpy.model.Model.add>` or using the ``+=`` operator (implemented by :meth:`__add__()`).
 
     See the full list of functions below.
@@ -322,7 +322,7 @@ def _update_variable_counters(model: Model):
                 pass
 
     if (_BoolVarImpl.counter > 0 and bv_counter > 0) or (_IntVarImpl.counter > 0 and iv_counter > 0):
-        warnings.warn(f"Model contains auxiliary {_IV_PREFIX}*/{_BV_PREFIX}* variables with the same name as already created. Only add expressions created AFTER loadig this model to avoid issues with duplicate variables.")
+        warnings.warn(f"Model contains auxiliary {_IV_PREFIX}*/{_BV_PREFIX}* variables with the same name as already created. Only add expressions created AFTER loading this model to avoid issues with duplicate variables.")
     # update counters for future variables
     _BoolVarImpl.counter = max(_BoolVarImpl.counter, bv_counter)
     _IntVarImpl.counter = max(_IntVarImpl.counter, iv_counter)

--- a/cpmpy/solvers/TEMPLATE.py
+++ b/cpmpy/solvers/TEMPLATE.py
@@ -408,7 +408,7 @@ class CPM_template(SolverInterface):
         # apply transformations
         # XXX chose the transformations your solver needs, see cpmpy/transformations/
         cpm_cons = toplevel_list(cpm_expr)
-        cpm_cons = no_partial_functions(cpm_cons) # if the solver requires supported partial function globals to be safened, use the follwing instead:
+        cpm_cons = no_partial_functions(cpm_cons) # if the solver requires supported partial function globals to be safened, use the following instead:
         # cpm_cons = no_partial_functions(cpm_cons, safen_toplevel=frozenset({"element", "nd_element", "div", "mod"}))        
         cpm_cons = push_down_negation(cpm_cons)
         cpm_cons = decompose_in_tree(cpm_cons,

--- a/cpmpy/solvers/__init__.py
+++ b/cpmpy/solvers/__init__.py
@@ -8,7 +8,7 @@ different assumption variables toggled on/off, and the solver will reuse informa
 See :ref:`supported-solvers` for the list of solvers and their capabilities.
 
 To benefit from incrementality, you have to instantiate the solver object and reuse it, rather than working on a Model object.
-Solvers must be instantiated throught the static :class:`cp.SolverLookup <cpmpy.solvers.utils.SolverLookup>` class:
+Solvers must be instantiated through the static :class:`cp.SolverLookup <cpmpy.solvers.utils.SolverLookup>` class:
 
 - :meth:`cp.SolverLookup.solvernames() <cpmpy.solvers.utils.SolverLookup.solvernames>` -- List all installed solvers (including subsolvers).
 - :meth:`cp.SolverLookup.get(solvername, model=None) <cpmpy.solvers.utils.SolverLookup.get>` -- Initialize a specific solver.

--- a/cpmpy/solvers/cplex.py
+++ b/cpmpy/solvers/cplex.py
@@ -149,7 +149,7 @@ class CPM_cplex(SolverInterface):
         if not self.installed():
             raise ModuleNotFoundError("CPM_cplex: Install the python package 'cpmpy[cplex]' to use this solver interface.")
         elif not self.license_ok():
-            raise ModuleNotFoundError("CPM_cplex: No license found or a problem occured during license check. Make sure your installed the CPLEX Optimization Studio and that you have an active license.")
+            raise ModuleNotFoundError("CPM_cplex: No license found or a problem occurred during license check. Make sure your installed the CPLEX Optimization Studio and that you have an active license.")
 
         from docplex.mp.model import Model
         self.cplex_model = Model()

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -141,7 +141,7 @@ class CPM_gurobi(SolverInterface):
         if not self.installed():
             raise ModuleNotFoundError("CPM_gurobi: Install the python package 'cpmpy[gurobi]' to use this solver interface.")
         elif not self.license_ok():
-            raise ModuleNotFoundError("CPM_gurobi: No license found or a problem occured during license check. Make sure your license is activated!")
+            raise ModuleNotFoundError("CPM_gurobi: No license found or a problem occurred during license check. Make sure your license is activated!")
         import gurobipy as gp
 
         # TODO: subsolver could be a GRB_ENV if a user would want to hand one over
@@ -620,7 +620,7 @@ class CPM_gurobi(SolverInterface):
             # use ._add_transformed instead of .add because we need the Gurobi constraint object later
             grb_hard_cons.append(s._add_transformed(cpm_con))
 
-        # update model so we can access constraint attribtutes
+        # update model so we can access constraint attributes
         # model updates can be expensive, so we do this only once!
         s.native_model.update()
         for grb_con in grb_hard_cons:
@@ -756,7 +756,7 @@ class CPM_gurobi(SolverInterface):
                     self.cpm_status.exitstatus = ExitStatus.FEASIBLE
                 else: # found all solutions
                     self.cpm_status.exitstatus = ExitStatus.OPTIMAL
-        # if unsat or timout with no solution, .solve() will have already set the state accordingly (so nothing to update)
+        # if unsat or timeout with no solution, .solve() will have already set the state accordingly (so nothing to update)
 
         return opt_sol_count
 

--- a/cpmpy/solvers/gurobi.py
+++ b/cpmpy/solvers/gurobi.py
@@ -590,7 +590,7 @@ class CPM_gurobi(SolverInterface):
         grb_soft_cons = []
 
         for soft_con in soft_cons:
-            # transform each constraint seperately, can map to multiple Gurobi-level constraints
+            # transform each constraint separately, can map to multiple Gurobi-level constraints
             soft_con_tf = s.transform(soft_con)
 
             if len(soft_con_tf) == 0:

--- a/cpmpy/solvers/hexaly.py
+++ b/cpmpy/solvers/hexaly.py
@@ -130,7 +130,7 @@ class CPM_hexaly(SolverInterface):
         if not self.installed():
             raise ModuleNotFoundError("CPM_hexaly: Install the python package 'cpmpy[hexaly]' to use this solver interface.") 
         elif not self.license_ok():
-            raise ModuleNotFoundError("CPM_hexaly: No license found or a problem occured during license check. Make sure your license is activated!")
+            raise ModuleNotFoundError("CPM_hexaly: No license found or a problem occurred during license check. Make sure your license is activated!")
 
         from hexaly.optimizer import HexalyOptimizer
 
@@ -169,7 +169,7 @@ class CPM_hexaly(SolverInterface):
             - iteration_limit: max number of iterations
             - verbosity: verbosity level
 
-            full list of parameters availble at:
+            full list of parameters available at:
             https://www.hexaly.com/docs/last/pythonapi/optimizer/hxparam.html
         """
         from hexaly.optimizer import HxObjectiveDirection

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -349,7 +349,7 @@ class CPM_minizinc(SolverInterface):
             =======================  ===========             
             
             
-            I am not sure where solver-specific arguments are documented, but the docs say that command line arguments can be passed by ommitting the '-' (e.g. 'f' instead of '-f')?
+            I am not sure where solver-specific arguments are documented, but the docs say that command line arguments can be passed by omitting the '-' (e.g. 'f' instead of '-f')?
             
             The minizinc solver parameters are partly defined in its API:
             https://minizinc-python.readthedocs.io/en/latest/api.html#minizinc.instance.Instance.solve

--- a/cpmpy/solvers/ortools.py
+++ b/cpmpy/solvers/ortools.py
@@ -383,7 +383,7 @@ class CPM_ortools(SolverInterface):
             self.user_vars.update(vs)  # save user variables
             ort_obj = ort.LinearExpr.weighted_sum(self.solver_vars(vs), ws) + const
         else:
-            # save user varables
+            # save user variables
             get_variables(expr, self.user_vars)
 
             # transform objective
@@ -696,7 +696,7 @@ class CPM_ortools(SolverInterface):
 
             elif cpm_expr.name == "circuit":
                 # ortools has a constraint over the arcs, so we need to create these
-                # when using an objective over arcs, using these vars direclty is recommended
+                # when using an objective over arcs, using these vars directly is recommended
                 # (see PCTSP-path model in the future)
                 x = cpm_expr.args
                 N = len(x)

--- a/cpmpy/solvers/pindakaas.py
+++ b/cpmpy/solvers/pindakaas.py
@@ -189,7 +189,7 @@ class CPM_pindakaas(SolverInterface):
             elif result.status == pdk.solver.Status.UNKNOWN:
                 self.cpm_status.exitstatus = ExitStatus.UNKNOWN
             else:
-                raise NotImplementedError(f"Pindakaas returned an unkown type of result status: {result}")
+                raise NotImplementedError(f"Pindakaas returned an unknown type of result status: {result}")
 
             # True/False depending on self.cpm_status
             has_sol = self._solve_return(self.cpm_status)

--- a/cpmpy/solvers/pysat.py
+++ b/cpmpy/solvers/pysat.py
@@ -292,7 +292,7 @@ class CPM_pysat(SolverInterface):
             has_sol = self.pysat_solver.solve_limited(assumptions=pysat_assum_vars, expect_interrupt=True)
             # ensure timer is stopped if early stopping
             t.cancel()
-            ## this part cannot be added to timer otherwhise it "interrups" the timeout timer too soon
+            ## this part cannot be added to timer otherwise it "interrupts" the timeout timer too soon
             self.pysat_solver.clear_interrupt()
         else:
             has_sol = self.pysat_solver.solve(assumptions=pysat_assum_vars)

--- a/cpmpy/solvers/solver_interface.py
+++ b/cpmpy/solvers/solver_interface.py
@@ -65,7 +65,7 @@ class SolverInterface(object):
 
     def __init__(self, name="dummy", cpm_model=None, subsolver=None):
         """
-            Initalize solver interface
+            Initialize solver interface
 
             - name: str: name of this solver
             - subsolver: string: not used/allowed here
@@ -412,7 +412,7 @@ class ExitStatus(Enum):
 
         `UNSATISFIABLE`: No satisfying solution exists
 
-        `ERROR`: Some error occured (solver should have thrown Exception)
+        `ERROR`: Some error occurred (solver should have thrown Exception)
 
         `UNKNOWN`: Outcome unknown, for example when timeout is reached
     """

--- a/cpmpy/tools/datasets/core.py
+++ b/cpmpy/tools/datasets/core.py
@@ -427,7 +427,7 @@ class FileDataset(Dataset):
     def open(cls, instance: os.PathLike) -> io.TextIOBase:
         """
         How an instance file from the dataset should be opened.
-        Especially usefull when files come compressed and won't work with
+        Especially useful when files come compressed and won't work with
         Python standard library's 'open', e.g. '.xz', '.lzma'.
 
         Arguments:

--- a/cpmpy/tools/explain/mcs.py
+++ b/cpmpy/tools/explain/mcs.py
@@ -5,7 +5,7 @@ from cpmpy.transformations.normalize import toplevel_list
 def mcs(soft, hard=[], solver="ortools"):
     """
         Compute Minimal Correction Subset of unsatisfiable model.
-        Removing these contraints will result in a satisfiable model.
+        Removing these constraints will result in a satisfiable model.
         Computes a subset of constraints which minimizes the total number of constraints to be removed
 
         :param: soft: list of soft constraints that may be part of the minimal correction subset
@@ -34,7 +34,7 @@ def mcs_opt(soft, hard, weights=1, solver="ortools"):
 def mcs_grow(soft, hard, solver="ortools"):
     """
         Computes correction subset without requirement of optimization support
-        Relies on assumptions so incremental solvers are adviced.
+        Relies on assumptions so incremental solvers are advised.
         Can be faster in some cases compared to optimal correction subset
 
         :param: soft: list of soft constraints that may be part of the minimal correction subset
@@ -48,8 +48,8 @@ def mcs_grow(soft, hard, solver="ortools"):
 
 def mcs_grow_naive(soft, hard, solver="ortools"):
     """
-        Compute Minimal Correction Subset of unsatsifiable model.
-        Computes a subset-minimal set of constraints by greedily removing contraints.
+        Compute Minimal Correction Subset of unsatisfiable model.
+        Computes a subset-minimal set of constraints by greedily removing constraints.
         Can be used when solver does not support assumptions
         No guarantees on optimality, but can be faster in some cases
 

--- a/cpmpy/tools/explain/mss.py
+++ b/cpmpy/tools/explain/mss.py
@@ -38,9 +38,9 @@ def mss_opt(soft, hard=[], weights=1, solver="ortools"):
 
 def mss_grow(soft, hard=[], solver="ortools"):
     """
-        Compute Maximal Satisfiable Subset of unsatsifiable model.
-        Computes a subset-maximal set of constraints by greedily adding contraints.
-        Relies on solving under assumptions, so using an incremental solver is adviced
+        Compute Maximal Satisfiable Subset of unsatisfiable model.
+        Computes a subset-maximal set of constraints by greedily adding constraints.
+        Relies on solving under assumptions, so using an incremental solver is advised
         No guarantees on optimality, but can be faster in some cases
 
         :param: soft: list of soft constraints to find a maximal satisfiable subset of
@@ -81,8 +81,8 @@ def mss_grow(soft, hard=[], solver="ortools"):
 
 def mss_grow_naive(soft, hard=[], solver="ortools"):
     """
-        Compute Maximal Satisfiable Subset of unsatsifiable model.
-        Computes a subset-maximal set of constraints by greedily adding contraints.
+        Compute Maximal Satisfiable Subset of unsatisfiable model.
+        Computes a subset-maximal set of constraints by greedily adding constraints.
         Can be used when solver does not support assumptions
         No guarantees on optimality, but can be faster in some cases
 

--- a/cpmpy/tools/explain/mus.py
+++ b/cpmpy/tools/explain/mus.py
@@ -28,10 +28,10 @@ def mus(soft, hard=[], solver="ortools"):
 
         Each constraint is an arbitrary CPMpy expression, so it can
         also be sublists of constraints (e.g. constraint groups),
-        contain aribtrary nested expressions, global constraints, etc.
+        contain arbitrary nested expressions, global constraints, etc.
 
         Will extract an unsat core and then shrink the core further
-        by repeatedly ommitting one assumption variable.
+        by repeatedly omitting one assumption variable.
 
         :param: soft: soft constraints, list of expressions
         :param: hard: hard constraints, optional, list of expressions
@@ -138,7 +138,7 @@ def ocus(soft, hard=[], weights=None, meta_constraint=True, solver="ortools", hs
         Find an optimal and constrained MUS according to a linear objective function.
         By not providing a weightvector, this function will return the smallest mus.
         Works by iteratively generating correction subsets and computing optimal hitting sets to those enumerated sets.
-        For better performance of the algorithm, use an incemental solver to compute the hitting sets such as Gurobi.
+        For better performance of the algorithm, use an incremental solver to compute the hitting sets such as Gurobi.
 
         Assumption-based implementation for solvers that support s.solve(assumptions=...)
         More naive version available as `optimal_mus_naive` to use with other solvers.

--- a/cpmpy/tools/io/scip_formats.py
+++ b/cpmpy/tools/io/scip_formats.py
@@ -132,7 +132,7 @@ def load_scip_format(instance: Union[str, os.PathLike, TextIO], open:Callable = 
                         warnings.warn(f"Continuous variable {name} has non-integer bounds {var.getLbOriginal()} - {var.getUbOriginal()}. CPMpy will assume it is integer.")
                     var_map[name] = cp.intvar(lb, ub, name=name)
                 else:
-                    raise ValueError(f"CPMpy does not support continious variables: {name}")
+                    raise ValueError(f"CPMpy does not support continuous variables: {name}")
             else:
                 raise ValueError(f"Unsupported variable type: {vtype}")
         

--- a/cpmpy/tools/io/wcnf.py
+++ b/cpmpy/tools/io/wcnf.py
@@ -44,7 +44,7 @@ def _get_var(i: int, vars_dict: dict[int, _BoolVarImpl]) -> _BoolVarImpl:
         cp.BoolVar: The CPMpy boolean decision variable matching to index `i`.
     """
     if i not in vars_dict:
-        vars_dict[i] = cp.boolvar(name=f"x{i}") # <- be carefull that name doesn't clash with generated variables during transformations / user variables
+        vars_dict[i] = cp.boolvar(name=f"x{i}") # <- be careful that name doesn't clash with generated variables during transformations / user variables
     return vars_dict[i]
 
 def load_wcnf(wcnf: Union[str, os.PathLike, TextIO], open:Callable=builtins.open) -> cp.Model:

--- a/cpmpy/tools/mus.py
+++ b/cpmpy/tools/mus.py
@@ -1,3 +1,3 @@
-# for backwards compatibilty reasons, this file is kept
+# for backwards compatibility reasons, this file is kept
 
 from .explain.mus import *

--- a/cpmpy/tools/xcsp3/analyze.py
+++ b/cpmpy/tools/xcsp3/analyze.py
@@ -102,7 +102,7 @@ def xcsp3_plot(df, time_limit=None):
 def get_cost(row):
     """
     Get the achieved objective value from the provided row.
-    If intermediate solutions are available, get the best found (not neccesarily proven optimal).
+    If intermediate solutions are available, get the best found (not necessarily proven optimal).
     """
     intermediate = row['intermediate']
 

--- a/cpmpy/tools/xcsp3/globals.py
+++ b/cpmpy/tools/xcsp3/globals.py
@@ -632,7 +632,7 @@ class DynamicCumulative(GlobalConstraint):
 
         # start, dur, end are np arrays
         start, dur, end, demand, capacity = arg_vals
-        # start and end seperated by duration
+        # start and end separated by duration
         if not (start + dur == end).all():
             return False
 

--- a/cpmpy/transformations/decompose_global.py
+++ b/cpmpy/transformations/decompose_global.py
@@ -5,10 +5,10 @@ This transformation is necessary for all non-CP solvers, and also used to decomp
 global constraints and global functions not implemented in a CP-solver.
 
 While a solver may natively support a global constraint, it may not support it natively in a reified context.
-In this case, we will als also decompose the global constraint.
+In this case, we will also decompose the global constraint.
 
 For numerical global functions, we will only decompose them if they are not supported in non-reified context.
-Even if the solver does not explicitely support them in a subexpression,
+Even if the solver does not explicitly support them in a subexpression,
 we can rewrite them using func:`cpmpy.transformations.reification.reify_rewrite` to a non-reified version when the function is total.
 E.g., bv <-> max(a,b,c) >= 4 can be rewritten as [bv <-> IV0 >= 4, IV0 == max(a,b,c)]
 

--- a/cpmpy/transformations/negation.py
+++ b/cpmpy/transformations/negation.py
@@ -253,7 +253,7 @@ def recurse_negation(expr: Expression|bool|np.bool_) -> Expression:
 
         elif expr.name == "and":
             # ~(x & y) :: ~x | ~y -- negate all arguments
-            # copy experession to avoid init checks and keep _has_subexpr
+            # copy expression to avoid init checks and keep _has_subexpr
             new_op = copy.copy(expr)
             new_op.name = "or"
             new_op.update_args([recurse_negation(a) for a in expr.args])
@@ -261,7 +261,7 @@ def recurse_negation(expr: Expression|bool|np.bool_) -> Expression:
         
         elif expr.name == "or":
             # ~(x | y) :: ~x & ~y -- negate all arguments
-            # copy experession to avoid init checks and keep _has_subexpr
+            # copy expression to avoid init checks and keep _has_subexpr
             new_op = copy.copy(expr)
             new_op.name = "and"
             new_op.update_args([recurse_negation(a) for a in expr.args])

--- a/cpmpy/transformations/normalize.py
+++ b/cpmpy/transformations/normalize.py
@@ -230,7 +230,7 @@ def _simplify_boolean_expr(expr: Expression, num_context=False) -> tuple[bool, E
     elif isinstance(expr, Comparison):
         changed, (lhs, rhs) = _simplify_boolean_args(expr.args, num_context=True)
         name = expr.name
-        if is_num(lhs) and is_boolexpr(rhs):  # flip arguments of comparison to reduct nb of cases
+        if is_num(lhs) and is_boolexpr(rhs):  # flip arguments of comparison to reduce nb of cases
             if name == "<":    
                 name = ">"
             elif name == ">":  

--- a/cpmpy/transformations/to_cnf.py
+++ b/cpmpy/transformations/to_cnf.py
@@ -22,7 +22,7 @@ def to_cnf(constraints, csemap=None, ivarmap=None, encoding="auto"):
     Arguments:
         constraints:    list[Expression] or Operator
         csemap:         `dict()` used for CSE
-        ivarmap:        `dict()` used to map integer variables to their encoding (usefull for finding the values of the now-encoded integer variables)
+        ivarmap:        `dict()` used to map integer variables to their encoding (useful for finding the values of the now-encoded integer variables)
         encoding:       the encoding used for `int2bool`, choose from ("auto", "direct", "order", or "binary")
     Returns:
         Equivalent CPMpy constraints in CNF, and the updated `ivarmap`


### PR DESCRIPTION
## Summary
- Fixed a handful of typos found by manual review and a `codespell` scan of the `cpmpy/` package (docstrings, comments, and error messages).
- Purely textual changes — no logic touched.

## Test plan
- [x] `import cpmpy` succeeds
- [x] All edited files still parse (`ast.parse`)