### PR TITLE
Description context manager 

### DIFF
--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -792,7 +792,7 @@ class Operator(Expression):
         # small cleanup: nested n-ary operators are merged into the toplevel
         # (this is actually against our design principle of creating
         #  expressions the way the user wrote them)
-        if arity == 0:
+        if arity == 0 and name != 'and': # special handling for nested description groups
             arg_list = list(arg_list)  # make sure its a writable list
             i = 0 # length can change
             while i < len(arg_list):

--- a/cpmpy/expressions/core.py
+++ b/cpmpy/expressions/core.py
@@ -792,7 +792,7 @@ class Operator(Expression):
         # small cleanup: nested n-ary operators are merged into the toplevel
         # (this is actually against our design principle of creating
         #  expressions the way the user wrote them)
-        if arity == 0 and name != 'and': # special handling for nested description groups
+        if arity == 0:
             arg_list = list(arg_list)  # make sure its a writable list
             i = 0 # length can change
             while i < len(arg_list):

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -126,6 +126,8 @@ class Model(object):
         If a single constraint is added, the description is set on that constraint.
         If several constraints are added, they are wrapped in a conjunction (``and``) and the description is set on that conjunction.
 
+        Nested ``description()`` blocks on the same model are not supported.
+
         Arguments:
             txt (str): description text
             override_print (bool): whether ``str()`` of the constraint shows the description (default: True)
@@ -370,6 +372,8 @@ class _DescriptionContext:
 
     def __enter__(self) -> "_DescriptionContext":
         self._prev_add = self.model.add
+        if getattr(self._prev_add, "__func__", None) is not Model.add:
+            raise RuntimeError("Cannot nest model.description() context managers")
         setattr(self.model, "add", self.add)  # constraints added to the model are now buffered here
         return self
 
@@ -379,7 +383,7 @@ class _DescriptionContext:
 
     def __exit__(self, exc_type, exc_value, traceback) -> Literal[False]:
         assert self._prev_add is not None
-        setattr(self.model, "add", self._prev_add)  # restore (may be another description context)
+        setattr(self.model, "add", self._prev_add)
 
         if exc_type is not None:
             return False

--- a/cpmpy/model.py
+++ b/cpmpy/model.py
@@ -28,16 +28,16 @@
 from __future__ import annotations
 import copy
 import warnings
-from typing import Optional
+from typing import Callable, Literal, Optional
 
 from .exceptions import NotSupportedError
 from .expressions.core import Expression, NestedBoolExprLike
-from .expressions.utils import is_any_list
+from .expressions.python_builtins import all as cpm_all
+from .expressions.utils import is_any_list, flatlist
 from .solvers.utils import SolverLookup
 from .solvers.solver_interface import SolverInterface, SolverStatus, Callback
 
 import pickle
-
 class Model(object):
     """
     CPMpy Model object, contains the constraint and objective expressions
@@ -115,7 +115,36 @@ class Model(object):
 
         self.constraints.append(con)
         return self
-    __add__ = add  # Make __add__() (for the += operation) be the same as add() 
+
+    def __add__(self, con: NestedBoolExprLike) -> "Model":
+        return self.add(con)
+
+    def description(self, txt: str, override_print: bool = True, full_print: bool = False) -> _DescriptionContext:
+        """
+        Context manager that attaches a human-readable description to constraints added inside the block.
+
+        If a single constraint is added, the description is set on that constraint.
+        If several constraints are added, they are wrapped in a conjunction (``and``) and the description is set on that conjunction.
+
+        Arguments:
+            txt (str): description text
+            override_print (bool): whether ``str()`` of the constraint shows the description (default: True)
+            full_print (bool): if True, ``str()`` is ``"<txt> -- <repr>"`` (default: False)
+
+        Example:
+            .. code-block:: python
+
+                x = boolvar(shape=5)
+                m = Model()
+
+                with m.description("at most three items"):
+                    m += sum(x) <= 3
+
+                with m.description("first item implies the next two"):
+                    m += x[0].implies(x[1])
+                    m += x[0].implies(x[2])
+        """
+        return _DescriptionContext(self, txt, override_print, full_print) 
 
 
     def minimize(self, expr: Expression) -> None:
@@ -326,3 +355,42 @@ def _update_variable_counters(model: Model):
     # update counters for future variables
     _BoolVarImpl.counter = max(_BoolVarImpl.counter, bv_counter)
     _IntVarImpl.counter = max(_IntVarImpl.counter, iv_counter)
+
+
+class _DescriptionContext:
+    """Buffers constraints added to a model while a :meth:`Model.description` block is active."""
+
+    def __init__(self, model: "Model", txt: str, override_print: bool, full_print: bool):
+        self.model = model
+        self.txt = txt
+        self.override_print = override_print
+        self.full_print = full_print
+        self._buffer: list[NestedBoolExprLike] = []
+        self._prev_add: Optional[Callable[[NestedBoolExprLike], Model]] = None
+
+    def __enter__(self) -> "_DescriptionContext":
+        self._prev_add = self.model.add
+        setattr(self.model, "add", self.add)  # constraints added to the model are now buffered here
+        return self
+
+    def add(self, con: NestedBoolExprLike) -> "Model":
+        self._buffer.append(con)
+        return self.model  # so `+=` works
+
+    def __exit__(self, exc_type, exc_value, traceback) -> Literal[False]:
+        assert self._prev_add is not None
+        setattr(self.model, "add", self._prev_add)  # restore (may be another description context)
+
+        if exc_type is not None:
+            return False
+        cons = flatlist(self._buffer) # TODO: use toplevel_list instead?
+        if len(cons) == 0:
+            return False
+        if len(cons) == 1:
+            wrapped = cons[0]
+        else:
+            wrapped = cpm_all(cons)
+        if isinstance(wrapped, Expression):
+            wrapped.set_description(self.txt, override_print=self.override_print, full_print=self.full_print)
+        self.model.add(wrapped)
+        return False

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -603,6 +603,19 @@ class TestBounds:
         assert repr(cons) == "(a) or (b)"
         assert str(cons) == "either a or b should be true, but not both -- (a) or (b)"
 
+        # variables: description must not replace the unique name
+        x = cp.boolvar(name="x")
+        x.set_description("a flag")
+        assert x.name == "x"
+        assert repr(x) == "x"
+        assert str(x) == "a flag"
+
+        y = cp.intvar(0, 5, name="y")
+        y.set_description("an integer", full_print=True)
+        assert y.name == "y"
+        assert repr(y) == "y"
+        assert str(y) == "an integer -- y"
+
 
     def test_dtype(self):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -113,3 +113,141 @@ class TestModel:
         model = cp.Model(cp.any(cp.boolvar(shape=3)))
 
         pytest.raises(ValueError, lambda : model.solve(solver="notasolver"))
+
+
+class TestModelDescription:
+
+    def test_single_constraint(self):
+        x = cp.boolvar(shape=5)
+        m = cp.Model()
+        cons = cp.sum(x) <= 3
+        with m.description("at most three items"):
+            m += cons
+        assert len(m.constraints) == 1
+        assert m.constraints[0] is cons
+        assert cons.name != "and"
+        assert str(cons) == "at most three items"
+        assert cons._description is not None
+
+    def test_multiple_adds(self):
+        x = cp.boolvar(shape=5)
+        m = cp.Model()
+        c1 = x[0].implies(x[1])
+        c2 = x[0].implies(x[2])
+        with m.description("first item implies the next two"):
+            m += c1
+            m += c2
+        assert len(m.constraints) == 1
+        wrapped = m.constraints[0]
+        assert wrapped.name == "and"
+        assert str(wrapped) == "first item implies the next two"
+        assert c1._description is None
+        assert c2._description is None
+        assert c1 in wrapped.args
+        assert c2 in wrapped.args
+
+    def test_list_of_constraints(self):
+        a, b = cp.boolvar(name="a"), cp.boolvar(name="b")
+        m = cp.Model()
+        with m.description("both"):
+            m += [a, b]
+        assert len(m.constraints) == 1
+        wrapped = m.constraints[0]
+        assert wrapped.name == "and"
+        assert str(wrapped) == "both"
+        assert a._description is None
+        assert b._description is None
+
+    def test_empty(self):
+        m = cp.Model()
+        with m.description("nothing"):
+            pass
+        assert len(m.constraints) == 0
+
+    def test_exception_drops_buffer(self):
+        m = cp.Model()
+        a = cp.boolvar(name="a")
+        try:
+            with m.description("will fail"):
+                m += a == 1
+                raise ValueError("boom")
+        except ValueError:
+            pass
+        assert len(m.constraints) == 0
+
+    def test_outside_and_other_model_unaffected(self):
+        m = cp.Model()
+        other = cp.Model()
+        a, b = cp.boolvar(name="a"), cp.boolvar(name="b")
+        m += a
+        other += b
+        with m.description("described"):
+            m += a | b
+        m += b
+        other += a
+        assert len(m.constraints) == 3
+        assert m.constraints[0] is a
+        assert str(m.constraints[1]) == "described"
+        assert m.constraints[2] is b
+        assert len(other.constraints) == 2
+        assert other.constraints[0] is b
+        assert other.constraints[1] is a
+
+    def test_boolvar_keeps_name(self):
+        b = cp.boolvar(name="flag")
+        m = cp.Model()
+        with m.description("must be true"):
+            m += b
+        assert b.name == "flag"
+        assert repr(b) == "flag"
+        assert str(b) == "must be true"
+        assert b._description is not None
+
+    def test_nested_same_model(self):
+        x = cp.boolvar(shape=5)
+        m = cp.Model()
+        with m.description("packing rules"):
+            m += cp.sum(x) <= 3
+            with m.description("first item implies the next two"):
+                m += x[0].implies(x[1])
+                m += x[0].implies(x[2])
+        assert len(m.constraints) == 1
+        outer = m.constraints[0]
+        assert outer.name == "and"
+        assert str(outer) == "packing rules"
+        assert len(outer.args) == 2
+        inner = outer.args[1]
+        assert inner.name == "and"
+        assert str(inner) == "first item implies the next two"
+        assert len(inner.args) == 2
+
+    def test_nested_different_models(self):
+        m1, m2 = cp.Model(), cp.Model()
+        a, b = cp.boolvar(name="a"), cp.boolvar(name="b")
+        with m1.description("on m1"):
+            with m2.description("on m2"):
+                m1 += a
+                m2 += b
+        assert len(m1.constraints) == 1
+        assert str(m1.constraints[0]) == "on m1"
+        assert a.name == "a"
+        assert len(m2.constraints) == 1
+        assert str(m2.constraints[0]) == "on m2"
+        assert b.name == "b"
+
+    def test_nested_inner_exception(self):
+        m = cp.Model()
+        a, b = cp.boolvar(name="a"), cp.boolvar(name="b")
+        with m.description("outer"):
+            m += a == 1
+            try:
+                with m.description("inner"):
+                    m += b == 1
+                    raise ValueError("boom")
+            except ValueError:
+                pass
+        assert len(m.constraints) == 1
+        assert str(m.constraints[0]) == "outer"
+        assert a.name == "a"
+        assert b.name == "b"
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -208,18 +208,11 @@ class TestModelDescription:
         m = cp.Model()
         with m.description("packing rules"):
             m += cp.sum(x) <= 3
-            with m.description("first item implies the next two"):
-                m += x[0].implies(x[1])
-                m += x[0].implies(x[2])
+            with pytest.raises(RuntimeError, match="Cannot nest"):
+                with m.description("first item implies the next two"):
+                    m += x[0].implies(x[1])
         assert len(m.constraints) == 1
-        outer = m.constraints[0]
-        assert outer.name == "and"
-        assert str(outer) == "packing rules"
-        assert len(outer.args) == 2
-        inner = outer.args[1]
-        assert inner.name == "and"
-        assert str(inner) == "first item implies the next two"
-        assert len(inner.args) == 2
+        assert str(m.constraints[0]) == "packing rules"
 
     def test_nested_different_models(self):
         m1, m2 = cp.Model(), cp.Model()
@@ -233,21 +226,5 @@ class TestModelDescription:
         assert a.name == "a"
         assert len(m2.constraints) == 1
         assert str(m2.constraints[0]) == "on m2"
-        assert b.name == "b"
-
-    def test_nested_inner_exception(self):
-        m = cp.Model()
-        a, b = cp.boolvar(name="a"), cp.boolvar(name="b")
-        with m.description("outer"):
-            m += a == 1
-            try:
-                with m.description("inner"):
-                    m += b == 1
-                    raise ValueError("boom")
-            except ValueError:
-                pass
-        assert len(m.constraints) == 1
-        assert str(m.constraints[0]) == "outer"
-        assert a.name == "a"
         assert b.name == "b"
 


### PR DESCRIPTION
Context manager to make it more natural for a user to add a description to a set of constraints added to the model.

Before, we had to wrap the epxressions into an `and`, set the description on that conjunction and then add it to the model.
This PR simplifies it in a more Pythononic way.

One thing thats currently unclear for me is how/whether we want to support nested descriptions.
Its a bit tricky as for Operators, we merge nested ands at construction time (which is something we probably want to keep doing). So if we would have something like this:

```python
with model.description("foo"):
    model += x + y <= 1
    with model.description("bar"):
        model += x == 4
        model += y != 1
```
we would merge the args of bar into foo: and(x + y <= 1, x == 4,  y != 1)

One solution could be to only allow adding expressions at the lowest level of the description manager, the nested structure would then just be glorified "ands" with a description attached to it.

@WoutPiessens probably has some interesting thoughts on this : )