### PR TITLE
Cumulative no duration demand fix

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1879,17 +1879,16 @@ class CumulativeOptional(GlobalConstraint):
         else:
             start, duration, end, demand, capacity, is_present = self.args
 
-        # demand of tasks that are present doesn't exceed capacity
-        # tasks are uninterruptible, so we only need to check each starting point of each task
-        # I.e., for each task, we check if it can be started, given the tasks that are already running.
+        # Check capacity at each present task's start time (enough for non-preemptive tasks).
+        # A task is active on [start, end), so duration 0 never contributes demand —
+        # same convention as .value() and the time-based decomposition.
         for t in range(len(start)):
             st = start[t]
-            demand_at_start_of_t = []
-            for j in range(len(start)):
-                if t != j:
-                    demand_at_start_of_t.append(demand[j] * (is_present[j] & (start[j] <= st) & (end[j] > st)))
-
-            cons.append(implies(is_present[t], (demand[t] + sum(demand_at_start_of_t)) <= capacity))
+            demand_at_start_of_t = [
+                demand[j] * (is_present[j] & (start[j] <= st) & (end[j] > st))
+                for j in range(len(start))
+            ]
+            cons.append(implies(is_present[t], sum(demand_at_start_of_t) <= capacity))
 
         return cons, []
 

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1676,17 +1676,16 @@ class Cumulative(GlobalConstraint):
         else:
             start, duration, end, demand, capacity = self.args
 
-        # demand doesn't exceed capacity
-        # tasks are uninterruptible, so we only need to check each starting point of each task
-        # I.e., for each task, we check if it can be started, given the tasks that are already running.
+        # Check capacity at each task's start time (enough for non-preemptive tasks).
+        # A task is active on [start, end), so duration 0 never contributes demand —
+        # same convention as .value() and the time-based decomposition.
         for t in range(len(start)):
             st = start[t]
-            demand_at_start_of_t = []
-            for j in range(len(start)):
-                if t != j:
-                    demand_at_start_of_t.append(demand[j] * ((start[j] <= st) & (end[j] > st)))
-
-            cons.append((demand[t] + sum(demand_at_start_of_t)) <= capacity)
+            demand_at_start_of_t = [
+                demand[j] * ((start[j] <= st) & (end[j] > st))
+                for j in range(len(start))
+            ]
+            cons.append(sum(demand_at_start_of_t) <= capacity)
 
         return cons, []
 

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1134,6 +1134,24 @@ class TestGlobal:
         # also test decomposition
         assert not cp.Model(cons.decompose()).solve()# capacity was not taken into account and this failed
 
+    def test_cumulative_zero_duration(self):
+        # Zero-duration tasks occupy no resource
+        from cpmpy.expressions.utils import argval
+
+        s = cp.intvar(0, 0, name="s")
+        d = cp.intvar(0, 0, name="d")
+        cons = cp.Cumulative([s], [d], demand=[2], capacity=1)
+
+        assert cp.Model([s == 0, d == 0]).solve()
+        assert cons.value() is True
+
+        task, _ = cons.decompose(how="task")
+        time, _ = cons.decompose(how="time")
+        assert all(argval(q) for q in task)
+        assert all(argval(q) for q in time)
+        assert cp.Model(cons.decompose(how="task")).solve()
+        assert cp.Model(cons.decompose(how="time")).solve()
+
     def test_cumulative_nested_expressions(self):
         import numpy as np
 


### PR DESCRIPTION
In Cumulative, we currently have an inconsistency.

When the duration of a task is 0, native cumulative (I tested ortools, choco, minizinc) does not take into account its demand, even if it is alone larger than the capacity. In our implementation, we also have this assumption in .value() and in time decomposition.

However, in task decomposition we actually did not follow this, getting different results.

In this PR, I changed task decomposition (also in the optional), to follow this assumption. Also added a test for it.