### PR TITLE
Skills infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated copy of skills/ for library-skills discovery (see skills/sync_into_package.py)
+cpmpy/.agents/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Hidden package-data dirs are skipped unless listed. Copied at build time
+# from skills/ into cpmpy/.agents/skills/ (see skills/sync_into_package.py).
+recursive-include cpmpy/.agents *

--- a/cpmpy/__init__.py
+++ b/cpmpy/__init__.py
@@ -11,6 +11,10 @@ The package consists of 4 modules:
 - `expressions`: all forms of expression objects that allow you to specify constraints and objectives over variables
 - `solvers`: CPMpy classes that translate a model into approriate calls of a solver's API
 - `transformations`: common methods for transforming expressions into other expressions, used by `solvers` modules to simplify/rewrite expressions
+
+Agent Skills are authored in ``skills/`` and copied into ``cpmpy/.agents/skills/``
+at install time. Install them into a project with ``pip install 'cpmpy[skills]'``
+then ``cpmpy skills``; refresh after upgrading with ``cpmpy skills update``.
 """
 # Tias Guns, 2019-2026
 

--- a/cpmpy/__init__.py
+++ b/cpmpy/__init__.py
@@ -15,6 +15,8 @@ The package consists of 4 modules:
 Agent Skills are authored in ``skills/`` and copied into ``cpmpy/.agents/skills/``
 at install time. Install them into a project with ``pip install 'cpmpy[skills]'``
 then ``cpmpy skills``; refresh after upgrading with ``cpmpy skills update``.
+Rebuild generated references from a source checkout with
+``cpmpy skills update --regenerate`` (requires ``cpmpy[docs]``).
 """
 # Tias Guns, 2019-2026
 

--- a/cpmpy/cli.py
+++ b/cpmpy/cli.py
@@ -1,32 +1,102 @@
 """
 Command-line interface for CPMpy.
 
-This module provides a simple CLI to interact with CPMpy, primarily to display
-version information about CPMpy itself and the available solver backends.
-
 Usage:
     cpmpy <COMMAND>
 
 Commands:
     version   Show the CPMpy library version and the versions of installed solver backends.
+    skills    Install or update Agent Skills for the current project (requires cpmpy[skills]).
 """
 
+from __future__ import annotations
+
 import argparse
+import importlib.util
+import shutil
+import subprocess
+import sys
+
 from cpmpy import __version__
 import cpmpy as cp
+
+SKILLS_EXTRA_HINT = "cpmpy skills requires optional dependencies. Install with: pip install 'cpmpy[skills]'"
+
+SKILLS_HELP = """\
+usage: cpmpy skills [-h] [update] [library-skills args ...]
+
+Install or refresh CPMpy Agent Skills in the current project via library-skills.
+
+Commands:
+  (none)              Interactive discover / install / repair
+  update              Refresh project links to the currently installed CPMpy
+                      (library-skills --yes). Does not upgrade the package;
+                      run `pip install -U 'cpmpy[skills]'` first for new content.
+
+Any other arguments are forwarded to library-skills, for example:
+  cpmpy skills install -y --claude
+  cpmpy skills list
+  cpmpy skills update --claude --copy
+"""
 
 
 def command_version(args):
     print(f"CPMpy version: {__version__}")
     cp.SolverLookup().print_version()
 
-def main():
+
+def _library_skills_available() -> bool:
+    return importlib.util.find_spec("library_skills") is not None
+
+
+def run_library_skills(argv: list[str]) -> int:
+    """
+    Run the library-skills CLI with ``argv``. Returns the process exit code.
+    """
+    if not _library_skills_available():
+        print(SKILLS_EXTRA_HINT, file=sys.stderr)
+        return 1
+
+    executable = shutil.which("library-skills")
+    if executable:
+        cmd = [executable, *argv]
+    else:
+        cmd = [sys.executable, "-m", "library_skills", *argv]
+    completed = subprocess.run(cmd)
+    return completed.returncode
+
+
+def command_skills(argv: list[str]) -> int:
+    """
+    Native ``cpmpy skills`` command. ``update`` maps to ``library-skills --yes``.
+    """
+    if argv and argv[0] in ("-h", "--help"):
+        print(SKILLS_HELP, end="")
+        return 0
+    if argv and argv[0] == "update":
+        argv = ["--yes", *argv[1:]]
+    return run_library_skills(argv)
+
+
+def main(argv: list[str] | None = None):
+    argv = sys.argv[1:] if argv is None else list(argv)
+    if argv and argv[0] == "skills":
+        raise SystemExit(command_skills(argv[1:]))
+
     parser = argparse.ArgumentParser(description="CPMpy command line interface")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    # cpmpy version
-    version_parser = subparsers.add_parser("version", help="Show version information on CPMpy and its solver backends")
+    version_parser = subparsers.add_parser(
+        "version", help="Show version information on CPMpy and its solver backends"
+    )
     version_parser.set_defaults(func=command_version)
 
-    args = parser.parse_args()
+    # Registered so `cpmpy --help` lists it; dispatch is handled above so
+    # library-skills flags like --claude are not swallowed by argparse.
+    subparsers.add_parser(
+        "skills",
+        help="Install or update Agent Skills for the current project (using library-skills)",
+    )
+
+    args = parser.parse_args(argv)
     args.func(args)

--- a/cpmpy/cli.py
+++ b/cpmpy/cli.py
@@ -130,6 +130,8 @@ def run_library_skills(argv: list[str]) -> int:
 def _load_sync_module(root: Path):
     sync_path = root / "skills" / "sync_into_package.py"
     spec = importlib.util.spec_from_file_location("cpmpy_sync_into_package", sync_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load skill sync module from {sync_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/cpmpy/cli.py
+++ b/cpmpy/cli.py
@@ -44,12 +44,6 @@ To regenerate from the Sphinx docs, clone the repo and install editable:
     cpmpy skills update --regenerate
 """
 
-CONTINUE_WITHOUT_GENERATED_PROMPT = "Continue without them? [y/N] "
-NON_TTY_MISSING_REFS_HINT = (
-    "Not a TTY; aborting. Generate the files with "
-    "`cpmpy skills update --regenerate` or rerun from a terminal."
-)
-
 SKILLS_HELP_PREAMBLE = """\
 usage: cpmpy skills [-h] [update] [library-skills args ...]
 
@@ -133,63 +127,12 @@ def run_library_skills(argv: list[str]) -> int:
     return completed.returncode
 
 
-def _sync_helper_path(root: Path | None = None) -> Path | None:
-    candidates = []
-    if root is not None:
-        candidates.append(root / "skills" / "sync_into_package.py")
-    candidates.append(Path(__file__).resolve().parent.parent / "skills" / "sync_into_package.py")
-    for path in candidates:
-        if path.is_file():
-            return path
-    return None
-
-
-def _load_sync_module(root: Path | None = None):
-    sync_path = _sync_helper_path(root)
-    if sync_path is None:
-        raise FileNotFoundError("skills/sync_into_package.py")
+def _load_sync_module(root: Path):
+    sync_path = root / "skills" / "sync_into_package.py"
     spec = importlib.util.spec_from_file_location("cpmpy_sync_into_package", sync_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-
-def _stdin_is_tty() -> bool:
-    return sys.stdin.isatty()
-
-
-def confirm_continue_with_missing_generated_refs() -> bool:
-    """Ask whether to continue after missing generated refs. Default is no."""
-    if not _stdin_is_tty():
-        print(NON_TTY_MISSING_REFS_HINT, file=sys.stderr)
-        return False
-    try:
-        print(CONTINUE_WITHOUT_GENERATED_PROMPT, end="", file=sys.stderr, flush=True)
-        answer = input()
-    except EOFError:
-        print(file=sys.stderr)
-        return False
-    return answer.strip().lower() in {"y", "yes"}
-
-
-def warn_if_generated_refs_missing(*, skip: bool = False) -> bool:
-    """
-    On an editable/source install, warn if gitignored generated refs are absent.
-
-    Returns True if the command should proceed. When files are missing, asks
-    whether to continue (default no).
-    """
-    if skip:
-        return True
-    root = _source_root()
-    if root is None:
-        return True
-    if _sync_helper_path(root) is None:
-        return True
-    missing = _load_sync_module(root).warn_if_generated_refs_missing(root / "skills")
-    if not missing:
-        return True
-    return confirm_continue_with_missing_generated_refs()
 
 
 def regenerate_skill_references() -> int:
@@ -255,13 +198,6 @@ def command_skills(argv: list[str]) -> int:
     if argv and argv[0] in ("-h", "--help"):
         print(skills_help(), end="")
         return 0
-    help_requested = "-h" in argv or "--help" in argv
-    skip_missing_prompt = bool(
-        argv and argv[0] == "update" and "--regenerate" in argv[1:]
-    )
-    if not help_requested:
-        if not warn_if_generated_refs_missing(skip=skip_missing_prompt):
-            return 1
     if argv and argv[0] == "update":
         return command_skills_update(argv[1:])
     return run_library_skills(argv)

--- a/cpmpy/cli.py
+++ b/cpmpy/cli.py
@@ -16,13 +16,41 @@ import importlib.util
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 from cpmpy import __version__
 import cpmpy as cp
 
 SKILLS_EXTRA_HINT = "cpmpy skills requires optional dependencies. Install with: pip install 'cpmpy[skills]'"
+DOCS_EXTRA_HINT = (
+    "cpmpy skills update --regenerate requires the docs extra. "
+    "Install with: pip install 'cpmpy[docs]'"
+)
+REGENERATE_SOURCE_HINT = """\
+--regenerate is only available when CPMpy is installed from source.
 
-SKILLS_HELP = """\
+This install looks like a wheel (e.g. pip install cpmpy). There is no docs/
+tree here to rebuild from; generated reference files already ship in the
+package. To pick up a newer snapshot:
+
+    pip install -U cpmpy
+    cpmpy skills update
+
+To regenerate from the Sphinx docs, clone the repo and install editable:
+
+    git clone https://github.com/CPMpy/cpmpy.git
+    cd cpmpy
+    pip install -e '.[docs]'
+    cpmpy skills update --regenerate
+"""
+
+CONTINUE_WITHOUT_GENERATED_PROMPT = "Continue without them? [y/N] "
+NON_TTY_MISSING_REFS_HINT = (
+    "Not a TTY; aborting. Generate the files with "
+    "`cpmpy skills update --regenerate` or rerun from a terminal."
+)
+
+SKILLS_HELP_PREAMBLE = """\
 usage: cpmpy skills [-h] [update] [library-skills args ...]
 
 Install or refresh CPMpy Agent Skills in the current project via library-skills.
@@ -32,7 +60,15 @@ Commands:
   update              Refresh project links to the currently installed CPMpy
                       (library-skills --yes). Does not upgrade the package;
                       run `pip install -U 'cpmpy[skills]'` first for new content.
+"""
 
+SKILLS_HELP_REGENERATE = """\
+  update --regenerate Rebuild generated reference files from the Sphinx docs,
+                      recopy them into the package, then refresh project links.
+                      Requires pip install 'cpmpy[docs]'.
+"""
+
+SKILLS_HELP_EPILOG = """
 Any other arguments are forwarded to library-skills, for example:
   cpmpy skills install -y --claude
   cpmpy skills list
@@ -47,6 +83,37 @@ def command_version(args):
 
 def _library_skills_available() -> bool:
     return importlib.util.find_spec("library_skills") is not None
+
+
+def _source_root() -> Path | None:
+    """
+    Repo root if this is an editable/source install, else None.
+    """
+    candidate = Path(cp.__file__).resolve().parent.parent
+    if (candidate / "skills" / "generate_references.py").is_file():
+        return candidate
+    return None
+
+
+def _can_regenerate() -> bool:
+    """
+    True when generated refs can be rebuilt (source checkout, not a wheel).
+    """
+    return _source_root() is not None
+
+
+def skills_help() -> str:
+    text = SKILLS_HELP_PREAMBLE
+    if _can_regenerate():
+        text += SKILLS_HELP_REGENERATE
+    return text + SKILLS_HELP_EPILOG
+
+
+def _docs_extra_available() -> bool:
+    return (
+        importlib.util.find_spec("sphinx") is not None
+        and importlib.util.find_spec("sphinx_llm") is not None
+    )
 
 
 def run_library_skills(argv: list[str]) -> int:
@@ -66,15 +133,137 @@ def run_library_skills(argv: list[str]) -> int:
     return completed.returncode
 
 
+def _sync_helper_path(root: Path | None = None) -> Path | None:
+    candidates = []
+    if root is not None:
+        candidates.append(root / "skills" / "sync_into_package.py")
+    candidates.append(Path(__file__).resolve().parent.parent / "skills" / "sync_into_package.py")
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def _load_sync_module(root: Path | None = None):
+    sync_path = _sync_helper_path(root)
+    if sync_path is None:
+        raise FileNotFoundError("skills/sync_into_package.py")
+    spec = importlib.util.spec_from_file_location("cpmpy_sync_into_package", sync_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stdin_is_tty() -> bool:
+    return sys.stdin.isatty()
+
+
+def confirm_continue_with_missing_generated_refs() -> bool:
+    """Ask whether to continue after missing generated refs. Default is no."""
+    if not _stdin_is_tty():
+        print(NON_TTY_MISSING_REFS_HINT, file=sys.stderr)
+        return False
+    try:
+        print(CONTINUE_WITHOUT_GENERATED_PROMPT, end="", file=sys.stderr, flush=True)
+        answer = input()
+    except EOFError:
+        print(file=sys.stderr)
+        return False
+    return answer.strip().lower() in {"y", "yes"}
+
+
+def warn_if_generated_refs_missing(*, skip: bool = False) -> bool:
+    """
+    On an editable/source install, warn if gitignored generated refs are absent.
+
+    Returns True if the command should proceed. When files are missing, asks
+    whether to continue (default no).
+    """
+    if skip:
+        return True
+    root = _source_root()
+    if root is None:
+        return True
+    if _sync_helper_path(root) is None:
+        return True
+    missing = _load_sync_module(root).warn_if_generated_refs_missing(root / "skills")
+    if not missing:
+        return True
+    return confirm_continue_with_missing_generated_refs()
+
+
+def regenerate_skill_references() -> int:
+    """
+    Rebuild ``*.generated.md`` from Sphinx docs and recopy skills into the package.
+    """
+    root = _source_root()
+    if root is None:
+        print(REGENERATE_SOURCE_HINT, file=sys.stderr)
+        return 1
+    if not _docs_extra_available():
+        print(DOCS_EXTRA_HINT, file=sys.stderr)
+        return 1
+
+    generator = root / "skills" / "generate_references.py"
+    completed = subprocess.run([sys.executable, str(generator), "--build"])
+    if completed.returncode:
+        return completed.returncode
+
+    _load_sync_module(root).sync_skills(
+        root / "skills",
+        root / "cpmpy" / ".agents" / "skills",
+    )
+    return 0
+
+
+def command_skills_update(argv: list[str]) -> int:
+    """
+    ``cpmpy skills update`` → ``library-skills --yes``, optionally regenerating refs.
+    """
+    parser = argparse.ArgumentParser(
+        prog="cpmpy skills update",
+        description=(
+            "Refresh project links to the currently installed CPMpy. "
+            "Does not run pip; upgrade the package first for newer skill content."
+        ),
+    )
+    can_regenerate = _can_regenerate()
+    if can_regenerate:
+        parser.add_argument(
+            "--regenerate",
+            action="store_true",
+            help=(
+                "Rebuild generated skill reference files from the Sphinx docs "
+                "(requires pip install 'cpmpy[docs]')."
+            ),
+        )
+    args, rest = parser.parse_known_args(argv)
+    if not can_regenerate and "--regenerate" in rest:
+        print(REGENERATE_SOURCE_HINT, file=sys.stderr)
+        return 1
+    if can_regenerate and args.regenerate:
+        code = regenerate_skill_references()
+        if code:
+            return code
+    return run_library_skills(["--yes", *rest])
+
+
 def command_skills(argv: list[str]) -> int:
     """
     Native ``cpmpy skills`` command. ``update`` maps to ``library-skills --yes``.
     """
     if argv and argv[0] in ("-h", "--help"):
-        print(SKILLS_HELP, end="")
+        print(skills_help(), end="")
         return 0
+    help_requested = "-h" in argv or "--help" in argv
+    skip_missing_prompt = bool(
+        argv and argv[0] == "update" and "--regenerate" in argv[1:]
+    )
+    if not help_requested:
+        if not warn_if_generated_refs_missing(skip=skip_missing_prompt):
+            return 1
     if argv and argv[0] == "update":
-        argv = ["--yes", *argv[1:]]
+        return command_skills_update(argv[1:])
     return run_library_skills(argv)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,8 @@ extensions = [
     'sphinx_automodapi.smart_resolver',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx.ext.autosectionlabel'
+    'sphinx.ext.autosectionlabel',
+    'sphinx_llm.txt'
 ]
 
 myst_enable_extensions = [
@@ -118,3 +119,8 @@ html_static_path = ['_static']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'cpmpy'
+
+# Config options for sphinx_llm
+llms_txt_exclude = [
+    'docs_todo',
+]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,28 @@
 from setuptools import find_packages, setup
+from setuptools.command.build_py import build_py as _build_py
 import codecs
+import importlib.util
 import os.path
+
+def _load_sync_skills():
+    """
+    Load skills/sync_into_package.py without importing the cpmpy package.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "skills", "sync_into_package.py")
+    spec = importlib.util.spec_from_file_location("cpmpy_sync_skills", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.sync_skills
+
+
+class build_py(_build_py):
+    """
+    Copy authored skills/ into cpmpy/.agents/skills/ before packaging.
+    """
+
+    def run(self):
+        _load_sync_skills()()
+        super().run()
 
 def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
@@ -84,6 +106,10 @@ setup(
         "test": ["pytest", "pytest-timeout"],
         "type": ["mypy", "types-tqdm"],
         "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2", "sphinx_llm"],
+        "skills": ["library-skills"],
+    },
+    cmdclass={
+        "build_py": build_py,
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,15 @@ format_dependencies = {
 }
 format_dependencies["io.all"] = list({pkg for group in format_dependencies.values() for pkg in group})
 
+docs_require = [
+    "sphinx>=5.3.0",
+    "sphinx_rtd_theme>=2.0.0",
+    "myst_parser",
+    "sphinx-automodapi",
+    "readthedocs-sphinx-search>=0.3.2",
+    "sphinx_llm",
+]
+
 setup(
     name='cpmpy',
     version=get_version("cpmpy/__init__.py"),
@@ -105,7 +114,7 @@ setup(
         # Other
         "test": ["pytest", "pytest-timeout"],
         "type": ["mypy", "types-tqdm"],
-        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2", "sphinx_llm"],
+        "docs": docs_require,
         "skills": ["library-skills"],
     },
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         # Other
         "test": ["pytest", "pytest-timeout"],
         "type": ["mypy", "types-tqdm"],
-        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2"],
+        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=2.0.0", "myst_parser", "sphinx-automodapi", "readthedocs-sphinx-search>=0.3.2", "sphinx_llm"],
     },
     entry_points={
         'console_scripts': [

--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -1,5 +1,0 @@
-# Generated reference files (see generate_references.py) are derived
-# entirely from this repo's own docs/, already tracked in git — committing a
-# second copy here would just be a duplicate that can silently drift.
-# Run `python skills/generate_references.py` to (re)create them locally.
-**/references/*.generated.md

--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -1,0 +1,5 @@
+# Generated reference files (see generate_references.py) are derived
+# entirely from this repo's own docs/, already tracked in git — committing a
+# second copy here would just be a duplicate that can silently drift.
+# Run `python skills/generate_references.py` to (re)create them locally.
+**/references/*.generated.md

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,53 @@
+# Agent Skills
+
+This directory holds **Agent Skills** for CPMpy. They follow the open
+[Agent Skills specification](https://agentskills.io/specification).
+
+## Using skills in a project
+
+Skills are **authored here** (`skills/<name>/`) and **copied into the installed
+package** at `cpmpy/.agents/skills/` when you build or `pip install` CPMpy (including
+editable installs), via [`sync_into_package.py`](sync_into_package.py). That copy is
+gitignored; do not edit it by hand.
+
+To link them into a consuming project's `.agents/skills/` (so Cursor, Claude Code,
+etc. can load them):
+
+```bash
+pip install 'cpmpy[skills]'    # CPMpy plus library-skills
+cpmpy skills                   # interactive install into the current project
+```
+
+After upgrading CPMpy, refresh the project's links to the newly installed content
+(this does not run `pip` itself):
+
+```bash
+pip install -U 'cpmpy[skills]'
+cpmpy skills update
+```
+
+To also rebuild generated reference files (`*.generated.md`) from the Sphinx docs,
+use a **source checkout** and the docs extra:
+
+```bash
+pip install -e '.[docs]'           # Sphinx + sphinx_llm
+cpmpy skills update --regenerate
+```
+
+`--regenerate` is only advertised in `cpmpy skills --help` for a source/editable
+install; a wheel from PyPI has no docs tree to rebuild from. It runs
+`skills/generate_references.py --build`, recopies `skills/` into
+`cpmpy/.agents/skills/`, then `library-skills --yes`. `cpmpy[docs]` is
+enough if `cpmpy[skills]` is already installed.
+
+A clone of this repo includes `*.generated.md` so `npx skills add` and a
+plain `pip install -e .` both get the reference files. Rebuild them when
+docs change (`pip install 'cpmpy[docs]'` then `cpmpy skills update --regenerate`).
+
+`cpmpy skills update` is `library-skills --yes`. Any other arguments are forwarded
+to [library-skills](https://library-skills.io/), e.g. `cpmpy skills install -y --claude`
+or `cpmpy skills list`. Without the extra, `cpmpy skills` tells you to
+`pip install 'cpmpy[skills]'`.
+
+The `skills/` tree is also what `npx skills add` looks at in this git repo,
+including committed `*.generated.md` reference files.

--- a/skills/cpmpy-model/SKILL.md
+++ b/skills/cpmpy-model/SKILL.md
@@ -1,21 +1,12 @@
 ---
 name: cpmpy-model
-description: Write and solve problems in CPMpy, a constraint programming and modelling library in Python, based on numpy, with direct solver access. 
-version: 0.0.1
+description: Write and solve problems in CPMpy, a constraint programming and modelling library in Python, based on numpy, with direct solver access.
 license: Apache-2.0
+compatibility: Requires Python 3.10+
 metadata:
   author: CPMpy team
   domain: constraint-programming
   library: cpmpy
-  tags:
-    - constraint-programming
-    - combinatorial-optimization
-    - constraint-modeling
-    - decision-variables
-    - global-constraints
-    - python
-    - or-tools
-    - optimization
 ---
 
 # CPMpy modeling

--- a/skills/cpmpy-model/SKILL.md
+++ b/skills/cpmpy-model/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cpmpy-model
+description: Write and solve problems in CPMpy, a constraint programming and modelling library in Python, based on numpy, with direct solver access. 
+version: 0.0.1
+license: Apache-2.0
+metadata:
+  author: CPMpy team
+  domain: constraint-programming
+  library: cpmpy
+  tags:
+    - constraint-programming
+    - combinatorial-optimization
+    - constraint-modeling
+    - decision-variables
+    - global-constraints
+    - python
+    - or-tools
+    - optimization
+---
+
+# CPMpy modeling
+
+Model and solve constrained (optimisation) problems using CPMpy with one of its many solver backends across SMT, CP, ILP, PB, (max)SAT. Model once in a numpy-style high-level language, using **decision variables** plus **constraints** over them, optionally with an **objective**, then solve with any backend.
+
+For an overview of the available backends and their abilities: [index](https://cpmpy.readthedocs.io/en/latest/index.html)
+
+For a compact, complete API listing: [references/api-cheatsheet.generated.md](references/api-cheatsheet.generated.md)
+
+For the full narrative documentation (global constraints catalog, solver selection, incremental solving, I/O, debugging), see [modeling](https://cpmpy.readthedocs.io/en/latest/modeling.html).
+

--- a/skills/cpmpy-model/SKILL.md
+++ b/skills/cpmpy-model/SKILL.md
@@ -17,5 +17,5 @@ For an overview of the available backends and their abilities: [index](https://c
 
 For a compact, complete API listing: [references/api-cheatsheet.generated.md](references/api-cheatsheet.generated.md)
 
-For the full narrative documentation (global constraints catalog, solver selection, incremental solving, I/O, debugging), see [modeling](https://cpmpy.readthedocs.io/en/latest/modeling.html).
+For the full narrative documentation (global constraints catalog, solver selection, incremental solving, I/O, debugging), see [documentation](https://cpmpy.readthedocs.io/en/latest/llm.txt).
 

--- a/skills/cpmpy-model/references/api-cheatsheet.generated.md
+++ b/skills/cpmpy-model/references/api-cheatsheet.generated.md
@@ -1,0 +1,141 @@
+<!--
+GENERATED FILE — do not edit by hand.
+Source: docs/_build/html/summary.html.md
+(built by the sphinx_llm Sphinx extension, see docs/conf.py)
+Regenerate: python skills/generate_references.py --build
+See skills/README.md#keeping-reference-files-in-sync
+-->
+
+# Summary sheet
+
+More extensive user documentation in [Modeling and solving with CPMpy](../../../docs/_build/html/modeling.html.md).
+
+`import cpmpy as cp`
+
+## Model class
+
+- [`model = cp.Model()`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.__init__) – Create a [`Model`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model).
+- [`model.add(constraint)`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.add) – Add a constraint (an [`Expression`](../../../docs/_build/html/api/expressions.html.md#module-cpmpy.expressions)) to the model, also allowed: model += constraint.
+- [`model.maximize(obj)`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.maximize) or [`model.minimize(obj)`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.minimize) – Set the objective (an [`Expression`](../../../docs/_build/html/api/expressions.html.md#module-cpmpy.expressions)).
+- [`model.solve()`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.solve) – Solve the model with the default solver, returns True/False.
+- [`model.solveAll()`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.solveAll) – Solve and enumerate all solutions, returns number of solutions.
+- [`model.status()`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.status) – Get the status of the last solver run.
+- [`model.objective_value()`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model.objective_value) – Get the objective value obtained during the last solver run.
+
+## Solvers
+
+[`Solvers`](../../../docs/_build/html/api/solvers.html.md#module-cpmpy.solvers) have the same API as [`Model`](../../../docs/_build/html/api/model.html.md#cpmpy.model.Model). Solvers are instantiated throught the static [`cp.SolverLookup`](../../../docs/_build/html/api/solvers/utils.html.md#cpmpy.solvers.utils.SolverLookup) class:
+
+- [`cp.SolverLookup.solvernames()`](../../../docs/_build/html/api/solvers/utils.html.md#cpmpy.solvers.utils.SolverLookup.solvernames) – List all installed solvers (including subsolvers).
+- [`cp.SolverLookup.get(solvername, model=None)`](../../../docs/_build/html/api/solvers/utils.html.md#cpmpy.solvers.utils.SolverLookup.get) – Initialize a specific solver.
+
+## Decision Variables
+
+[`Decision variables`](../../../docs/_build/html/api/expressions/variables.html.md#module-cpmpy.expressions.variables) are NumPy-like objects: `shape=None|1` creates one variable, `shape=4` creates a vector of 4 variables, `shape=(2,3)` creates a matrix of 2x3 variables, etc.
+Name is optional too, indices are automatically added to the name so each variable has a unique name.
+
+- [`x = cp.boolvar(shape=4, name="x")`](../../../docs/_build/html/api/expressions/variables.html.md#cpmpy.expressions.variables.boolvar) – Create four Boolean decision variables.
+- [`x = cp.intvar(lb, ub)`](../../../docs/_build/html/api/expressions/variables.html.md#cpmpy.expressions.variables.intvar) – Create one integer decision variable with domain `[lb, ub]` (inclusive).
+- [`x.value()`](../../../docs/_build/html/api/expressions/variables.html.md#cpmpy.expressions.variables._NumVarImpl.value) – Get the value of `x` obtained during the last solver run.
+
+## Core Expressions
+
+You can apply the following standard Python operators on CPMpy expressions, which creates the corresponding [`Core Expression`](../../../docs/_build/html/api/expressions/core.html.md#module-cpmpy.expressions.core) object:
+
+- Comparison: `==`, `!=`, `<`, `<=`, `>`, `>=`
+- Arithmetic: `+`, `-`, `*`, `//` (integer division), `%` (modulo), `**` (power)
+- Logical: `&` (and), `|` (or), `~` (not), `^` (xor)
+- Logical implication: [`x.implies(y)`](../../../docs/_build/html/api/expressions/core.html.md#cpmpy.expressions.core.Expression.implies)
+
+Logical operators only work on Boolean variables/constraints, numeric operators work on both integer and Boolean variables/expressions.
+
+CPMpy overwrites the following [`Python built-ins`](../../../docs/_build/html/api/expressions/python_builtins.html.md#module-cpmpy.expressions.python_builtins), they allow vectorized operations:
+
+- [`cp.sum`](../../../docs/_build/html/api/expressions/python_builtins.html.md#cpmpy.expressions.python_builtins.sum), [`cp.abs`](../../../docs/_build/html/api/expressions/python_builtins.html.md#cpmpy.expressions.python_builtins.abs), [`cp.max`](../../../docs/_build/html/api/expressions/python_builtins.html.md#cpmpy.expressions.python_builtins.max), [`cp.min`](../../../docs/_build/html/api/expressions/python_builtins.html.md#cpmpy.expressions.python_builtins.min)
+- [`cp.all`](../../../docs/_build/html/api/expressions/python_builtins.html.md#cpmpy.expressions.python_builtins.all), [`cp.any`](../../../docs/_build/html/api/expressions/python_builtins.html.md#cpmpy.expressions.python_builtins.any)
+
+You can **index** CPMpy expressions with an integer decision variable: `x[y]`, which will create an [`Element`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Element) expression object.
+To index non-CPMpy arrays, wrap them with [`cpm_array()`](../../../docs/_build/html/api/expressions/variables.html.md#cpmpy.expressions.variables.cpm_array): `cpm_array([1,2,3])[y]`.
+
+## Global Functions
+
+[`Global functions`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#module-cpmpy.expressions.globalfunctions) are numeric functions that some solvers support natively (through a solver-specific global constraint). CPMpy automatically rewrites the global function as needed to work with any solver.
+
+| [`Minimum`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Minimum)           | Computes the minimum value of the arguments                                                                     |
+|--------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| [`Maximum`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Maximum)           | Computes the maximum value of the arguments                                                                     |
+| [`Abs`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Abs)                   | Computes the absolute value of the argument                                                                     |
+| [`Element`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Element)           | The Element(Arr, Idx) global function allows indexing into an array with a decision variable.                   |
+| [`Count`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Count)               | The Count global function represents the number of occurrences of a value in an array                           |
+| [`Among`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.Among)               | The Among global function counts how many variables in an array take values that are in a given set of values.  |
+| [`NValue`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.NValue)             | The NValue global function counts the number of distinct values in an array.                                    |
+| [`NValueExcept`](../../../docs/_build/html/api/expressions/globalfunctions.html.md#cpmpy.expressions.globalfunctions.NValueExcept) | The NValueExcept global function counts the number of distinct values in an array, excluding a specified value. |
+
+## Global Constraints
+
+[`Global constraints`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#module-cpmpy.expressions.globalconstraints) are constraints (Boolean functions) that some solvers support natively. All global constraints can be reified (implication, equivalence) and used in other expressions, which CPMpy will handle.
+
+| [`AllDifferent`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.AllDifferent)                     | Enforces that all arguments have a different (distinct) value                                                                                                          |
+|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`AllDifferentExcept0`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.AllDifferentExcept0)       | Enforces that all arguments, except those equal to 0, have a different (distinct) value.                                                                               |
+| [`AllDifferentExceptN`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.AllDifferentExceptN)       | Enforces that all arguments, except those equal to a value in n, have a different (distinct) value.                                                                    |
+| [`AllEqual`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.AllEqual)                             | Enforces that all arguments have the same value                                                                                                                        |
+| [`AllEqualExceptN`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.AllEqualExceptN)               | Enforces that all arguments, except those equal to a value in n, have the same value.                                                                                  |
+| [`Circuit`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Circuit)                               | Enforces that the sequence of variables form a circuit, where x[i] = j means that node j is the successor of node i.                                                   |
+| [`Inverse`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Inverse)                               | Enforces that the forward and reverse arrays represent the inverse function of one another.                                                                            |
+| [`Table`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Table)                                   | Enforces that the values of the variables in 'array' correspond to a row in 'table'.                                                                                   |
+| [`ShortTable`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.ShortTable)                         | Extension of the Table constraint where the table matrix may contain wildcards (STAR), meaning there are no restrictions for the corresponding variable in that tuple. |
+| [`NegativeTable`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.NegativeTable)                   | The values of the variables in 'array' do not correspond to any row in 'table'.                                                                                        |
+| [`IfThenElse`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.IfThenElse)                         | Enforces a conditional expression of the form: if condition then if_true else if_false.                                                                                |
+| [`InDomain`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.InDomain)                             | Enforces the expression is assigned to a value in the given domain.                                                                                                    |
+| [`Xor`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Xor)                                       | Enforces the exclusive-or relation of the arguments.                                                                                                                   |
+| [`Cumulative`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Cumulative)                         | Enforces that a set of tasks is scheduled such that the capacity of the resource is never exceeded and enforces:                                                       |
+| [`Precedence`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Precedence)                         | Enforces a precedence relationship between a set of variables.                                                                                                         |
+| [`NoOverlap`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.NoOverlap)                           | Enforces that a set of tasks are scheduled without overlapping, and enforces:                                                                                          |
+| [`GlobalCardinalityCount`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.GlobalCardinalityCount) | Enforces that the number of occurrences of each value vals[i] in the list of variables vars is equal to occ[i].                                                        |
+| [`Increasing`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Increasing)                         | Enforces that the expressions are assigned to (non-strictly) increasing values.                                                                                        |
+| [`Decreasing`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.Decreasing)                         | Enforces that the expressions are assigned to (non-strictly) decreasing values.                                                                                        |
+| [`IncreasingStrict`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.IncreasingStrict)             | Enforces that the expressions are assigned to strictly increasing values.                                                                                              |
+| [`DecreasingStrict`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.DecreasingStrict)             | Enforces that the expressions are assigned to strictly decreasing values.                                                                                              |
+| [`LexLess`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.LexLess)                               | Enforces that the first list is lexicographically smaller than the second list.                                                                                        |
+| [`LexLessEq`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.LexLessEq)                           | Enforces that the first list is lexicographically smaller than or equal to the second list.                                                                            |
+| [`LexChainLess`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.LexChainLess)                     | Enforces that all rows of the matrix are lexicographically ordered.                                                                                                    |
+| [`LexChainLessEq`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.LexChainLessEq)                 | Enforces that all rows of the matrix are lexicographically ordered (less or equal)                                                                                     |
+| [`DirectConstraint`](../../../docs/_build/html/api/expressions/globalconstraints.html.md#cpmpy.expressions.globalconstraints.DirectConstraint)             | A `DirectConstraint` will directly call a function of the underlying solver when added to a CPMpy solver                                                               |
+
+## Guidelines and tips
+
+- Do not `from cpmpy import *`, the implicit overloading of any/all and sum may break or slow down other libraries.
+- Explicitly use CPMpy versions of built-in functions (`cp.sum`, `cp.all`, etc.).
+- Use global constraints/global functions where possible, some solvers will be much faster.
+- Stick to integer constants in constraints and model objectives (some solvers support FloatSum but its very limited)
+- For maintainability, use logical code organization and comments to explain your constraints.
+
+## Toy example
+
+```python
+import cpmpy as cp
+
+# Decision Variables
+b = cp.boolvar()
+x1, x2, x3 = x = cp.intvar(1, 10, shape=3)
+
+# Constraints
+model = cp.Model()
+
+model.add(x[0] == 1)
+model.add(cp.AllDifferent(x))
+model.add(cp.Count(x, 9) == 1)
+model.add(b.implies(x[1] + x[2] > 5))
+
+# Objective
+model.maximize(cp.sum(x) + 100 * b)
+
+# Solving
+solved = model.solve()
+if solved:
+    print("Solution found:")
+    print('b:', b.value(), ' x:', x.value().tolist())
+else:
+    print("No solution found.")
+```

--- a/skills/generate_references.py
+++ b/skills/generate_references.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Generate skill reference files from this repo's Sphinx docs.
+
+A skill's `references/*.generated.md` files are never hand-edited, they are
+"generated" from the agent-friendly Markdown mirror that the `sphinx_llm` Sphinx
+extension writes alongside the HTML build (one `<page>.html.md` per doc page
+in `docs/_build/html/`, enabled in `docs/conf.py`). This keeps a skill's 
+reference material in sync with the actual documentation.
+
+Setup (only needed to run this script, not to use a skill):
+    pip install -e ".[docs]"     # from the repo root; installs sphinx_llm
+    python skills/generate_references.py --build
+                                  # builds the docs, then generates
+
+Or build the docs yourself first (`cd docs && make html`) and just run:
+    python skills/generate_references.py
+
+Usage:
+    python skills/generate_references.py             # (re)generate every file below
+    python skills/generate_references.py --build     # build the docs first
+    python skills/generate_references.py --check     # verify generated files are
+                                                     # up to date; exit 1 if not
+                                                     # (use in CI after docs change)
+
+To add a new generated reference file, add an entry to SOURCES below.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+DOCS_BUILD_HTML = DOCS_DIR / "_build" / "html"
+
+# Each entry: (sphinx_llm-generated markdown file, relative to
+#              docs/_build/html/,
+#              ordered list of heading texts to extract from it, or None to
+#              copy the whole page,
+#              output file relative to repo root)
+SOURCES = [
+    (
+        "summary.html.md",
+        None,
+        "skills/cpmpy-model/references/api-cheatsheet.generated.md",
+    ),
+]
+
+GENERATED_HEADER = """<!--
+GENERATED FILE — do not edit by hand.
+Source: docs/_build/html/{source}{sections_note}
+(built by the sphinx_llm Sphinx extension, see docs/conf.py)
+Regenerate: python skills/generate_references.py --build
+See skills/README.md#keeping-reference-files-in-sync
+-->
+
+"""
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+
+
+def _find_headings(lines: list[str]) -> list[tuple[int, int, str]]:
+    """Return (line_index, level, text) for every Markdown heading line."""
+    marks = []
+    in_code_block = False
+    for i, line in enumerate(lines):
+        if line.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        m = _HEADING_RE.match(line)
+        if m:
+            marks.append((i, len(m.group(1)), m.group(2)))
+    return marks
+
+
+def extract_sections(text: str, headings: list[str]) -> str:
+    """Extract each named section (heading + its body + any subsections) from
+    a Markdown document, in the order given by `headings`, not the order they
+    appear in the source."""
+    lines = text.splitlines(keepends=True)
+    marks = _find_headings(lines)
+    by_text: dict[str, list[int]] = {}
+    for idx, (_line_i, _level, heading_text) in enumerate(marks):
+        by_text.setdefault(heading_text, []).append(idx)
+
+    chunks = []
+    for wanted in headings:
+        matches = by_text.get(wanted)
+        if not matches:
+            raise ValueError(
+                f"heading {wanted!r} not found (looked for an exact Markdown "
+                f"heading match)"
+            )
+        if len(matches) > 1:
+            raise ValueError(f"heading {wanted!r} is ambiguous ({len(matches)} matches)")
+        mark_idx = matches[0]
+        start_line, level, _ = marks[mark_idx]
+        end_line = len(lines)
+        for line_i, other_level, _ in marks[mark_idx + 1 :]:
+            if other_level <= level:
+                end_line = line_i
+                break
+        chunk = "".join(lines[start_line:end_line]).rstrip("\n")
+        chunks.append(chunk)
+    return "\n\n".join(chunks) + "\n"
+
+
+def build_docs() -> None:
+    # Invoke sphinx-build as a module of *this* interpreter (sys.executable),
+    # not via `make`/PATH — that can silently resolve to a different Python
+    # environment's sphinx-build, one without sphinx_llm installed.
+    subprocess.run(
+        [sys.executable, "-m", "sphinx", "-b", "html", str(DOCS_DIR), str(DOCS_BUILD_HTML)],
+        check=True,
+    )
+
+
+# sphinx_llm's markdown links other doc pages relative to docs/_build/html/
+# (e.g. `modeling.html.md`, `api/expressions/globalconstraints.html.md#...`).
+# Once copied into a skill's references/ dir those links resolve to the wrong
+# place, so rewrite them relative to the generated file's own location instead.
+_MD_LINK_RE = re.compile(r"\]\(([^)\s]+)\)")
+
+
+def _rebase_links(text: str, output_path: Path) -> str:
+    prefix = os.path.relpath(DOCS_BUILD_HTML, output_path.parent)
+    if prefix == ".":
+        return text
+
+    def repl(match: re.Match) -> str:
+        target = match.group(1)
+        if target.startswith(("http://", "https://", "mailto:", "#", "/")):
+            return match.group(0)
+        return f"]({prefix}/{target})"
+
+    return _MD_LINK_RE.sub(repl, text)
+
+
+def build(source: str, headings: list[str] | None, output: str) -> str:
+    source_path = DOCS_BUILD_HTML / source
+    if not source_path.exists():
+        raise FileNotFoundError(
+            f"{source_path.relative_to(REPO_ROOT)} not found. Build the docs first: "
+            f"`pip install -e '.[docs]'` then `python skills/generate_references.py "
+            f"--build` (or `cd docs && make html` yourself)."
+        )
+    text = source_path.read_text()
+    body = text if headings is None else extract_sections(text, headings)
+    body = _rebase_links(body, REPO_ROOT / output)
+
+    sections_note = f" (sections: {', '.join(headings)})" if headings else ""
+    header = GENERATED_HEADER.format(source=source, sections_note=sections_note)
+    return header + body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--build", action="store_true", help="build the Sphinx docs first (runs `make html`)"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="don't write files; exit 1 if any generated file is stale/missing",
+    )
+    args = parser.parse_args()
+
+    if args.build:
+        build_docs()
+
+    stale = []
+    for source, headings, output in SOURCES:
+        content = build(source, headings, output)
+        output_path = REPO_ROOT / output
+        if args.check:
+            current = output_path.read_text() if output_path.exists() else None
+            if current != content:
+                stale.append(output)
+        else:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(content)
+            print(f"wrote {output}")
+
+    if args.check and stale:
+        print("stale or missing generated reference file(s):", file=sys.stderr)
+        for output in stale:
+            print(f"  {output}", file=sys.stderr)
+        print("run: python skills/generate_references.py --build", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/generate_references.py
+++ b/skills/generate_references.py
@@ -22,12 +22,14 @@ Usage:
     python skills/generate_references.py --check     # verify generated files are
                                                      # up to date; exit 1 if not
                                                      # (use in CI after docs change)
+    python skills/generate_references.py --clean     # delete generated files (dev)
 
 To add a new generated reference file, add an entry to SOURCES below.
 """
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import re
 import subprocess
@@ -160,6 +162,14 @@ def build(source: str, headings: list[str] | None, output: str) -> str:
     return header + body
 
 
+def _load_sync_module():
+    path = Path(__file__).resolve().parent / "sync_into_package.py"
+    spec = importlib.util.spec_from_file_location("cpmpy_sync_into_package", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -170,7 +180,26 @@ def main() -> int:
         action="store_true",
         help="don't write files; exit 1 if any generated file is stale/missing",
     )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="delete generated reference files and recopy skills into the package",
+    )
     args = parser.parse_args()
+
+    if args.clean and (args.build or args.check):
+        parser.error("--clean cannot be combined with --build or --check")
+
+    if args.clean:
+        sync = _load_sync_module()
+        removed = sync.clean_generated_refs(REPO_ROOT / "skills")
+        sync.sync_skills(warn_missing=False)
+        if removed:
+            for path in removed:
+                print(f"removed {path.relative_to(REPO_ROOT)}")
+        else:
+            print("no generated skill reference files to remove")
+        return 0
 
     if args.build:
         build_docs()

--- a/skills/generate_references.py
+++ b/skills/generate_references.py
@@ -193,7 +193,7 @@ def main() -> int:
     if args.clean:
         sync = _load_sync_module()
         removed = sync.clean_generated_refs(REPO_ROOT / "skills")
-        sync.sync_skills(warn_missing=False)
+        sync.sync_skills()
         if removed:
             for path in removed:
                 print(f"removed {path.relative_to(REPO_ROOT)}")

--- a/skills/sync_into_package.py
+++ b/skills/sync_into_package.py
@@ -16,25 +16,13 @@ also run it directly:
 
 from __future__ import annotations
 
-import re
 import shutil
-import sys
 from pathlib import Path
 
 SKILLS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SKILLS_DIR.parent
 DEFAULT_SRC = SKILLS_DIR
 DEFAULT_DEST = REPO_ROOT / "cpmpy" / ".agents" / "skills"
-
-_GENERATED_LINK_RE = re.compile(r"\]\(([^)\s#]+\.generated\.md)")
-
-GENERATED_REFS_HINT = """\
-Agent skill is missing its reference files. These are not included by default in a source checkout
-Install the docs extra and rebuild them:
-
-    pip install 'cpmpy[docs]'
-    cpmpy skills update --regenerate
-"""
 
 
 def iter_skill_dirs(src_dir: Path) -> list[Path]:
@@ -46,32 +34,6 @@ def iter_skill_dirs(src_dir: Path) -> list[Path]:
         if skill.is_dir() and (skill / "SKILL.md").is_file():
             skills.append(skill)
     return skills
-
-
-def generated_refs_missing_from(src_dir: Path) -> list[Path]:
-    """Return ``*.generated.md`` files linked from ``SKILL.md`` that are absent."""
-    missing: list[Path] = []
-    for skill in iter_skill_dirs(src_dir):
-        text = (skill / "SKILL.md").read_text(encoding="utf-8")
-        for rel in _GENERATED_LINK_RE.findall(text):
-            target = skill / rel
-            if not target.is_file():
-                missing.append(target)
-    return missing
-
-
-def warn_if_generated_refs_missing(src_dir: Path) -> list[Path]:
-    """Print a hint on stderr if generated refs are missing. Returns the missing paths."""
-    missing = generated_refs_missing_from(src_dir)
-    if missing:
-        print(GENERATED_REFS_HINT, file=sys.stderr, end="")
-        for path in missing:
-            try:
-                rel = path.relative_to(src_dir.parent)
-            except ValueError:
-                rel = path
-            print(f"  missing: {rel}", file=sys.stderr)
-    return missing
 
 
 def iter_generated_ref_files(src_dir: Path) -> list[Path]:
@@ -97,15 +59,13 @@ def clean_generated_refs(src_dir: Path) -> list[Path]:
 def sync_skills(
     src: Path | str | None = None,
     dest: Path | str | None = None,
-    *,
-    warn_missing: bool = True,
 ) -> list[str]:
     """
     Copy each ``skills/<name>/`` directory that contains a ``SKILL.md``.
 
     Wipes ``dest`` first so removed skills do not linger. Returns the names of
     skill directories that were copied. Generated ``*.generated.md`` files are
-    included when present (they stay gitignored under ``skills/``).
+    included when present (they are committed under ``skills/``).
     """
     src_dir = Path(src) if src is not None else DEFAULT_SRC
     dest_dir = Path(dest) if dest is not None else DEFAULT_DEST
@@ -119,8 +79,6 @@ def sync_skills(
         shutil.copytree(skill, dest_dir / skill.name)
         copied.append(skill.name)
 
-    if warn_missing:
-        warn_if_generated_refs_missing(src_dir)
     return copied
 
 

--- a/skills/sync_into_package.py
+++ b/skills/sync_into_package.py
@@ -16,7 +16,9 @@ also run it directly:
 
 from __future__ import annotations
 
+import re
 import shutil
+import sys
 from pathlib import Path
 
 SKILLS_DIR = Path(__file__).resolve().parent
@@ -24,10 +26,79 @@ REPO_ROOT = SKILLS_DIR.parent
 DEFAULT_SRC = SKILLS_DIR
 DEFAULT_DEST = REPO_ROOT / "cpmpy" / ".agents" / "skills"
 
+_GENERATED_LINK_RE = re.compile(r"\]\(([^)\s#]+\.generated\.md)")
+
+GENERATED_REFS_HINT = """\
+Agent skill is missing its reference files. These are not included by default in a source checkout
+Install the docs extra and rebuild them:
+
+    pip install 'cpmpy[docs]'
+    cpmpy skills update --regenerate
+"""
+
+
+def iter_skill_dirs(src_dir: Path) -> list[Path]:
+    """Return skill directories under ``src_dir`` (each contains ``SKILL.md``)."""
+    if not src_dir.is_dir():
+        return []
+    skills = []
+    for skill in sorted(src_dir.iterdir()):
+        if skill.is_dir() and (skill / "SKILL.md").is_file():
+            skills.append(skill)
+    return skills
+
+
+def generated_refs_missing_from(src_dir: Path) -> list[Path]:
+    """Return ``*.generated.md`` files linked from ``SKILL.md`` that are absent."""
+    missing: list[Path] = []
+    for skill in iter_skill_dirs(src_dir):
+        text = (skill / "SKILL.md").read_text(encoding="utf-8")
+        for rel in _GENERATED_LINK_RE.findall(text):
+            target = skill / rel
+            if not target.is_file():
+                missing.append(target)
+    return missing
+
+
+def warn_if_generated_refs_missing(src_dir: Path) -> list[Path]:
+    """Print a hint on stderr if generated refs are missing. Returns the missing paths."""
+    missing = generated_refs_missing_from(src_dir)
+    if missing:
+        print(GENERATED_REFS_HINT, file=sys.stderr, end="")
+        for path in missing:
+            try:
+                rel = path.relative_to(src_dir.parent)
+            except ValueError:
+                rel = path
+            print(f"  missing: {rel}", file=sys.stderr)
+    return missing
+
+
+def iter_generated_ref_files(src_dir: Path) -> list[Path]:
+    """Return existing ``references/*.generated.md`` files under skill directories."""
+    found: list[Path] = []
+    if not src_dir.is_dir():
+        return found
+    for path in sorted(src_dir.rglob("*.generated.md")):
+        if path.is_file() and path.parent.name == "references":
+            found.append(path)
+    return found
+
+
+def clean_generated_refs(src_dir: Path) -> list[Path]:
+    """Delete generated skill reference files under ``src_dir``. Returns removed paths."""
+    removed: list[Path] = []
+    for path in iter_generated_ref_files(src_dir):
+        path.unlink()
+        removed.append(path)
+    return removed
+
 
 def sync_skills(
     src: Path | str | None = None,
     dest: Path | str | None = None,
+    *,
+    warn_missing: bool = True,
 ) -> list[str]:
     """
     Copy each ``skills/<name>/`` directory that contains a ``SKILL.md``.
@@ -44,16 +115,12 @@ def sync_skills(
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     copied: list[str] = []
-    if not src_dir.is_dir():
-        return copied
-
-    for skill in sorted(src_dir.iterdir()):
-        if not skill.is_dir():
-            continue
-        if not (skill / "SKILL.md").is_file():
-            continue
+    for skill in iter_skill_dirs(src_dir):
         shutil.copytree(skill, dest_dir / skill.name)
         copied.append(skill.name)
+
+    if warn_missing:
+        warn_if_generated_refs_missing(src_dir)
     return copied
 
 

--- a/skills/sync_into_package.py
+++ b/skills/sync_into_package.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Copy Agent Skills into the importable CPMpy package.
+
+Agent skills live in this directory (``skills/<name>/``). ``library-skills``
+only discovers ``.agents/skills/*/SKILL.md`` inside the installed package, so
+this script copies those directories to ``cpmpy/.agents/skills/`` at
+build/install time. The destination is generated (gitignored); do not edit it
+by hand.
+
+Called from ``setup.py``'s ``build_py`` (wheels and editable installs). You can
+also run it directly:
+
+    python skills/sync_into_package.py
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SKILLS_DIR.parent
+DEFAULT_SRC = SKILLS_DIR
+DEFAULT_DEST = REPO_ROOT / "cpmpy" / ".agents" / "skills"
+
+
+def sync_skills(
+    src: Path | str | None = None,
+    dest: Path | str | None = None,
+) -> list[str]:
+    """
+    Copy each ``skills/<name>/`` directory that contains a ``SKILL.md``.
+
+    Wipes ``dest`` first so removed skills do not linger. Returns the names of
+    skill directories that were copied. Generated ``*.generated.md`` files are
+    included when present (they stay gitignored under ``skills/``).
+    """
+    src_dir = Path(src) if src is not None else DEFAULT_SRC
+    dest_dir = Path(dest) if dest is not None else DEFAULT_DEST
+
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    if not src_dir.is_dir():
+        return copied
+
+    for skill in sorted(src_dir.iterdir()):
+        if not skill.is_dir():
+            continue
+        if not (skill / "SKILL.md").is_file():
+            continue
+        shutil.copytree(skill, dest_dir / skill.name)
+        copied.append(skill.name)
+    return copied
+
+
+if __name__ == "__main__":
+    names = sync_skills()
+    dest = DEFAULT_DEST
+    print(f"Copied {len(names)} skill(s) to {dest}: {', '.join(names) or '(none)'}")


### PR DESCRIPTION
All the infrastructure needed to add Agent skills to the repo. For now includes one reference skill to expand upon.

Skills are located under /skills. This is inline with skill.sh's expectation (the somewhat defacto cli for installing agent skills).
After merging into master, you can run:
```console
npx skills add CPMpy/cpmpy
``` 
Right now you need:
```console
npx skills add https://github.com/CPMpy/cpmpy/tree/skills
```
It gets all the skill markdown files directly from the github repo. After enough usage, our skill should appear in their [skills directory](https://www.skills.sh/)

Python also has the upcoming [library-skills](https://library-skills.io/), which starts to get well-accepted within the python community (FastAPI, Streamlit, Typr, ...). It is a standard for bundling skill files with python library wheels. The library-skills library with its cli can than discover them and add to your local project's .agents or .claude. But contrary to skills.sh, it expects the files to be located under cpmpy/.agents. So to prevent duplicating files, I've included some build scripts that auto run on pip install that copy /skills over to that location. Also works for editable installs from source.

So the proposed flow:
A) Use skill.sh
```console
npx skills add CPMpy/cpmpy
``` 
B) Install from cpmpy wheel
1) run command to setup skills in local project
```console
cpmpy skill
```
-> will complain about missing deps:
```console
pip install cpmpy[skills]
```
(this installs library-skills)
C) Users already using library-skills
```console
library-skills
```
-> will auto-discover cpmpy skills from python environment's installed wheels

Skills can have reference files, like excerpts from the user docs. Builds on #1099 for agent-friendly markdown version of the docs.

Once merged in master, we can add a shield to the GitHub readme with a link to the skills. 


Useful links:
| | |
| - | - |
| Python's `library-skills` | https://library-skills.io/ |
| Skills.sh | https://www.skills.sh/ |
| FastAPI's skills | https://github.com/fastapi/fastapi/tree/master/fastapi/.agents/skills/fastapi |
| Nvidia skills for cuOpt | https://github.com/NVIDIA/skills/blob/main/skills/cuopt-numerical-optimization-api/SKILL.md |
| Agent Skills standard spec | https://agentskills.io/specification |
| blogposts from person at Nvidia | https://jacobtomlinson.dev/posts/2026/documenting-your-software-libraries-for-agents/ |


