### PR TITLE
NoOverlap zero duration

### DIFF
--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -1959,6 +1959,9 @@ class NoOverlap(GlobalConstraint):
     Enforces that a set of tasks are scheduled without overlapping, and enforces:
         - duration >= 0
         - start + duration == end
+
+    Tasks with zero duration are considered to overlap, similar to MiniZinc's `disjunctive_strict` constraint.
+    If you need to enforce that tasks with zero duration are allowed to overlap, use `cp.Cumulative(start, duration, end, demand=1, capacity=1)` instead.
     """
 
     def __init__(self, start: ListLike[ExprLike], duration: ListLike[ExprLike], end: Optional[ListLike[ExprLike]] = None):
@@ -2020,17 +2023,17 @@ class NoOverlap(GlobalConstraint):
             end = [s + d for s,d in zip(start, duration)]
         else:
             start, duration,end = argvals(self.args)
-            if any(a is None for a in [start, duration,end]):
+            if any(a is None for a in start + duration + end):
                 return None
         
-        tasks = sorted(zip(start, duration,end), key=lambda x: x[0])
+        tasks = sorted(zip(start, duration, end), key=lambda x: (x[0], x[1] != 0)) # break ties, sort 0-duration tasks first
 
         for i, (s,d,e) in enumerate(tasks):
             if d < 0:
                 return False
             if s + d != e:
                 return False
-            if i < len(tasks) - 1 and e < tasks[i+1][0]: # overlaps with next
+            if i < len(tasks) - 1 and e > tasks[i+1][0]: # overlaps with next
                 return False
                 
         return True
@@ -2115,13 +2118,14 @@ class NoOverlapOptional(GlobalConstraint):
             if any(a is None for a in start + duration + end + is_present):
                 return None
 
-        tasks = sorted(((s,d,e) for s,d,e,p in zip(start, duration,end, is_present) if p), key=lambda x: x[0])
+        tasks = sorted(((s,d,e) for s,d,e,p in zip(start, duration,end, is_present) if p),
+                       key=lambda x: (x[0], x[1] != 0)) # break ties, sort 0-duration tasks first
         for i, (s,d,e) in enumerate(tasks):
             if d < 0:
                 return False
             if s + d != e:
                 return False
-            if i < len(tasks) - 1 and e < tasks[i+1][0]: # overlaps with next
+            if i < len(tasks) - 1 and e > tasks[i+1][0]: # overlaps with next
                 return False
     
         return True

--- a/cpmpy/expressions/globalconstraints.py
+++ b/cpmpy/expressions/globalconstraints.py
@@ -2022,14 +2022,17 @@ class NoOverlap(GlobalConstraint):
             start, duration,end = argvals(self.args)
             if any(a is None for a in [start, duration,end]):
                 return None
-       
-        if any(d < 0 for d in duration):
-            return False
-        if any(s + d != e for s,d,e in zip(start, duration,end)):
-            return False
-        for (s1,d1), (s2,d2) in all_pairs(zip(start,duration)):
-            if s1 + d1 > s2 and s2 + d2 > s1:
+        
+        tasks = sorted(zip(start, duration,end), key=lambda x: x[0])
+
+        for i, (s,d,e) in enumerate(tasks):
+            if d < 0:
                 return False
+            if s + d != e:
+                return False
+            if i < len(tasks) - 1 and e < tasks[i+1][0]: # overlaps with next
+                return False
+                
         return True
 
 class NoOverlapOptional(GlobalConstraint):
@@ -2112,13 +2115,15 @@ class NoOverlapOptional(GlobalConstraint):
             if any(a is None for a in start + duration + end + is_present):
                 return None
 
-        if any(p and d < 0 for d,p in zip(duration,is_present)):
-            return False
-        if any(p and s + d != e for s,d,e,p in zip(start, duration,end, is_present)):
-            return False
-        for (s1,d1,p1), (s2,d2,p2) in all_pairs(zip(start,duration,is_present)):
-            if p1 and p2 and (s1 + d1 > s2) and (s2 + d2 > s1):
+        tasks = sorted(((s,d,e) for s,d,e,p in zip(start, duration,end, is_present) if p), key=lambda x: x[0])
+        for i, (s,d,e) in enumerate(tasks):
+            if d < 0:
                 return False
+            if s + d != e:
+                return False
+            if i < len(tasks) - 1 and e < tasks[i+1][0]: # overlaps with next
+                return False
+    
         return True
     
 class Precedence(GlobalConstraint):

--- a/cpmpy/solvers/choco.py
+++ b/cpmpy/solvers/choco.py
@@ -90,7 +90,7 @@ class CPM_choco(SolverInterface):
                                     "increasing", "decreasing", "strictly_increasing", "strictly_decreasing",
                                     "lex_lesseq", "lex_less", "mdd",
                                     "min", "max", "div", "mod", "pow", "abs", "mul", "count", "element", "nvalue", "among"})
-    supported_reified_global_constraints = supported_global_constraints  # choco supports everything reified
+    supported_reified_global_constraints = supported_global_constraints - {"no_overlap"}  # choco supports everything reified
 
     @staticmethod
     def supported():
@@ -679,10 +679,17 @@ class CPM_choco(SolverInterface):
             elif cpm_expr.name == "no_overlap": # post as Cumulative with capacity 1
                 if len(cpm_expr.args) == 2:
                     start, dur = cpm_expr.args
-                    return self._get_constraint(Cumulative(start, dur, demand=1, capacity=1))
+                    chc_cons = self._get_constraint(Cumulative(start, dur, demand=1, capacity=1))
                 else:
                     start, dur, end = cpm_expr.args
-                    return self._get_constraint(Cumulative(start, dur, end, demand=1, capacity=1))
+                    chc_cons = self._get_constraint(Cumulative(start, dur, end, demand=1, capacity=1))
+                    
+                if any(lb <= 0 for lb in get_bounds(dur)[0]): # zero-duration tasks cannot overlap, not enforced by Cumulative
+                    assert "no_overlap" not in self.supported_reified_global_constraints # otherwise cannot post decomposition toplevel
+                    self.add(cpm_expr.decompose())
+
+                return chc_cons
+
             elif cpm_expr.name == "precedence":
                 return self.chc_model.int_value_precede_chain(self._to_vars(cpm_expr.args[0]), cpm_expr.args[1])
             elif cpm_expr.name == "gcc":

--- a/cpmpy/solvers/cpo.py
+++ b/cpmpy/solvers/cpo.py
@@ -695,13 +695,7 @@ class CPM_cpo(SolverInterface):
         if not is_optional:
             is_present = BoolVal(True) # eases handling below
 
-        lb, ub = get_bounds(dur)
         extra_cons = []
-        if lb == 0 == ub:
-            if end is None: # nothing to enforce
-                return None, []
-            return None, extra_cons + self._cpo_expr([implies(is_present, start == end)]) # no task, just enforce 0 duration
-
         # Normal setting
         if end is None: # no end provided by user
             task = docp.expression.interval_var(start=get_bounds(start), size=get_bounds(dur), end=get_bounds(start+dur), optional=is_optional)

--- a/cpmpy/solvers/minizinc.py
+++ b/cpmpy/solvers/minizinc.py
@@ -768,7 +768,7 @@ class CPM_minizinc(SolverInterface):
                 start, dur, end = expr.args
                 extra_cons += [s + d == e for s, d, e in zip(start, dur, end)]
             
-            global_str = "disjunctive({},{})"
+            global_str = "disjunctive_strict({},{})"
             # ensure duration is non-negative
             dur, dur_cons = get_nonneg_args(dur)
             extra_cons += dur_cons

--- a/cpmpy/solvers/pumpkin.py
+++ b/cpmpy/solvers/pumpkin.py
@@ -582,10 +582,16 @@ class CPM_pumpkin(SolverInterface):
             elif cpm_expr.name == "no_overlap":
                 if len(cpm_expr.args) == 2:
                     start, dur = cpm_expr.args
-                    return self._get_constraint(Cumulative(start, dur, demand=1, capacity=1), tag=tag)
+                    pum_cons = self._get_constraint(Cumulative(start, dur, demand=1, capacity=1), tag=tag)
                 else:
                     start, dur, end = cpm_expr.args
-                    return self._get_constraint(Cumulative(start, dur, end, demand=1, capacity=1), tag=tag)
+                    pum_cons = self._get_constraint(Cumulative(start, dur, end, demand=1, capacity=1), tag=tag)
+                
+                if any(lb <= 0 for lb in get_bounds(dur)[0]): # zero-duration tasks cannot overlap, not enforced by Cumulative
+                    assert f"no_overlap" not in self.supported_reified_global_constraints # otherwise cannot post decomposition toplevel
+                    self.add(cpm_expr.decompose())
+            
+                return pum_cons
 
             elif cpm_expr.name == "table":
                 arr, table = cpm_expr.args

--- a/cpmpy/solvers/scip.py
+++ b/cpmpy/solvers/scip.py
@@ -38,7 +38,7 @@ from ..expressions.core import Expression, BoolVal, Comparison, Operator, Nested
 from ..expressions.variables import _BoolVarImpl, NegBoolView, _NumVarImpl
 from ..expressions.globalconstraints import Cumulative, DirectConstraint, GlobalConstraint
 from ..expressions.globalfunctions import GlobalFunction, FloatSum
-from ..expressions.utils import is_num, is_int, is_true_cst, is_false_cst, get_nonneg_args
+from ..expressions.utils import get_bounds, is_num, is_int, is_true_cst, is_false_cst, get_nonneg_args
 from ..transformations.negation import push_down_negation, push_down_negation_objective
 from ..transformations.comparison import only_numexpr_equality
 from ..transformations.flatten_model import flatten_constraint, flatten_objective
@@ -478,6 +478,9 @@ class CPM_scip(SolverInterface):
                 else:
                     start, dur, end = cpm_expr.args
                     self._add_transformed_constraint(Cumulative(start, dur, end, demand=1, capacity=1))
+                
+                if any(lb <= 0 for lb in get_bounds(dur)[0]): # zero-duration tasks cannot overlap, not enforced by Cumulative
+                    self.add(cpm_expr.decompose())
 
             else:
                 raise NotImplementedError(

--- a/tests/test_globalconstraints.py
+++ b/tests/test_globalconstraints.py
@@ -1543,6 +1543,43 @@ class TestGlobal:
 
         cp.Model(~cons).solveAll(display=check_val)
 
+    def test_no_overlap_zero_duration(self, solver):
+        
+        start = cp.intvar(0,5, shape=3, name=tuple("ABC"))
+        start_val = [1,0,5] # task A starts midway through task B, but has 0 duration
+        dur = [0,5,3]
+
+        cons = cp.NoOverlap(start=start, duration=dur)
+
+        assert cp.Model(cons, start == start_val).solve(solver=solver) is False # 0-duration tasks should overlap
+        assert cp.Model(~cons, start == start_val).solve(solver=solver) is True
+        assert cons.value() is False
+
+
+        # start at the same time is fine
+        start_val = [0,0,5]
+        assert cp.Model(cons, start == start_val).solve(solver=solver) is True
+
+    def test_no_overlap_optional_zero_duration(self, solver):
+        start = cp.intvar(0,5, shape=3, name=tuple("ABC"))
+        start_val = [1,0,5] # task A starts midway through task B, but has 0 duration
+        dur = [0,5,3]
+
+        cons = cp.NoOverlapOptional(start=start, duration=dur, is_present=[True, True, True])
+        assert cp.Model(cons, start == start_val).solve(solver=solver) is False # 0-duration tasks should overlap
+        assert cp.Model(~cons, start == start_val).solve(solver=solver) is True
+        assert cons.value() is False
+
+        # absent zero-duration task or overlapping task: no conflict
+        cons = cp.NoOverlapOptional(start=start, duration=dur, is_present=[False, True, True])
+        assert cp.Model(cons, start == start_val).solve(solver=solver) is True
+        assert cons.value() is True
+
+        cons = cp.NoOverlapOptional(start=start, duration=dur, is_present=[True, False, True])
+        assert cp.Model(cons, start == start_val).solve(solver=solver) is True
+        assert cons.value() is True
+
+
 class TestBounds:
     def test_bounds_minimum(self):
         x = cp.intvar(-8, 8)


### PR DESCRIPTION
Following #1102 and the discussion in #1084 I changed the semantics of NoOverlap to follow the strict version of disjunctive in MiniZinc.

Concretely, this means 0-duration tasks cannot overlap with other tasks. They can be scheduled (i.e., be non-optional) the start has to be before/after other tasks.

I checked the MiniZinc parsers for pumpkin and choco, they both post disjunctive_strict using the decomposition. In this PR, I slightly changed this so that both the Cumulative and decomposition are posted. 

Also fixes an existing bug in CPO and implemented a faster checker for NoOverlap (which is how I got to this issue in the first place...)