### PR TITLE
Fix linearize when trivially unsat comparison

### DIFF
--- a/cpmpy/transformations/linearize.py
+++ b/cpmpy/transformations/linearize.py
@@ -237,7 +237,7 @@ def linearize_constraint(lst_of_expr, supported={"sum","wsum","->"}, reified=Fal
                     continue
                 elif not t_lb and not t_ub:
                     newlist += linearize_constraint([BoolVal(False)], supported=supported, csemap=csemap) # post the linear version of False
-                    break
+                    continue
 
             # now fix the comparisons themselves
             if cpm_expr.name == "<":

--- a/tests/test_trans_linearize.py
+++ b/tests/test_trans_linearize.py
@@ -335,6 +335,13 @@ class TestVarsLhs:
         cons = linearize_constraint([cp.sum([a,b,c,10]) <= rhs])[0]
         assert str(cp.BoolVal(False)) == str(cons)
 
+    def test_trivial_unsat_keeps_later_constraints(self):
+        # A trivially false comparison should not abort linearization of the rest
+        x = cp.intvar(0, 3, name="x")
+        y = cp.boolvar(name="y")
+        lin = linearize_constraint([x >= 10, y, x <= 2])
+        assert str(lin) == "[boolval(False), y >= 1, sum(x) <= 2]"
+
     def test_sum(self):
         a,b,c = [cp.intvar(0,10,name=n) for n in "abc"]
         rhs = 15


### PR DESCRIPTION
When facing a trivially unsat comparison, linearize just posts boolval(false) and breaks. I do not think this is intended behaviour. First, it just continues in other cases of trivially unsat (e.g. lines 224-225). Second, although in a single solve this will have the same result, in other cases, like explanations etc, it will just ignore several constraints of the problem.

This PR just changes the "break" to "continue", and adds a test.