### PR TITLE
PyPI-compatible logo image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/CPMpy_Logo__Vertical_Blue.png" alt="CPMpy logo" width="220">
+<img src="https://raw.githubusercontent.com/CPMpy/cpmpy/master/docs/CPMpy_Logo__Vertical_Blue.png" alt="CPMpy logo" width="220">
 
 ![Github Version](https://img.shields.io/github/v/release/CPMpy/cpmpy?label=Github%20Release&logo=github)
 ![PyPI version](https://img.shields.io/pypi/v/cpmpy?color=blue&label=Pypi%20version&logo=pypi&logoColor=white)


### PR DESCRIPTION
[PyPI](https://pypi.org/project/cpmpy/) does not evaluate image links relative to the repo, so
```html
<img src="docs/CPMpy_Logo__Vertical_Blue.png" alt="CPMpy logo" width="220">
```
does not work, showing the alt text instead of our beautiful logo. Instead convert to a public url:
```html
<img src="https://raw.githubusercontent.com/CPMpy/cpmpy/master/docs/CPMpy_Logo__Vertical_Blue.png" alt="CPMpy logo" width="220">
```
<img src="https://raw.githubusercontent.com/CPMpy/cpmpy/master/docs/CPMpy_Logo__Vertical_Blue.png" alt="CPMpy logo" width="220">