### PR TITLE
Add sphinx-llm for agent friendly docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,8 @@ extensions = [
     'sphinx_automodapi.smart_resolver',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx.ext.autosectionlabel'
+    'sphinx.ext.autosectionlabel',
+    'sphinx_llm.txt'
 ]
 
 myst_enable_extensions = [
@@ -118,3 +119,8 @@ html_static_path = ['_static']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'cpmpy'
+
+# Config options for sphinx_llm
+llms_txt_exclude = [
+    'docs_todo',
+]

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         # Other
         "test": ["pytest", "pytest-timeout"],
         "type": ["mypy", "types-tqdm"],
-        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2"],
+        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2", "sphinx_llm"],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Use sphinx-llm to generate agent-friendly markdown versions of the docs.

sphinx-llm is a sphinx extension that makes a parallel build of the docs to md + adds a comment at the top of the html version for agents to use the .md version. Follows the [llms.txt](https://llmstxt.org/) standard. When searching on the web, cursor apparently uses it. After building the site, the markdown version of each page is available by appending `.md` to the path. Also generates a `llm.txt` file as an agent-friendly TOC of the entire docs.

Will in the future also be useful as a source for including snippets of the docs as "references" in agent skills.